### PR TITLE
refactor: add tests for AuthManager

### DIFF
--- a/sample/Packages/manifest.json
+++ b/sample/Packages/manifest.json
@@ -6,7 +6,7 @@
     "com.unity.ide.rider": "3.0.21",
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",
-    "com.unity.test-framework": "1.1.33",
+    "com.unity.test-framework": "2.0.1-exp.1",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.6.5",
     "com.unity.ugui": "1.0.0",

--- a/sample/Packages/packages-lock.json
+++ b/sample/Packages/packages-lock.json
@@ -108,7 +108,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ext.nunit": {
-      "version": "1.0.6",
+      "version": "2.0.2",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
@@ -161,11 +161,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.33",
+      "version": "2.0.1-exp.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.ext.nunit": "1.0.6",
+        "com.unity.ext.nunit": "2.0.2",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },

--- a/sample/ProjectSettings/PackageManagerSettings.asset
+++ b/sample/ProjectSettings/PackageManagerSettings.asset
@@ -12,12 +12,12 @@ MonoBehaviour:
   m_Script: {fileID: 13964, guid: 0000000000000000e000000000000000, type: 0}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_EnablePreReleasePackages: 0
+  m_EnablePreReleasePackages: 1
   m_EnablePackageDependencies: 0
   m_AdvancedSettingsExpanded: 1
   m_ScopedRegistriesSettingsExpanded: 1
   m_SeeAllPackageVersions: 0
-  oneTimeWarningShown: 0
+  oneTimeWarningShown: 1
   m_Registries:
   - m_Id: main
     m_Name: 
@@ -31,6 +31,6 @@ MonoBehaviour:
   m_RegistryInfoDraft:
     m_Modified: 0
     m_ErrorMessage: 
-    m_UserModificationsInstanceId: -824
-    m_OriginalInstanceId: -826
+    m_UserModificationsInstanceId: -828
+    m_OriginalInstanceId: -830
   m_LoadAssets: 0

--- a/sample/ProjectSettings/ProjectSettings.asset
+++ b/sample/ProjectSettings/ProjectSettings.asset
@@ -363,6 +363,103 @@ PlayerSettings:
       m_Height: 36
       m_Kind: 0
       m_SubKind: 
+  - m_BuildTarget: iPhone
+    m_Icons:
+    - m_Textures: []
+      m_Width: 180
+      m_Height: 180
+      m_Kind: 0
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 120
+      m_Height: 120
+      m_Kind: 0
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 167
+      m_Height: 167
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 152
+      m_Height: 152
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 76
+      m_Height: 76
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 120
+      m_Height: 120
+      m_Kind: 3
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 80
+      m_Height: 80
+      m_Kind: 3
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 80
+      m_Height: 80
+      m_Kind: 3
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 40
+      m_Height: 40
+      m_Kind: 3
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 87
+      m_Height: 87
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 58
+      m_Height: 58
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 29
+      m_Height: 29
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 58
+      m_Height: 58
+      m_Kind: 1
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 29
+      m_Height: 29
+      m_Kind: 1
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 60
+      m_Height: 60
+      m_Kind: 2
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 40
+      m_Height: 40
+      m_Kind: 2
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 40
+      m_Height: 40
+      m_Kind: 2
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 20
+      m_Height: 20
+      m_Kind: 2
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 1024
+      m_Height: 1024
+      m_Kind: 4
+      m_SubKind: App Store
   m_BuildTargetBatching: []
   m_BuildTargetShaderSettings: []
   m_BuildTargetGraphicsJobs:

--- a/sample/ProjectSettings/TimelineSettings.asset
+++ b/sample/ProjectSettings/TimelineSettings.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 61
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a287be6c49135cd4f9b2b8666c39d999, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  assetDefaultFramerate: 60
+  m_DefaultFrameRate: 60

