### PR TITLE
feat: startup engine timeout

### DIFF
--- a/sample/Assets/Scenes/AuthenticatedScene.unity
+++ b/sample/Assets/Scenes/AuthenticatedScene.unity
@@ -5005,8 +5005,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1375070108}
   m_HandleRect: {fileID: 1375070107}
   m_Direction: 0
-  m_Value: 1
-  m_Size: 0.99999994
+  m_Value: 0
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -7214,7 +7214,7 @@ MonoBehaviour:
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 1600, y: 1200}
   m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
+  m_MatchWidthOrHeight: 0.5
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
@@ -8692,7 +8692,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1335469791}
   m_Direction: 2
   m_Value: 0
-  m_Size: 0.99999994
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:

--- a/sample/Assets/Scenes/UnauthenticatedScene.unity
+++ b/sample/Assets/Scenes/UnauthenticatedScene.unity
@@ -1625,7 +1625,7 @@ MonoBehaviour:
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 1600, y: 1200}
   m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
+  m_MatchWidthOrHeight: 0.5
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96

--- a/sample/Assets/Scripts/UnauthenticatedScript.cs
+++ b/sample/Assets/Scripts/UnauthenticatedScript.cs
@@ -24,12 +24,20 @@ public class UnauthenticatedScript : MonoBehaviour
             connectButton.gameObject.SetActive(false);
             tryAgainButton.gameObject.SetActive(false);
 
+            string clientId = "ZJL7JvetcDFBNDlgRs5oJoxuAUUl6uQj";
+            string environment = Immutable.Passport.Model.Environment.SANDBOX;
             string? redirectUri = null;
-#if UNITY_ANDROID || UNITY_IPHONE
+#if UNITY_IPHONE || UNITY_ANDROID
             redirectUri = "imxsample://callback";
 #endif
 
-            passport = await Passport.Init("ZJL7JvetcDFBNDlgRs5oJoxuAUUl6uQj", Immutable.Passport.Model.Environment.SANDBOX, redirectUri);
+            passport = await Passport.Init(
+#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
+                clientId, environment, redirectUri, 10000
+#else
+                clientId, environment, redirectUri
+#endif
+                );
 
             // Check if user's logged in before
             bool hasCredsSaved = await passport.HasCredentialsSaved();

--- a/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
@@ -45,10 +45,10 @@ namespace Immutable.Passport
         }
 
         /// <summary>
-        ///     Initialises Passport
+        /// Initialises Passport
         /// </summary>
         /// <param name="clientId">The client ID</param>
-        /// <param name="environment">The envronment to connect to</param>
+        /// <param name="environment">The environment to connect to</param>
         /// <param name="redirectUri">(Currently, mobile only) The URL to which auth will redirect the browser after authorisation has been granted by the user</param>
         /// <param name="engineStartupTimeoutMs">(Windows only) Timeout time for waiting for the engine to start (in milliseconds)</param>
         public static UniTask<Passport> Init(

--- a/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
@@ -44,13 +44,30 @@ namespace Immutable.Passport
 #endif
         }
 
-        public static UniTask<Passport> Init(string clientId, string environment, string? redirectUri = null)
+        /// <summary>
+        ///     Initialises Passport
+        /// </summary>
+        /// <param name="clientId">The client ID</param>
+        /// <param name="environment">The envronment to connect to</param>
+        /// <param name="redirectUri">(Currently, mobile only) The URL to which auth will redirect the browser after authorisation has been granted by the user</param>
+        /// <param name="engineStartupTimeoutMs">(Windows only) Timeout time for waiting for the engine to start (in milliseconds)</param>
+        public static UniTask<Passport> Init(
+#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
+            string clientId, string environment, string? redirectUri = null, int engineStartupTimeoutMs = 4000
+#else
+            string clientId, string environment, string? redirectUri = null
+#endif
+        )
         {
             if (Instance == null)
             {
                 Instance = new Passport();
                 // Wait until we get a ready signal
-                return Instance.Initialise()
+                return Instance.Initialise(
+#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
+                        engineStartupTimeoutMs
+#endif
+                    )
                     .ContinueWith(async () =>
                     {
                         await UniTask.WaitUntil(() => readySignalReceived != null);
@@ -75,14 +92,18 @@ namespace Immutable.Passport
             }
         }
 
-        private async UniTask Initialise()
+        private async UniTask Initialise(
+#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
+            int engineStartupTimeoutMs
+#endif
+        )
         {
             try
             {
                 BrowserCommunicationsManager communicationsManager = new(webBrowserClient);
                 communicationsManager.OnReady += () => readySignalReceived = true;
 #if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
-                await ((WebBrowserClient)webBrowserClient).Init();
+                await ((WebBrowserClient)webBrowserClient).Init(engineStartupTimeoutMs);
 #endif
                 passportImpl = new PassportImpl(communicationsManager);
             }
@@ -105,7 +126,7 @@ namespace Immutable.Passport
 #endif
 
         /// <summary>
-        /// Sets the timeout time for` waiting for each call to respond (in milliseconds).
+        /// Sets the timeout time for waiting for each call to respond (in milliseconds).
         /// This only applies to functions that use the browser communications manager.
         /// </summary>
         public void SetCallTimeout(int ms)
@@ -271,12 +292,12 @@ namespace Immutable.Passport
 
         /// <summary>
         /// Returns the balance of the account of given address.
+        /// </summary>
         /// <param name="address">Address to check for balance</param>
         /// <param name="blockNumberOrTag">Integer block number, or the string "latest", "earliest" or "pending"</param>
         /// <returns>
         /// The balance in wei
         /// </returns>
-        /// </summary>
         public async UniTask<string> ZkEvmGetBalance(string address, string blockNumberOrTag = "latest")
         {
             return await GetPassportImpl().ZkEvmGetBalance(address, blockNumberOrTag);

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
@@ -250,8 +250,11 @@ namespace VoltstroStudios.UnityWebBrowser.Core
         ///     Inits the browser client
         /// </summary>
         /// <exception cref="FileNotFoundException"></exception>
-        public async UniTask Init()
+        public async UniTask Init(int engineStartupTimeout = 4000)
         {
+            this.engineStartupTimeout = engineStartupTimeout;
+            UnityEngine.Debug.Log($"Engine startup timeout: {engineStartupTimeout}");
+
             // Get the path to the Windows UWB process
             EngineConfiguration engineConfiguration = new EngineConfiguration();
             engineConfiguration.engineAppName = ENGINE_APP_NAME;


### PR DESCRIPTION
* Sometimes, Windows takes longer to start up the browser engine, so adding the ability to set the engine startup time during initialisation.
* Added docs
* Updated screen resolution for sample app on phones