### PR TITLE
fix: call function not defined

### DIFF
--- a/src/Packages/Passport/Runtime/Assets/Resources/index.js
+++ b/src/Packages/Passport/Runtime/Assets/Resources/index.js
@@ -14,6 +14,10 @@ const PassportFunctions = {
     signMessage: "signMessage"
 }
 
+// To notify Unity that this file is loaded
+const initRequest = "init";
+const initRequestId = "1";
+
 const getPassportConfig = () => {
     const sharedConfigurationValues = {
         scope,
@@ -111,3 +115,12 @@ async function callFunction(jsonData) {
         });
     }
 }
+
+console.log("index.js loaded");
+// File loaded
+// This is to prevent callFunction not defined error
+callbackToUnity({
+    responseFor: initRequest,
+    requestId: initRequestId,
+    success: true
+});

--- a/src/Packages/Passport/Runtime/Assets/Scripts/Passport.cs
+++ b/src/Packages/Passport/Runtime/Assets/Scripts/Passport.cs
@@ -80,6 +80,7 @@ namespace Immutable.Passport
                 webBrowserClient.OnLoadFinish += OnLoadFinish;
 
                 communicationsManager = new BrowserCommunicationsManager(webBrowserClient);
+                communicationsManager.OnReady += () => readySignalReceived = true;
             }
             catch (Exception ex)
             {
@@ -109,9 +110,6 @@ namespace Immutable.Passport
             Debug.Log($"{TAG} On load finish: {url}");
             if (url.StartsWith(INITIAL_URL))
             {
-                Debug.Log($"{TAG} Browser is ready");
-                // Browser is considered ready to load local HTML file
-                // Once the initial URL is loaded 
                 string filePath = "";
 #if UNITY_EDITOR
                 filePath = SCHEME_FILE + Path.GetFullPath($"{PASSPORT_PACKAGE_RESOURCES_DIRECTORY}{PASSPORT_HTML_FILE_NAME}");
@@ -121,7 +119,6 @@ namespace Immutable.Passport
 #endif     
 #endif
                 webBrowserClient.LoadUrl(filePath);
-                readySignalReceived = true;
                 // Clean up listener
                 webBrowserClient.OnLoadFinish -= OnLoadFinish;
             }


### PR DESCRIPTION
If the user clicks the sample app 'Connect' button too fast, a `callFunction` not defined reference error is thrown. This PR fixes this by detecting when the `index.js` file is loaded.