### PR TITLE
feat: use ASWebAuthenticationSession for iOS PKCE

### DIFF
--- a/src/Packages/Passport/Editor/PassportPostprocess.cs
+++ b/src/Packages/Passport/Editor/PassportPostprocess.cs
@@ -84,7 +84,11 @@ namespace Immutable.Passport.Editor
                     var method = type.GetMethod("AddFrameworkToProject");
                     method.Invoke(proj, new object[] { target, "WebKit.framework", false });
                 }
-
+                {
+                    var method = type.GetMethod("AddFrameworkToProject");
+                    method.Invoke(proj, new object[] { target, "AuthenticationServices.framework", false });
+                }
+                
                 var cflags = "";
                 if (EditorUserBuildSettings.development)
                 {

--- a/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
@@ -385,8 +385,6 @@ namespace Immutable.Passport
                 }
                 return;
             }
-
-            Debug.Log($"{TAG} Unhandled onPostMessageError. id: {id} message: {message}");
         }
     }
 }

--- a/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
@@ -35,11 +35,11 @@ namespace Immutable.Passport
 #if UNITY_EDITOR_WIN
             Application.quitting += OnQuit;
 #elif UNITY_IPHONE || UNITY_ANDROID || UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
-            Application.deepLinkActivated += onDeepLinkActivated;
+            Application.deepLinkActivated += OnDeepLinkActivated;
             if (!string.IsNullOrEmpty(Application.absoluteURL))
             {
                 // Cold start and Application.absoluteURL not null so process Deep Link.
-                onDeepLinkActivated(Application.absoluteURL);
+                OnDeepLinkActivated(Application.absoluteURL);
             }
 #endif
         }
@@ -314,7 +314,7 @@ namespace Immutable.Passport
             throw new PassportException("Passport not initialised");
         }
 
-        private async void onDeepLinkActivated(string url)
+        private void OnDeepLinkActivated(string url)
         {
             deeplink = url;
 

--- a/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/WebViewObject.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/WebViewObject.cs
@@ -167,8 +167,6 @@ public class WebViewObject
             }
             return;
         }
-
-        Debug.Log($"{TAG} delegateMessageReceived unsupported key " + key);
     }
 #endif
 

--- a/src/Packages/Passport/Runtime/ThirdParty/ImmutableBrowserCore/IWebBrowserClient.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/ImmutableBrowserCore/IWebBrowserClient.cs
@@ -3,7 +3,11 @@ namespace Immutable.Browser.Core
     public interface IWebBrowserClient
     {
         event OnUnityPostMessageDelegate OnUnityPostMessage;
+        event OnUnityPostMessageDelegate OnAuthPostMessage;
+        event OnUnityPostMessageErrorDelegate OnPostMessageError;
 
         void ExecuteJs(string js);
+
+        void LaunchAuthURL(string url);
     }
 }

--- a/src/Packages/Passport/Runtime/ThirdParty/ImmutableBrowserCore/OnUnityPostMessage.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/ImmutableBrowserCore/OnUnityPostMessage.cs
@@ -1,4 +1,5 @@
 namespace Immutable.Browser.Core
 {
     public delegate void OnUnityPostMessageDelegate(string data);
+    public delegate void OnUnityPostMessageErrorDelegate(string id, string error);
 }

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
@@ -592,6 +592,8 @@ namespace VoltstroStudios.UnityWebBrowser.Core
         ///     Invoked when the browser goes in or out of fullscreen
         /// </summary>
         public event OnFullscreenChange OnFullscreen;
+        public event OnUnityPostMessageDelegate OnAuthPostMessage;
+        public event OnUnityPostMessageErrorDelegate OnPostMessageError;
 
         internal void InvokeFullscreen(bool fullscreen)
         {
@@ -735,6 +737,11 @@ namespace VoltstroStudios.UnityWebBrowser.Core
             CheckIfIsReadyAndConnected();
 
             communicationsManager.ExecuteJs(js);
+        }
+
+        public void LaunchAuthURL(string url)
+        {
+            Application.OpenURL(url);
         }
 
         [DebuggerStepThrough]

--- a/src/Packages/Passport/Tests/Runtime/Scripts/Core/BrowserCommunicationsManagerTests.cs
+++ b/src/Packages/Passport/Tests/Runtime/Scripts/Core/BrowserCommunicationsManagerTests.cs
@@ -152,6 +152,9 @@ namespace Immutable.Passport.Core
     internal class MockBrowserClient : IWebBrowserClient
     {
         public event OnUnityPostMessageDelegate? OnUnityPostMessage;
+        public event OnUnityPostMessageDelegate? OnAuthPostMessage;
+        public event OnUnityPostMessageErrorDelegate? OnPostMessageError;
+
         public BrowserRequest? request = null;
         public BrowserResponse? browserResponse = null;
         public bool setRequestId = true;
@@ -190,6 +193,11 @@ namespace Immutable.Passport.Core
                 return "";
             }
             return value[adjustedPosA..posB];
+        }
+
+        public void LaunchAuthURL(string url)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Packages/Passport/Tests/Runtime/Scripts/PassportTests.cs
+++ b/src/Packages/Passport/Tests/Runtime/Scripts/PassportTests.cs
@@ -4,6 +4,7 @@ using Immutable.Passport.Core;
 using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
 using Newtonsoft.Json;
+using Immutable.Browser.Core;
 
 namespace Immutable.Passport
 {
@@ -66,11 +67,19 @@ namespace Immutable.Passport
         public string response = "";
         public string fxName = "";
         public string? data = "";
+        public event OnUnityPostMessageDelegate? OnAuthPostMessage;
+        public event OnUnityPostMessageErrorDelegate? OnPostMessageError;
+
         public UniTask<string> Call(string fxName, string? data = null, bool ignoreTimeout = false)
         {
             this.fxName = fxName;
             this.data = data;
             return UniTask.FromResult(response);
+        }
+
+        public void LaunchAuthURL(string url)
+        {
+            throw new NotImplementedException();
         }
 
         public void SetCallTimeout(int ms)


### PR DESCRIPTION
This is the standard way of dealing with SSO on iOS.

Asynchronous error handling is now being bubbled up to PassportImpl
where it can be parsed by their identifier to complete unfinished
tasks.