### PR TITLE
feat: log out

### DIFF
--- a/sample/Assets/Scenes/AuthenticatedScene.unity
+++ b/sample/Assets/Scenes/AuthenticatedScene.unity
@@ -1318,7 +1318,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &1341903191
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2645,7 +2645,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1335469792}
   m_HandleRect: {fileID: 1335469791}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:

--- a/sample/Assets/Scripts/AuthenticatedScript.cs
+++ b/sample/Assets/Scripts/AuthenticatedScript.cs
@@ -36,17 +36,20 @@ public class AuthenticatedScript : MonoBehaviour
     }
 
     public async void Logout() {
-        showOutput("Called Logout()...");
         passport.Logout();
-        showOutput("Logged out");
+        // Destroying passport as we're redirecting the user back 
+        // to the scene which Passport is instantiated
+        // TODO Try handling this in the SDK
+        passport.Destroy();
+        SceneManager.LoadScene(sceneName:"UnauthenticatedScene");
     }
 
     public void GetAccessToken() {
-        showOutput(passport.GetAccessToken());
+        ShowOutput(passport.GetAccessToken());
     }
 
     public void GetIdToken() {
-        showOutput(passport.GetIdToken());
+        ShowOutput(passport.GetIdToken());
     }
 
     public async void SignMessage() {
@@ -59,7 +62,7 @@ public class AuthenticatedScript : MonoBehaviour
         }
     }
 
