### PR TITLE
fix: user is not logged out if there is no network

### DIFF
--- a/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
@@ -206,8 +206,13 @@ namespace Immutable.Passport
             catch (Exception ex)
             {
                 Debug.LogError($"{TAG} Failed to connect to Passport using saved credentials: {ex.Message}");
+
+                if (!(ex is PassportException) || (ex is PassportException pEx && !pEx.IsNetworkError()))
+                {
+                    await Logout();
+                }
             }
-            await Logout();
+
             return false;
         }
 


### PR DESCRIPTION
When trying to do a silent login, if user does not have network they should not be logged out.