### PR TITLE
Clean response and error handling

### DIFF
--- a/sample/Assets/Scripts/AuthenticatedScript.cs
+++ b/sample/Assets/Scripts/AuthenticatedScript.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -26,8 +27,12 @@ public class AuthenticatedScript : MonoBehaviour
 
     public async void GetAddress() {
         showOutput($"Called GetAddress()...");
-        string? address = await Passport.Instance.GetAddress();
-        showOutput(address);
+        try {
+            string? address = await Passport.Instance.GetAddress();
+            showOutput(address);
+        } catch (Exception e) {
+            showOutput("Unable to get address");
+        }
     }
 
     public async void Logout() {
@@ -46,8 +51,12 @@ public class AuthenticatedScript : MonoBehaviour
 
     public async void SignMessage() {
         showOutput("Called SignMessage()...");
-        string? result = await passport.SignMessage(signInput.text);
-        showOutput(result);
+        try {
+            string? result = await passport.SignMessage(signInput.text);
+            showOutput(result);
+        } catch (Exception e) {
+            showOutput("Unable to sign message");
+        }
     }
 
     private void showOutput(string message) {

--- a/src/Packages/Passport/Runtime/Assets/Resources/index.js
+++ b/src/Packages/Passport/Runtime/Assets/Resources/index.js
@@ -49,8 +49,8 @@ async function callFunction(jsonData) {
         let json = JSON.parse(jsonData);
         let fxName = json[keyFunctionName];
         let requestId = json[keyRequestId];
-        let data = JSON.parse(json[keyData]);
         try {
+            let data = JSON.parse(json[keyData]);
             switch (fxName) {
                 case PassportFunctions.getAddress: {
                     const address = await providerInstance?.getAddress();

--- a/src/Packages/Passport/Runtime/Scripts/PassportFunction.cs
+++ b/src/Packages/Passport/Runtime/Scripts/PassportFunction.cs
@@ -1,8 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
-using UnityEngine;
-
 namespace Immutable.Passport
 {
     public static class PassportFunction 

--- a/src/Packages/Passport/Runtime/Scripts/Response.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Response.cs
@@ -1,7 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
 namespace Immutable.Passport
 {
     internal class Response {


### PR DESCRIPTION
- In `index.js` moved data parsing into try block that sends back `responseFor` and `requestId` to Unity
- Created generic `notifyRequestResult` method to handle communicating response back to Unity
- Generically handle exceptions for all request types