-    private void showOutput(string message) {
+    private void ShowOutput(string message) {
         if (output != null) {
             output.text = message;
         }

--- a/sample/Assets/Scripts/UnauthenticatedScript.cs
+++ b/sample/Assets/Scripts/UnauthenticatedScript.cs
@@ -22,13 +22,12 @@ public class UnauthenticatedScript : MonoBehaviour
 
     void Start()
     {
+        ShowOutput("Starting...");
         connectButton.gameObject.SetActive(false);
         userCodeText.gameObject.SetActive(false);
         proceedLoginButton.gameObject.SetActive(false);
 
         passport.OnReady += OnReady;
-
-        ShowOutput("Starting...");
     }
 
     private void OnReady() {
@@ -77,8 +76,6 @@ public class UnauthenticatedScript : MonoBehaviour
     }
 
     private void ShowOutput(string message) {
-        if (output != null) {
-            output.text = message;
-        }
+        output.text = message;
     }
 }

--- a/sample/ProjectSettings/BurstAotSettings_WSAPlayer.json
+++ b/sample/ProjectSettings/BurstAotSettings_WSAPlayer.json
@@ -1,0 +1,16 @@
+{
+  "MonoBehaviour": {
+    "Version": 4,
+    "EnableBurstCompilation": true,
+    "EnableOptimisations": true,
+    "EnableSafetyChecks": false,
+    "EnableDebugInAllBuilds": false,
+    "CpuMinTargetX32": 0,
+    "CpuMaxTargetX32": 0,
+    "CpuMinTargetX64": 0,
+    "CpuMaxTargetX64": 0,
+    "CpuTargetsX32": 6,
+    "CpuTargetsX64": 72,
+    "OptimizeFor": 0
+  }
+}

--- a/sample/ProjectSettings/ProjectSettings.asset
+++ b/sample/ProjectSettings/ProjectSettings.asset
@@ -699,8 +699,8 @@ PlayerSettings:
   apiCompatibilityLevelPerPlatform: {}
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
-  metroPackageName: 2D_BuiltInRenderer
-  metroPackageVersion: 
+  metroPackageName: 2DBuiltInRenderer
+  metroPackageVersion: 1.0.0.0
   metroCertificatePath: 
   metroCertificatePassword: 
   metroCertificateSubject: 
@@ -708,7 +708,7 @@ PlayerSettings:
   metroCertificateNotAfter: 0000000000000000
   metroApplicationDescription: 2D_BuiltInRenderer
   wsaImages: {}
-  metroTileShortName: 
+  metroTileShortName: sample
   metroTileShowName: 0
   metroMediumTileShowName: 0
   metroLargeTileShowName: 0

--- a/src/Packages/Passport/Runtime/Scripts/Auth/AuthManager.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Auth/AuthManager.cs
@@ -96,7 +96,7 @@ namespace Immutable.Passport.Auth {
             {
                 using var response = await client.PostAsync($"{DOMAIN}{PATH_TOKEN}", content);
                 var responseString = await response.Content.ReadAsStringAsync();
-                Debug.Log($"{TAG} Refresh token response: " + responseString);
+                Debug.Log($"{TAG} Refresh token response: {responseString}");
                 return JsonConvert.DeserializeObject<TokenResponse>(responseString);
             }
             catch (Exception ex)
@@ -153,7 +153,7 @@ namespace Immutable.Passport.Auth {
             {
                 using var response = await client.PostAsync($"{DOMAIN}{PATH_AUTH_CODE}", content);
                 var responseString = await response.Content.ReadAsStringAsync();
-                Debug.Log("Device code response: " + responseString);
+                Debug.Log($"{TAG} Device code response: {responseString}");
                 return JsonConvert.DeserializeObject<DeviceCodeResponse>(responseString);
             }
             catch (Exception ex)
@@ -219,7 +219,7 @@ namespace Immutable.Passport.Auth {
             try {
                 using var response = await client.PostAsync($"{DOMAIN}{PATH_TOKEN}", content);
                 var responseString = await response.Content.ReadAsStringAsync();
-                Debug.Log($"{TAG} Token response: " + responseString);
+                Debug.Log($"{TAG} Token response: {responseString}");
                 return responseString;
             }
             catch (Exception ex)
@@ -231,7 +231,6 @@ namespace Immutable.Passport.Auth {
         }
 
         public void Logout() {
-            // TODO implement log out
             manager.ClearCredentials();
         }
 

--- a/src/Packages/Passport/Runtime/Scripts/Passport.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Passport.cs
@@ -44,9 +44,15 @@ namespace Immutable.Passport
         void Awake() {
             if (Instance == null) {
                 Instance = this;
+
                 // Keep this alive in every scene
                 DontDestroyOnLoad(this.gameObject);
             }
+        }
+
+        public void Destroy() {
+            Instance = null;
+            Destroy(this.gameObject);
         }
 
         private void OnLoadFinish(string url) {
@@ -58,6 +64,8 @@ namespace Immutable.Passport
                 string filePath = Path.GetFullPath("Packages/com.immutable.passport/Runtime/Assets/Resources/passport.html");
                 webBrowserClient.LoadUrl($"file:///{filePath}");
                 OnReady?.Invoke();
+                // Clean up listener
+                webBrowserClient.OnLoadFinish -= OnLoadFinish;
             }
         }
 

--- a/src/Packages/Passport/Runtime/Scripts/Storage/CredentialsManager.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Storage/CredentialsManager.cs
@@ -44,7 +44,6 @@ namespace Immutable.Passport.Storage {
                 AccessTokenPayload? accessTokenPayload = JsonConvert.DeserializeObject<AccessTokenPayload>(accessToken);
                 Debug.Log($"{TAG} Access token payload is not null? {accessTokenPayload != null}");
 
-
                 long expiresAt = accessTokenPayload?.exp ?? 0;
                 long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
                 bool valid = expiresAt > now;
@@ -57,6 +56,7 @@ namespace Immutable.Passport.Storage {
         }
 
         public void ClearCredentials() {
+            Debug.Log($"{TAG} Clear Credentials");
             PlayerPrefs.DeleteKey(KEY_PREFS_CREDENTIALS);
         }
     }


### PR DESCRIPTION
* Complete logout
* Clean up logging
* Created Passport `Destroy()` function so that developers can destroy the Passport instance. This is required in the sample app when logging out and redirecting the user back to the scene which instantiated Passport. 