### PR TITLE
fix: amount field to string in ETH

### DIFF
--- a/src/Packages/Passport/Runtime/Scripts/Private/Model/Request/UnsignedTransferRequest.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Model/Request/UnsignedTransferRequest.cs
@@ -17,7 +17,7 @@ namespace Immutable.Passport.Model
         public string Type { get; }
 
         /**
-        * The amount of tokens being transferred
+        * The amount of tokens being transferred. For ETH the amount is in unit Wei.
         */
         public string Amount { get; }
 
@@ -33,32 +33,36 @@ namespace Immutable.Passport.Model
 
         private UnsignedTransferRequest(
             string type,
-            int amount,
+            string amount,
             string receiver,
             string? tokenId = null,
             string? tokenAddress = null
             )
         {
             this.Type = type;
-            this.Amount = $"{amount}";
+            this.Amount = amount;
             this.TokenId = tokenId;
             this.TokenAddress = tokenAddress;
             this.Receiver = receiver;
         }
 
-        public static UnsignedTransferRequest ETH(string receiver, int amount)
+
+        /**
+        * Receiver's ETH address and amount in unit Wei
+        */
+        public static UnsignedTransferRequest ETH(string receiver, string amount)
         {
             return new UnsignedTransferRequest("ETH", amount, receiver);
         }
 
         public static UnsignedTransferRequest ERC20(string receiver, int amount, string tokenAddress)
         {
-            return new UnsignedTransferRequest("ERC20", amount, receiver, null, tokenAddress);
+            return new UnsignedTransferRequest("ERC20", $"{amount}", receiver, null, tokenAddress);
         }
 
         public static UnsignedTransferRequest ERC721(string receiver, string tokenId, string tokenAddress)
         {
-            return new UnsignedTransferRequest("ERC721", 1, receiver, tokenId, tokenAddress);
+            return new UnsignedTransferRequest("ERC721", "1", receiver, tokenId, tokenAddress);
         }
     }
 }


### PR DESCRIPTION
Amount for ETH transfer was mistakenly done in int, which doesn't support long values for Wei. It has since been replaced for a string and added some description to clarify the expected amount is in Wei.