### PR TITLE
fix: get credentials false positive

### DIFF
--- a/src/Packages/Passport/Runtime/Scripts/Json.meta
+++ b/src/Packages/Passport/Runtime/Scripts/Json.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0adc2b8a02ff21c4982da23a0b468813
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Passport/Runtime/Scripts/Json/JsonHelpers.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Json/JsonHelpers.cs
@@ -1,0 +1,24 @@
+using Newtonsoft.Json;
+
+namespace Immutable.Passport.Json
+{
+    public static class JsonExtensions
+    {
+        /**
+        * Return null if the deserialization fails. 
+        * To require non-null values apply [JsonProperty(Required = Required.Always)] 
+        * above member declarations.
+        */
+        public static T? OptDeserializeObject<T>(this string json) where T : class
+        {
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(json);
+            }
+            catch (JsonSerializationException e)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Packages/Passport/Runtime/Scripts/Json/JsonHelpers.cs.meta
+++ b/src/Packages/Passport/Runtime/Scripts/Json/JsonHelpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a68ea34d838464e47a2f6d21eab53d12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Passport/Runtime/Scripts/Model/AuthType.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Model/AuthType.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace Immutable.Passport.Model
 {
 #pragma warning disable CS8618
@@ -10,11 +12,15 @@ namespace Immutable.Passport.Model
 
     public class TokenResponse
     {
-        public string? accessToken;
+        [JsonProperty(Required = Required.Always)]
+        public string accessToken;
         public string? refreshToken;
-        public string? idToken;
-        public string? tokenType;
-        public int? expiresIn;
+        [JsonProperty(Required = Required.Always)]
+        public string idToken;
+        [JsonProperty(Required = Required.Always)]
+        public string tokenType;
+        [JsonProperty(Required = Required.Always)]
+        public int expiresIn;
     }
 #pragma warning restore CS8618
 #pragma warning restore IDE1006


### PR DESCRIPTION
We had been assuming that if the declaration of the deserialised object wasn't being met that `JsonConvert.DeserializeObject` would return null (e.g. idToken isn't in the json payload). This was incorrect, it was instead instantiating these values leading to false positives when checking `GetStoredCredentials`.

To fix this I have added `[JsonProperty(Required = Required.Always)]` to the relevant member declarations and created a Json helper to return null if theres a deserialisation exception.