### PR TITLE
fix: invalid token magic error

### DIFF
--- a/src/Packages/Passport/Runtime/Assets/Scripts/Auth/AuthManager.cs
+++ b/src/Packages/Passport/Runtime/Assets/Scripts/Auth/AuthManager.cs
@@ -68,7 +68,7 @@ namespace Immutable.Passport.Auth
             TokenResponse? savedCreds = manager.GetCredentials();
             if (savedCreds != null && manager.HasValidCredentials())
             {
-                Debug.Log($"{TAG} Access token exists and is still valid");
+                Debug.Log($"{TAG} Tokens exist and are still valid");
                 user = savedCreds.ToUser();
                 return null;
             }
@@ -86,7 +86,8 @@ namespace Immutable.Passport.Auth
                 catch (Exception)
                 {
                     Debug.Log($"{TAG} Token refresh failed");
-                    // Fallback to device code below
+                    // Clear everything and fallback to device code below
+                    manager.ClearCredentials();
                 }
             }
 

--- a/src/Packages/Passport/Runtime/Assets/Scripts/Auth/AuthType.cs
+++ b/src/Packages/Passport/Runtime/Assets/Scripts/Auth/AuthType.cs
@@ -25,7 +25,7 @@ namespace Immutable.Passport.Auth
         public int expires_in { get; set; }
     }
 
-    internal class AccessTokenPayload
+    internal class TokenPayload
     {
         public long? exp { get; set; }
     }

--- a/src/Packages/Passport/Runtime/Assets/Scripts/Storage/CredentialsManager.cs
+++ b/src/Packages/Passport/Runtime/Assets/Scripts/Storage/CredentialsManager.cs
@@ -51,36 +51,43 @@ namespace Immutable.Passport.Storage
             return JsonConvert.DeserializeObject<TokenResponse>(json);
         }
 
-        /// Checks whether the access token is still valid
+        /// Checks if both the access token and id token are still valid
         public bool HasValidCredentials()
         {
             Debug.Log($"{TAG} Has Valid Credentials");
             TokenResponse? response = GetCredentials();
             if (response != null)
             {
-                Debug.Log($"{TAG} Decoding access token...");
-                string? accessToken = JwtUtility.DecodeJwt(response.access_token);
-                if (accessToken == null)
-                {
-                    Debug.Log($"{TAG} Could not decode access token...");
-                    return false;
-                }
-
-                // Grab the expiry time
-                AccessTokenPayload? accessTokenPayload = JsonConvert.DeserializeObject<AccessTokenPayload>(accessToken);
-
-                long expiresAt = accessTokenPayload?.exp ?? 0;
-                long now = GetCurrentTimeSeconds() + VALID_CREDENTIALS_MIN_TTL_SEC;
-                bool valid = expiresAt > now;
-                Debug.Log($"{TAG} Access Token expires (UTC seconds): {expiresAt}");
-                Debug.Log($"{TAG} Time now (UTC seconds): {now}");
-                return valid;
+                Debug.Log($"{TAG} Checking access token: {response.access_token}");
+                bool accessTokenValid = IsTokenValid(response.access_token);
+                Debug.Log($"{TAG} Checking ID token: {response.id_token}");
+                bool idTokenValid = IsTokenValid(response.id_token);
+                return accessTokenValid && idTokenValid;
             }
             else
             {
                 Debug.Log($"{TAG} No Credentials");
                 return false;
             }
+        }
+
+        private bool IsTokenValid(string jwt) {
+            Debug.Log($"{TAG} Decoding {jwt}...");
+            string? token = JwtUtility.DecodeJwt(jwt);
+            if (token == null)
+            {
+                Debug.Log($"{TAG} Could not decode token...");
+                return false;
+            }
+            // Grab expiry time
+            TokenPayload? tokenPayload = JsonConvert.DeserializeObject<TokenPayload>(token);
+            long expiresAt = tokenPayload?.exp ?? 0;
+            Debug.Log($"{TAG} Token expires (UTC seconds): {expiresAt}");
+            
+            long now = GetCurrentTimeSeconds() + VALID_CREDENTIALS_MIN_TTL_SEC;
+            Debug.Log($"{TAG} Time now (UTC seconds): {now}");
+
+            return expiresAt > now;
         }
 
         protected virtual long GetCurrentTimeSeconds()