--- a/src/Packages/Passport/Runtime/Scripts/Storage/CredentialsManager.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Storage/CredentialsManager.cs
@@ -5,7 +5,16 @@ using UnityEngine;
 using Newtonsoft.Json;
 
 namespace Immutable.Passport.Storage {
-    public class CredentialsManager {
+
+    public interface ICredentialsManager
+    {
+        void SaveCredentials(TokenResponse tokenResponse);
+        TokenResponse? GetCredentials();
+        bool HasValidCredentials();
+        void ClearCredentials();
+    }
+
+    public class CredentialsManager : ICredentialsManager {
         private const string TAG = "[Credentials Manager]";
 
         public static string KEY_PREFS_CREDENTIALS = "prefs_credentials";

--- a/src/Packages/Passport/Tests/Runtime/Scripts/Auth.meta
+++ b/src/Packages/Passport/Tests/Runtime/Scripts/Auth.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0dc27f4d11fcc1f42be3b95320b2afee
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Passport/Tests/Runtime/Scripts/Auth/AuthManagerTests.cs
+++ b/src/Packages/Passport/Tests/Runtime/Scripts/Auth/AuthManagerTests.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Immutable.Passport.Storage;
+using Immutable.Passport.Auth;
+using Immutable.Passport.Utility.Tests;
+using UnityEngine;
+using System.Threading.Tasks;
+
+namespace Immutable.Passport.Auth
+{
+    [TestFixture]
+    public class AuthManagerTests
+    {
+        internal static string VALID_TOKEN_RESPONSE = "{\"access_token\":\"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjNhYVl5dGR3d2UwMzJzMXIzVElyOSJ9.eyJlbWFpbCI6ImRvbWluaWMubXVycmF5QGltbXV0YWJsZS5jb20iLCJvcmciOiJhNTdiMWYzZC1mYTU3LTRiNzgtODZkYy05ZDEyZDM1YjlhNjgiLCJldGhlcl9rZXkiOiIweGRlMDYzYmViNmNmNDhlNGMxOTcxYzc3N2M0OGY0NTU3MTA1MjU5ZWMiLCJzdGFya19rZXkiOiIweGM1NTYxZGU3Nzg4NTUxOTY0ZWQxMjI0Yzc2ZjQ5ZDk5ZmVjODkyOGQ1OWVkNTcwZTExZGIwYzk3ZGYwMTFmIiwidXNlcl9hZG1pbl9rZXkiOiIweGY4MjY4OTI0MWU3NTM1YjYyNTgyMmI4M2I1OWMxZDM3ZWUwOTBiZGMiLCJpc3MiOiJodHRwczovL2F1dGguaW1tdXRhYmxlLmNvbS8iLCJzdWIiOiJlbWFpbHw2NDJiN2Q0YWI5N2IzYWMyNDg3NzBlNTEiLCJhdWQiOlsicGxhdGZvcm1fYXBpIiwiaHR0cHM6Ly9wcm9kLmltbXV0YWJsZS5hdXRoMGFwcC5jb20vdXNlcmluZm8iXSwiaWF0IjoxNjg2ODg5MDgwLCJleHAiOjE2ODY5NzU0ODAsImF6cCI6IlpKTDdKdmV0Y0RGQk5EbGdSczVvSm94dUFVVWw2dVFqIiwic2NvcGUiOiJvcGVuaWQgcHJvZmlsZSBlbWFpbCB0cmFuc2FjdCBvZmZsaW5lX2FjY2VzcyJ9.aqFem4Pp0k91YWdYuxBo1wfCrYAHy1Y1zIqof2GMQXd_mwhGBkHotUlgFAsOIQmvO6lQG5m3cHLR9zlEsFJ_2AJuJg3NTNnF0dEx12H5hx24_aN4qDga8Q9KNDdGc3x4LAxv48PH-P6OcdMnpWekCUPAI3zZ9qWC1YWU9HaouQuBJNbUV8ujyooFGOP4YzejQf2Uyxz9wmzDiMS-e70BSmY8IPRR2A3QjOEo7oI3enqM_jylfbDo8BsDRouDbwbZrMeX-rcJ_HBY5iZEdagVpcvOmfZCaad55MI_WJcXHrDMzmLqck1fd15Oklo7fajQtiG0ByINxTmm9_0YnEy02w\",\"refresh_token\":\"v1.NOQCr0kkmy0Cky_Doia8VgJdclSKOOOrkicjZ4NFeabS5J7xNct-oRwO2H65ua0mPOhzWfIf8lhxlM1sIUBqLoc\",\"id_token\":\"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjNhYVl5dGR3d2UwMzJzMXIzVElyOSJ9.eyJkZXZlbG9wZXJfaHViIjp7ImFjdGl2YXRlZCI6dHJ1ZSwib3JnYW5pemF0aW9uIjp7ImlkIjoiYTU3YjFmM2QtZmE1Ny00Yjc4LTg2ZGMtOWQxMmQzNWI5YTY4In0sInJlc3BvbnNlSWQiOiI4MzhiangzOG1maG15cWs3bjgzOGJqeGZrMjdhZXQxMCIsInJlc3BvbnNlcyI6eyJmdW5kaW5nIjoiUHJlZmVyIG5vdCB0byBzYXkiLCJoYXZlTWludGVkTmZ0c0JlZm9yZSI6Ik5vIiwicGVvcGxlIjoiSnVzdCBtZSIsInByb2plY3RTdGFnZSI6IkNvbmNlcHQiLCJwcm9qZWN0VHlwZSI6Ik90aGVyIiwicm9sZSI6Ik90aGVyIn0sInJvbGVzIjpbXSwidXNlck1ldGFkYXRhIjp7InJlY2VpdmVNYXJrZXRpbmdFbWFpbHNDb25zZW50Ijp7ImNvbnNlbnRlZCI6ZmFsc2UsImRhdGUiOiIyMDIzLTA0LTIwVDAxOjA2OjI2LjgwOFoiLCJ2ZXJzaW9uIjoxfX19LCJwYXNzcG9ydCI6eyJldGhlcl9rZXkiOiIweGRlMDYzYmViNmNmNDhlNGMxOTcxYzc3N2M0OGY0NTU3MTA1MjU5ZWMiLCJzdGFya19rZXkiOiIweGM1NTYxZGU3Nzg4NTUxOTY0ZWQxMjI0Yzc2ZjQ5ZDk5ZmVjODkyOGQ1OWVkNTcwZTExZGIwYzk3ZGYwMTFmIiwidXNlcl9hZG1pbl9rZXkiOiIweGY4MjY4OTI0MWU3NTM1YjYyNTgyMmI4M2I1OWMxZDM3ZWUwOTBiZGMifSwibmlja25hbWUiOiJkb21pbmljLm11cnJheSIsIm5hbWUiOiJkb21pbmljLm11cnJheUBpbW11dGFibGUuY29tIiwicGljdHVyZSI6Imh0dHBzOi8vcy5ncmF2YXRhci5jb20vYXZhdGFyL2NkOTkwYWNiYzYwNWQ4ZDdiYWMwNjExMWFkZTljNWI1P3M9NDgwJnI9cGcmZD1odHRwcyUzQSUyRiUyRmNkbi5hdXRoMC5jb20lMkZhdmF0YXJzJTJGZG8ucG5nIiwidXBkYXRlZF9hdCI6IjIwMjMtMDYtMTNUMDY6MTE6MjQuOTgxWiIsImVtYWlsIjoiZG9taW5pYy5tdXJyYXlAaW1tdXRhYmxlLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJpc3MiOiJodHRwczovL2F1dGguaW1tdXRhYmxlLmNvbS8iLCJhdWQiOiJaSkw3SnZldGNERkJORGxnUnM1b0pveHVBVVVsNnVRaiIsImlhdCI6MTY4Njg4OTA4MCwiZXhwIjoxNjg2OTI1MDgwLCJzdWIiOiJlbWFpbHw2NDJiN2Q0YWI5N2IzYWMyNDg3NzBlNTEifQ.X1G-59ay7yKCHUdq01Kntx4JLgNv5KjQSeWjDULuG1CNDS8eUrlWvZS1bok77AQd683GflTjoM50T6KuDanW0pcsDGcZDnGQ-yj8-Eb381zrWybkYok3AkJbzRJ2M9AQsFdv6wjjQg78xAFgutRev4XtCsEApD7wIfCFi8EkqLwJMDbkjzNjyRjVHP8g_h6XfkI23iRhjz0qSySV3ogmLxxkPse9uOILfXvB5SczJWe6RPRZKoMk-uoqAbDPNgSAa7G_PoPAQd404vYrkltVV3tT8bxiyasO_Uhk9Djre0_dnzJ3Cqfmmlvk7kS9g22ELFvIJBJ0zgcCzqa6fIFDZQ\",\"token_type\":\"Bearer\",\"expires_in\":86400}";
+
+        private AuthManager manager;
+        private MockHttpMessageHandler httpMock;
+        private MockCredentialsManager credentialsManager;
+        
+        [SetUp] 
+        public void Init()
+        { 
+            httpMock = new MockHttpMessageHandler();
+            credentialsManager = new MockCredentialsManager();
+            manager = new AuthManager(httpMock.ToHttpClient(), credentialsManager);
+        }
+
+        private void PrepareForConfirmCode() {
+            credentialsManager.hasValidCredentials = false;
+            credentialsManager.token = null;
+            AddDeviceCodeResponse();
+            var code = manager.Login().Result;
+        }
+
+        private void AddDeviceCodeResponse() {
+            var deviceCodeResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            deviceCodeResponse.Content = new StringContent("{\"device_code\": \"deviceCode\",\"user_code\": \"userCode\",\"verification_uri\": \"verificationUri\",\"expires_in\": 3600000,\"interval\": 1,\"verification_uri_complete\": \"verificationUriComplete\"}");
+            httpMock.responses.Add(deviceCodeResponse);
+        }
+
+        [Test]
+        public void Login_Success_FreshLogin()
+        {
+            credentialsManager.hasValidCredentials = false;
+            credentialsManager.token = null;
+            AddDeviceCodeResponse();
+            var code = manager.Login().Result;
+            var request = httpMock.requests[0];
+
+            Assert.AreEqual(request.RequestUri, "https://auth.immutable.com/oauth/device/code");
+            Assert.AreEqual(request.Method, HttpMethod.Post);
+            Assert.AreEqual(code, "userCode");
+        }
+
+        [Test]
+        public void Login_Success_ExistingCredentials()
+        {
+            credentialsManager.hasValidCredentials = true;
+            credentialsManager.token = new TokenResponse();
+            var code = manager.Login().Result;
+            Assert.Null(code);
+            Assert.NotNull(manager.GetUser());
+        }
+
+        [Test]
+        public void Login_Success_UsingRefreshToken()
+        {
+            credentialsManager.hasValidCredentials = false;
+            credentialsManager.token = new TokenResponse();
+            credentialsManager.token.refresh_token = "thisIsTheRefreshToken";
+            var refreshTokenResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            refreshTokenResponse.Content = new StringContent(VALID_TOKEN_RESPONSE);
+            httpMock.responses.Add(refreshTokenResponse);
+
+            Assert.Null(manager.GetUser());
+
+            var code = manager.Login().Result;
+            Assert.Null(code);
+            Assert.NotNull(manager.GetUser());
+
+            var request = httpMock.requests[0];
+            Assert.AreEqual(request.RequestUri, "https://auth.immutable.com/oauth/token");
+            Assert.AreEqual(request.Method, HttpMethod.Post);
+            Assert.True(request.Content.ReadAsStringAsync().Result.Contains("refresh_token=thisIsTheRefreshToken"));
+        }
+        
+        [Test]
+        public void Login_Failed_GetDeviceCode()
+        {
+            credentialsManager.hasValidCredentials = false;
+            credentialsManager.token = null;
+            var deviceCodeResponse = new HttpResponseMessage(HttpStatusCode.NotAcceptable);
+            httpMock.responses.Add(deviceCodeResponse);
+            Exception? e = null;
+            try {
+                var result = manager.Login().Result;
+            } catch (Exception exception) {
+                e = exception;
+            }
+            Assert.NotNull(e);
+            var request = httpMock.requests[0];
+            Assert.AreEqual(request.RequestUri, "https://auth.immutable.com/oauth/device/code");
+            Assert.AreEqual(request.Method, HttpMethod.Post);
+        }
+
+        [Test]
+        public void Login_Success_RefreshFailed_DeviceCodeFallback()
+        {
+            credentialsManager.hasValidCredentials = false;
+            credentialsManager.token = new TokenResponse();
+            credentialsManager.token.refresh_token = "thisIsTheRefreshToken";
+            var refreshTokenResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            refreshTokenResponse.Content = new StringContent("{}");
+            httpMock.responses.Add(refreshTokenResponse);
+
+            AddDeviceCodeResponse();
+
+            var code = manager.Login().Result;
+            Assert.AreEqual(code, "userCode");
+
+            var request = httpMock.requests[0];
+            Assert.AreEqual(request.RequestUri, "https://auth.immutable.com/oauth/token");
+
+            var deviceCodeRequest = httpMock.requests[1];
+            Assert.AreEqual(deviceCodeRequest.RequestUri, "https://auth.immutable.com/oauth/device/code");
+        }
+
+        [Test]
+        public async Task ConfirmCode_Success()
+        {
+            PrepareForConfirmCode();
+            var tokenResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            tokenResponse.Content = new StringContent(VALID_TOKEN_RESPONSE);
+            httpMock.responses.Add(tokenResponse);
+
+            Assert.Null(manager.GetUser());
+
+            var user = await manager.ConfirmCode();
+
+            Assert.NotNull(user);
+            Assert.AreEqual(user, manager.GetUser());
+
+            Assert.AreEqual(2, httpMock.requests.Count);
+            var request = httpMock.requests[1];
+            Assert.AreEqual(request.RequestUri, "https://auth.immutable.com/oauth/token");
+            Assert.AreEqual(request.Method, HttpMethod.Post);
+            Assert.True(request.Content.ReadAsStringAsync().Result.Contains("device_code=deviceCode"));
+        }
+
+        [Test]
+        public async Task ConfirmCode_Failed_PendingAndExpired()
+        {
+            PrepareForConfirmCode();
+            var slowDownResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            slowDownResponse.Content = new StringContent("{\"error\":\"authorization_pending\",\"error_description\":\"description\"}");
+            httpMock.responses.Add(slowDownResponse);
+
+            var expiredResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            expiredResponse.Content = new StringContent("{\"error\":\"expired_token\",\"error_description\":\"description\"}");
+            httpMock.responses.Add(expiredResponse);
+
+            Assert.Null(manager.GetUser());
+
+            Exception? e = null;
+            try {
+                var result = await manager.ConfirmCode();
+            } catch (Exception exception) {
+                e = exception;
+                Debug.Log("Exception: " + e);
+            }
+            Assert.NotNull(e);
+            Assert.AreEqual(e.GetType(), typeof(InvalidOperationException));
+            Assert.AreEqual(3, httpMock.requests.Count);
+        }
+
+        [Test]
+        public async Task ConfirmCode_Failed_SlowDownAndAccessDenied()
+        {
+            PrepareForConfirmCode();
+            var slowDownResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            slowDownResponse.Content = new StringContent("{\"error\":\"slow_down\",\"error_description\":\"description\"}");
+            httpMock.responses.Add(slowDownResponse);
+
+            var expiredResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            expiredResponse.Content = new StringContent("{\"error\":\"access_denied\",\"error_description\":\"description\"}");
+            httpMock.responses.Add(expiredResponse);
+
+            Assert.Null(manager.GetUser());
+
+            Exception? e = null;
+            try {
+                var result = await manager.ConfirmCode();
+            } catch (Exception exception) {
+                e = exception;
+                Debug.Log("Exception: " + e);
+            }
+            Assert.NotNull(e);
+            Assert.AreEqual(e.GetType(), typeof(UnauthorizedAccessException));
+            Assert.AreEqual(3, httpMock.requests.Count);
+        }
+
+        [Test]
+        public async Task ConfirmCode_Failed_UnexpectedErrorCode()
+        {
+            PrepareForConfirmCode();
+            var unexpectedResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            unexpectedResponse.Content = new StringContent("{\"error\":\"whats_this\",\"error_description\":\"description\"}");
+            httpMock.responses.Add(unexpectedResponse);
+
+            Assert.Null(manager.GetUser());
+
+            Exception? e = null;
+            try {
+                var result = await manager.ConfirmCode();
+            } catch (Exception exception) {
+                e = exception;
+                Debug.Log("Exception: " + e);
+            }
+            Assert.NotNull(e);
+            Assert.AreEqual(2, httpMock.requests.Count);
+        }
+
+        [Test]
+        public async Task ConfirmCode_Failed_UnexpectedResponse()
+        {
+            PrepareForConfirmCode();
+            var unexpectedResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            unexpectedResponse.Content = new StringContent("{}");
+            httpMock.responses.Add(unexpectedResponse);
+
+            Assert.Null(manager.GetUser());
+
+            Exception? e = null;
+            try {
+                var result = await manager.ConfirmCode();
+            } catch (Exception exception) {
+                e = exception;
+                Debug.Log("Exception: " + e);
+            }
+            Assert.NotNull(e);
+            Assert.AreEqual(2, httpMock.requests.Count);
+        }
+    }
+
+    internal class MockCredentialsManager : ICredentialsManager {
+        public bool hasValidCredentials = false;
+        public TokenResponse? token = null;
+
+        public void SaveCredentials(TokenResponse tokenResponse) {
+            token = tokenResponse;
+        }
+
+        public TokenResponse? GetCredentials() {
+            return token;
+        }
+
+        public bool HasValidCredentials() {
+            return hasValidCredentials;
+        }
+
+        public void ClearCredentials() {
+
+        }
+    }
+}

--- a/src/Packages/Passport/Tests/Runtime/Scripts/Auth/AuthManagerTests.cs.meta
+++ b/src/Packages/Passport/Tests/Runtime/Scripts/Auth/AuthManagerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 26aa813edd1d7c14c85ba785f0a1de8f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Passport/Tests/Runtime/Scripts/Utility/MockHttpMessageHandler.cs
+++ b/src/Packages/Passport/Tests/Runtime/Scripts/Utility/MockHttpMessageHandler.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Immutable.Passport.Utility.Tests
+{
+    internal class MockHttpMessageHandler : HttpMessageHandler
+    {
+        // Requests made in order
+        public List<HttpRequestMessage> requests { get; private set; } = new List<HttpRequestMessage>(); 
+        
+        // Responses to return matching request order 
+        public List<HttpResponseMessage> responses { get; private set; } = new List<HttpResponseMessage>();
+
+        public MockHttpMessageHandler()
+        {
+        }
+        
+        public HttpClient ToHttpClient()
+        {
+            return new HttpClient(this);
+        }
+
+        /// <summary>
+        /// Maps the request to the most appropriate configured response
+        /// </summary>
+        /// <param name="request">The request being sent</param>
+        /// <param name="cancellationToken">The token used to cancel the request</param>
+        /// <returns>A Task containing the future response message</returns>
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // Debug.Log("Request made: " + request.RequestUri);
+            requests.Add(request);
+            if (requests.Count <= responses.Count) {
+                return Task.FromResult(responses[requests.Count - 1]);
+            }
+
+            return Task.FromException<HttpResponseMessage>(new Exception($"No response for this request: {request.RequestUri}"));
+        }
+
+        /// <summary>
+        /// Disposes the current instance
+        /// </summary>
+        /// <param name="disposing">true if called from Dispose(); false if called from dtor()</param>
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Packages/Passport/Tests/Runtime/Scripts/Utility/MockHttpMessageHandler.cs.meta
+++ b/src/Packages/Passport/Tests/Runtime/Scripts/Utility/MockHttpMessageHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 601402dcf4d44a44c97259b60270fd8f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Passport/Packages/manifest.json
+++ b/src/Passport/Packages/manifest.json
@@ -5,7 +5,7 @@
     "com.unity.ide.rider": "3.0.21",
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",
-    "com.unity.test-framework": "1.1.33",
+    "com.unity.test-framework": "2.0.1-exp.1",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.6.5",
     "com.unity.ugui": "1.0.0",


### PR DESCRIPTION
- Updated test framework to experimental 2.0.1 so we can test C# Tasks
- Refactored AuthManager to use dependency injection for CredentialsManager and HttpClient
- Fixed existing credentials to fallback to logging in with device code if the refresh token request failed
- Created interface for CredentialsManager
- Created `MockHttpMessageHandler`. Responses can be set in order of execution and requests can be validated against.
- Created tests for AuthManager