### PR TITLE
feat: add proguard rules for releases

### DIFF
--- a/src/Packages/Passport/Runtime/Assets/ImmutableAndroid.androidlib/build.gradle
+++ b/src/Packages/Passport/Runtime/Assets/ImmutableAndroid.androidlib/build.gradle
@@ -18,5 +18,6 @@ android {
         targetSdkVersion 33
         versionCode 1
         versionName '1.0'
+        consumerProguardFiles 'proguard-immutable.txt'
     }
 }

--- a/src/Packages/Passport/Runtime/Assets/ImmutableAndroid.androidlib/proguard-immutable.txt
+++ b/src/Packages/Passport/Runtime/Assets/ImmutableAndroid.androidlib/proguard-immutable.txt
@@ -1,0 +1,8 @@
+-dontwarn com.immutable.unity
+-keep class com.immutable.** { *; }
+-keep interface com.immutable.** { *; }
+-keep public class com.immutable.unity.ImmutableAndroid { public protected *; }
+
+-dontwarn androidx.**
+-keep class androidx.** { *; }
+-keep interface androidx.** { *; }

--- a/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/WebViewObject.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/WebViewObject.cs
@@ -102,7 +102,7 @@ public class WebViewObject
         IntPtr instance, string url);
     [DllImport("__Internal")]
     private static extern void _CWebViewPlugin_SetDelegate(DelegateMessage callback);
-#elif UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
+#elif UNITY_STANDALONE_OSX
     [DllImport("WebView")]
     private static extern IntPtr _CWebViewPlugin_Init(string ua);
     [DllImport("WebView")]


### PR DESCRIPTION
Fixes the `ImmutableAndroid` class being discarded when performing a minified release/build.