### PR TITLE
fix: windows compilation flags

### DIFF
--- a/sample/Packages/manifest.json
+++ b/sample/Packages/manifest.json
@@ -4,7 +4,7 @@
     "com.unity.ide.visualstudio": "2.0.21",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "2.0.1-exp.1",
-    "com.unity.visualscripting": "1.8.0",
+    "com.unity.visualscripting": "1.9.1",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/sample/Packages/packages-lock.json
+++ b/sample/Packages/packages-lock.json
@@ -50,7 +50,7 @@
       }
     },
     "com.unity.visualscripting": {
-      "version": "1.8.0",
+      "version": "1.9.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/sample/ProjectSettings/ProjectSettings.asset
+++ b/sample/ProjectSettings/ProjectSettings.asset
@@ -163,7 +163,7 @@ PlayerSettings:
   overrideDefaultApplicationIdentifier: 1
   AndroidBundleVersionCode: 1
   AndroidMinSdkVersion: 22
-  AndroidTargetSdkVersion: 0
+  AndroidTargetSdkVersion: 34
   AndroidPreferredInstallLocation: 1
   aotOptions: 
   stripEngineCode: 1
@@ -792,7 +792,7 @@ PlayerSettings:
   allowUnsafeCode: 0
   useDeterministicCompilation: 1
   enableRoslynAnalyzers: 1
-  selectedPlatform: 0
+  selectedPlatform: 2
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
   gcIncremental: 1

--- a/src/Packages/Passport/Runtime/Scripts/Private/Core/BrowserCommunicationsManager.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Core/BrowserCommunicationsManager.cs
@@ -2,7 +2,7 @@ using System.Net;
 using System;
 using Cysharp.Threading.Tasks;
 using System.Collections.Generic;
-#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
 using VoltstroStudios.UnityWebBrowser.Core;
 #else
 using Immutable.Browser.Gree;

--- a/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System;
-#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
 using VoltstroStudios.UnityWebBrowser.Core;
 #else
 using Immutable.Browser.Gree;
@@ -19,7 +19,7 @@ namespace Immutable.Passport
 
         public static Passport? Instance { get; private set; }
 
-#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
         private readonly IWebBrowserClient webBrowserClient = new WebBrowserClient();
 #else
         private readonly IWebBrowserClient webBrowserClient = new GreeBrowserClient();
@@ -32,7 +32,7 @@ namespace Immutable.Passport
 
         private Passport()
         {
-#if UNITY_EDITOR_WIN
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
             Application.quitting += OnQuit;
 #elif UNITY_IPHONE || UNITY_ANDROID || UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
             Application.deepLinkActivated += OnDeepLinkActivated;
@@ -103,7 +103,7 @@ namespace Immutable.Passport
             {
                 BrowserCommunicationsManager communicationsManager = new(webBrowserClient);
                 communicationsManager.OnReady += () => readySignalReceived = true;
-#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
                 await ((WebBrowserClient)webBrowserClient).Init(engineStartupTimeoutMs);
 #endif
                 passportImpl = new PassportImpl(communicationsManager);
@@ -117,7 +117,7 @@ namespace Immutable.Passport
             }
         }
 
-#if UNITY_EDITOR_WIN
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
         private void OnQuit()
         {
             // Need to clean up UWB resources when quitting the game in the editor

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Editor/EngineManagement/EngineManagerPostprocess.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Editor/EngineManagement/EngineManagerPostprocess.cs
@@ -3,7 +3,7 @@
 // 
 // This project is under the MIT license. See the LICENSE.md file for more details.
 
-#if UNITY_EDITOR_WIN
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
 
 using System.Collections.Generic;
 using System.IO;


### PR DESCRIPTION
Previously, Unity complained about Unity Web Browser code if you tried to build an Android app on Windows Editor. So, fixed Windows compilation flags so you can only target the Windows platform on a Windows Editor. 

This change makes more sense, as building and testing a Windows game on a Windows machine is more manageable. If the developer wants to create a Windows game on a Mac machine, they could edit our SDK compilation flag.

Note. I will create another PR that updates the docs to show what platform developers can target using Windows/macOS Editor.