### PR TITLE
feat: remove passport monobehaviour

### DIFF
--- a/sample/Assets/Scripts/UnauthenticatedScript.cs
+++ b/sample/Assets/Scripts/UnauthenticatedScript.cs
@@ -25,7 +25,7 @@ public class UnauthenticatedScript : MonoBehaviour
             userCodeText.gameObject.SetActive(false);
             proceedLoginButton.gameObject.SetActive(false);
 
-            passport = await Passport.Initialise();
+            passport = await Passport.Init();
             connectButton.gameObject.SetActive(true);
             ShowOutput("Ready");
         }

--- a/src/Packages/Passport/Runtime/Assets/Scripts/Passport.cs
+++ b/src/Packages/Passport/Runtime/Assets/Scripts/Passport.cs
@@ -38,12 +38,12 @@ namespace Immutable.Passport
 #endif
         }
 
-        public static UniTask<Passport> Initialise()
+        public static UniTask<Passport> Init()
         {
             if (Instance == null)
             {
                 Instance = new Passport();
-                Instance.Init();
+                Instance.Initialise();
             }
             else 
             {
@@ -65,7 +65,7 @@ namespace Immutable.Passport
                 });
         }
 
-        private async void Init() {
+        private async void Initialise() {
             try
             {
                 BrowserCommunicationsManager communicationsManager = new BrowserCommunicationsManager(webBrowserClient);


### PR DESCRIPTION
* Removed the name for Monobehaviour
* Added code to clean up UWB resources when the user quits the game in the editor. Otherwise, the engine process will keep running, and the browser can't startup again. This is not required for the standalone Windows app, as the child engine process will get killed with the parent game process.