### PR TITLE
feat: add chrome custom tabs callback to android pkce flow

### DIFF
--- a/sample/Assets/Scripts/UnauthenticatedScript.cs
+++ b/sample/Assets/Scripts/UnauthenticatedScript.cs
@@ -1,4 +1,5 @@
 using System;
+using Cysharp.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.SceneManagement;
@@ -102,6 +103,10 @@ public class UnauthenticatedScript : MonoBehaviour
             {
                 error = $"Connect() error: Check your internet connection and try again";
             }
+            else if (ex is OperationCanceledException)
+            {
+                error = "Connect() cancelled";
+            }
             else
             {
                 error = $"Connect() error: {ex.Message}";
@@ -124,6 +129,7 @@ public class UnauthenticatedScript : MonoBehaviour
 
     private void ShowOutput(string message)
     {
+        Debug.Log($"Output: {message}");
         if (output != null)
         {
             output.text = message;


### PR DESCRIPTION
* Removed unused `PKCEResult` from the `Passport` class
* Added Android Chrome Custom Tabs callback so the game knows if the user has closed the embedded browser before authenticating.
  * Added cancelled check to sample app