### PR TITLE
fix: macos editor path to index file

### DIFF
--- a/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/GreeBrowserClient.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/GreeBrowserClient.cs
@@ -9,7 +9,7 @@ namespace Immutable.Browser.Gree
         private const string TAG = "[GreeBrowserClient]";
         private const string ANDROID_DATA_DIRECTORY = "android_asset";
         private const string MAC_DATA_DIRECTORY = "/Resources/Data";
-        private const string MAC_EDITOR_RESOURCES_DIRECTORY = "/../src/Packages/Passport/Runtime/Resources";
+        private const string MAC_EDITOR_RESOURCES_DIRECTORY = "Packages/com.immutable.passport/Runtime/Resources";
         private readonly WebViewObject webViewObject;
         public event OnUnityPostMessageDelegate OnUnityPostMessage;
         public event OnUnityPostMessageDelegate OnAuthPostMessage;
@@ -27,7 +27,7 @@ namespace Immutable.Browser.Gree
 #if UNITY_ANDROID
             string filePath = Constants.SCHEME_FILE + ANDROID_DATA_DIRECTORY + Constants.PASSPORT_DATA_DIRECTORY_NAME + Constants.PASSPORT_HTML_FILE_NAME;
 #elif UNITY_EDITOR_OSX
-            string filePath = Constants.SCHEME_FILE + Path.GetDirectoryName(Application.dataPath) + MAC_EDITOR_RESOURCES_DIRECTORY + Constants.PASSPORT_HTML_FILE_NAME;
+            string filePath = Constants.SCHEME_FILE + Path.GetFullPath(MAC_EDITOR_RESOURCES_DIRECTORY) + Constants.PASSPORT_HTML_FILE_NAME;
 #elif UNITY_STANDALONE_OSX
             string filePath = Constants.SCHEME_FILE + Path.GetFullPath(Application.dataPath) + MAC_DATA_DIRECTORY + Constants.PASSPORT_DATA_DIRECTORY_NAME + Constants.PASSPORT_HTML_FILE_NAME;
 #else


### PR DESCRIPTION
The path to the index file for the macOS editor needs to be corrected. Currently, it’s assuming the path of the sample app, but the location on the SDK could be anywhere on the disk.