### PR TITLE
feat: check exception is network error

### DIFF
--- a/sample/Assets/Scripts/UnauthenticatedScript.cs
+++ b/sample/Assets/Scripts/UnauthenticatedScript.cs
@@ -97,11 +97,21 @@ public class UnauthenticatedScript : MonoBehaviour
         }
         catch (Exception ex)
         {
-            string error = $"Connect() error: {ex.Message}";
+            PassportException passportException = ex as PassportException;
+            string error;
+            if (passportException != null && passportException.IsNetworkError())
+            {
+                error = $"Connect() error: Check your internet connection and try again";
+            }
+            else
+            {
+                error = $"Connect() error: {ex.Message}";
+                // Restart everything
+                await passport.Logout();
+            }
+
             Debug.Log(error);
             ShowOutput(error);
-            // Restart everything
-            await passport.Logout();
         }
     }
 

--- a/src/Packages/Passport/Runtime/Scripts/Model/PassportException.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Model/PassportException.cs
@@ -26,5 +26,14 @@ namespace Immutable.Passport.Model
         {
             this.Type = type;
         }
+
+        /**
+        * The error message for api requests via axios that fail due to network connectivity is "Network Error".
+        * This isn't the most reliable way to determine connectivity but it is currently the best we have. 
+        */
+        public bool IsNetworkError()
+        {
+            return Message.EndsWith("Network Error");
+        }
     }
 }

--- a/src/Packages/Passport/Runtime/Scripts/PassportImpl.cs
+++ b/src/Packages/Passport/Runtime/Scripts/PassportImpl.cs
@@ -67,7 +67,6 @@ namespace Immutable.Passport
                 }
             }
 
-            await Logout();
             throw new PassportException(
                 response?.error ?? "Something went wrong, please call Connect() again",
                 PassportErrorType.AUTHENTICATION_ERROR


### PR DESCRIPTION
- Add ability to check if PassportException was due to a Network Error
- Removed unnecessary logout call at the end of `InitialiseDeviceCodeAuth`. This method shouldn't be called if credentials already exist. 