--- a/src/Packages/Passport/Tests/Runtime/Scripts/Storage/CredentialsManagerTests.cs
+++ b/src/Packages/Passport/Tests/Runtime/Scripts/Storage/CredentialsManagerTests.cs
@@ -12,8 +12,13 @@ namespace Immutable.Passport.Storage
     {
         internal static string ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikp" +
             "vaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjcyMDB9.zKW_cyLXjQ0Vbc7LsrHGo6fIUfCy9QQhFNdKN5JxlZY";
+        internal static string INVALID_ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmF" + 
+            "tZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjB9.JWKPB-5Q8rTYzl-MfhRGpP9WpDpQxC7JkIAGFMDZnpg";
         internal static string REFRESH_TOKEN = "refreshToken";
-        internal static string ID_TOKEN = "idToken";
+        internal static string ID_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IklEIHRva2VuIiwiZXh" + 
+            "wIjo3MjAwfQ.k4THNItPrrW7g5WmbBhRlpUwW1_dRpg1Zwg6jBVAvnA";
+        internal static string INVALID_ID_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IklEIHRva2V" + 
+            "uIiwiZXhwIjowfQ.DHDYnvJ9M8UMNeRD95oBQX91yn_snlMEpdK_qqilDB0";
         internal static string TOKEN_TYPE = "Bearer";
         internal static int EXPIRES_IN = 86400;
         internal static string SET_STRING = "SetString";
@@ -96,12 +101,40 @@ namespace Immutable.Passport.Storage
         }
 
         [Test]
-        public void HasValidCredentialsTest_Invalid()
+        public void HasValidCredentialsTest_BothInvalid()
         {
             manager.mockCurrentTimeSeconds = 3600;
             Assert.False(manager.HasValidCredentials());
 
             manager.mockCurrentTimeSeconds = 9999;
+            Assert.False(manager.HasValidCredentials());
+        }
+
+        [Test]
+        public void HasValidCredentialsTest_InvalidAccessToken()
+        {
+            manager.mockCurrentTimeSeconds = 1;
+            manager.mockToken = new TokenResponse() {
+                access_token = CredentialsManagerTests.INVALID_ACCESS_TOKEN,
+                refresh_token = CredentialsManagerTests.REFRESH_TOKEN,
+                id_token = CredentialsManagerTests.ID_TOKEN,
+                token_type = CredentialsManagerTests.TOKEN_TYPE,
+                expires_in = CredentialsManagerTests.EXPIRES_IN
+            };
+            Assert.False(manager.HasValidCredentials());
+        }
+
+        [Test]
+        public void HasValidCredentialsTest_InvalidIdToken()
+        {
+            manager.mockCurrentTimeSeconds = 1;
+            manager.mockToken = new TokenResponse() {
+                access_token = CredentialsManagerTests.ACCESS_TOKEN,
+                refresh_token = CredentialsManagerTests.REFRESH_TOKEN,
+                id_token = CredentialsManagerTests.INVALID_ID_TOKEN,
+                token_type = CredentialsManagerTests.TOKEN_TYPE,
+                expires_in = CredentialsManagerTests.EXPIRES_IN
+            };
             Assert.False(manager.HasValidCredentials());
         }
 
@@ -119,6 +152,7 @@ namespace Immutable.Passport.Storage
 
         private PlayerPrefsDelegate onPlayerPrefs;
         public string? mockTokenJson;
+        public TokenResponse? mockToken;
         public long mockCurrentTimeSeconds = 0;
 
         public TestableCredentialsManager(PlayerPrefsDelegate onPlayerPrefs) {
@@ -131,7 +165,7 @@ namespace Immutable.Passport.Storage
         }
 
         protected override TokenResponse DeserializeTokenResponse(string json) {
-            return new TokenResponse() {
+            return mockToken ?? new TokenResponse() {
                 access_token = CredentialsManagerTests.ACCESS_TOKEN,
                 refresh_token = CredentialsManagerTests.REFRESH_TOKEN,
                 id_token = CredentialsManagerTests.ID_TOKEN,


### PR DESCRIPTION
If the access and id tokens are nearing expiration, an invalid token error may be returned by Magic. To prevent this error, I am:
* checking the validity of both the access and id tokens
* implementing a minimum duration (1 hour) for which the token should remain valid