### PR TITLE
[DX-2472] fix: wrap uwb files in windows only compilation flag and add constraint to windows dlls

### DIFF
--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Plugins/VoltstroStudios.UnityWebBrowser.Shared.dll.meta
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Plugins/VoltstroStudios.UnityWebBrowser.Shared.dll.meta
@@ -5,29 +5,78 @@ PluginImporter:
   serializedVersion: 2
   iconMap: {}
   executionOrder: {}
-  defineConstraints: []
+  defineConstraints:
+  - UNITY_2021_3_OR_NEWER
   isPreloaded: 0
   isOverridable: 1
   isExplicitlyReferenced: 0
   validateReferences: 1
   platformData:
   - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 0
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 0
+        Exclude Win: 0
+        Exclude Win64: 0
+        Exclude WindowsStoreApps: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 0
+      settings:
+        CPU: ARMv7
+  - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 1
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
   - first:
       Windows Store Apps: WindowsStoreApps
     second:
       enabled: 0
       settings:
         CPU: AnyCPU
+        DontProcess: false
+        PlaceholderPath: 
+        SDK: AnySDK
+        ScriptingBackend: AnyScriptingBackend
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/AssemblyInfo.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/AssemblyInfo.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -40,3 +42,5 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("VoltstroStudios.UnityWebBrowser.Prj")]
 [assembly: InternalsVisibleTo("VoltstroStudios.UnityWebBrowser.Editor")]
 [assembly: InternalsVisibleTo("VoltstroStudios.UnityWebBrowser.Tests")]
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Communication/CommunicationLayer.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Communication/CommunicationLayer.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -60,3 +62,5 @@ namespace VoltstroStudios.UnityWebBrowser.Communication
             [CanBeNull] out string assemblyLocation);
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Communication/TCPCommunicationLayer.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Communication/TCPCommunicationLayer.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -50,3 +52,5 @@ namespace VoltstroStudios.UnityWebBrowser.Communication
         }
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/BaseUwbClientManager.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/BaseUwbClientManager.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -147,3 +149,5 @@ namespace VoltstroStudios.UnityWebBrowser.Core
         #endregion
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Engine.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Engine.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -28,3 +30,5 @@ namespace VoltstroStudios.UnityWebBrowser.Core.Engines
 #endif
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/EngineConfiguration.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/EngineConfiguration.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -46,3 +48,5 @@ namespace VoltstroStudios.UnityWebBrowser.Core.Engines
 #endif
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserArgsBuilder.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserArgsBuilder.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -50,3 +52,5 @@ namespace VoltstroStudios.UnityWebBrowser.Core
         }
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -838,3 +840,5 @@ namespace VoltstroStudios.UnityWebBrowser.Core
         #endregion
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserCommunicationsManager.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserCommunicationsManager.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -231,3 +233,5 @@ namespace VoltstroStudios.UnityWebBrowser.Core
         #endregion
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Editor/EngineManagement/EngineManager.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Editor/EngineManagement/EngineManager.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -63,5 +65,7 @@ namespace VoltstroStudios.UnityWebBrowser.Editor.EngineManagement
         }
     }
 }
+
+#endif
 
 #endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnFullscreenChange.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnFullscreenChange.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -7,3 +9,5 @@ namespace VoltstroStudios.UnityWebBrowser.Events
 {
     public delegate void OnFullscreenChange(bool fullscreen);
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadFinish.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadFinish.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -7,3 +9,5 @@ namespace VoltstroStudios.UnityWebBrowser.Events
 {
     public delegate void OnLoadFinishDelegate(string url);
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadStart.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadStart.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -7,3 +9,5 @@ namespace VoltstroStudios.UnityWebBrowser.Events
 {
     public delegate void OnLoadStartDelegate(string url);
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadingProgressChange.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadingProgressChange.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -7,3 +9,5 @@ namespace VoltstroStudios.UnityWebBrowser.Events
 {
     public delegate void OnLoadingProgressChange(double progress);
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnTitleChange.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnTitleChange.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -7,3 +9,5 @@ namespace VoltstroStudios.UnityWebBrowser.Events
 {
     public delegate void OnTitleChange(string title);
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnUrlChange.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnUrlChange.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -7,3 +9,5 @@ namespace VoltstroStudios.UnityWebBrowser.Events
 {
     public delegate void OnUrlChangeDelegate(string url);
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Helper/ProcessExtensions.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Helper/ProcessExtensions.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -96,3 +98,5 @@ namespace VoltstroStudios.UnityWebBrowser.Helper
         }
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Helper/WebBrowserUtils.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Helper/WebBrowserUtils.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -207,3 +209,5 @@ namespace VoltstroStudios.UnityWebBrowser.Helper
         }
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputHandler.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputHandler.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -66,3 +68,5 @@ namespace VoltstroStudios.UnityWebBrowser.Input
         #endregion
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputHelper.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputHelper.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -282,3 +284,5 @@ namespace VoltstroStudios.UnityWebBrowser.Input
 #endif
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputSystemHandler.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputSystemHandler.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -126,5 +128,7 @@ namespace VoltstroStudios.UnityWebBrowser.Input
         }
     }
 }
+
+#endif
 
 #endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserOldInputHandler.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserOldInputHandler.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -109,3 +111,5 @@ namespace VoltstroStudios.UnityWebBrowser.Input
         }
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/DefaultUnityWebBrowserLogger.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/DefaultUnityWebBrowserLogger.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -37,3 +39,5 @@ namespace VoltstroStudios.UnityWebBrowser.Logging
         }
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/IWebBrowserLogger.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/IWebBrowserLogger.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -18,3 +20,5 @@ namespace VoltstroStudios.UnityWebBrowser.Logging
         public void Error(object message);
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/JsonLogSeverityConverter.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/JsonLogSeverityConverter.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -47,3 +49,5 @@ namespace VoltstroStudios.UnityWebBrowser.Logging
         }
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/JsonLogStructure.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/JsonLogStructure.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -26,3 +28,5 @@ namespace VoltstroStudios.UnityWebBrowser.Logging
         [JsonProperty("@i")] public string EventId { get; set; }
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/ProcessLogHandler.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/ProcessLogHandler.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -75,3 +77,5 @@ namespace VoltstroStudios.UnityWebBrowser.Logging
         }
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsConnectedException.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsConnectedException.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -19,3 +21,5 @@ namespace VoltstroStudios.UnityWebBrowser
         }
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsNotConnectedException.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsNotConnectedException.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -17,3 +19,5 @@ namespace VoltstroStudios.UnityWebBrowser
         }
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsNotReadyException.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsNotReadyException.cs
@@ -1,3 +1,5 @@
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
@@ -18,3 +20,5 @@ namespace VoltstroStudios.UnityWebBrowser
         }
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/org.nuget.voltrpc@3.1.0/netstandard2.1/VoltRpc.dll.meta
+++ b/src/Packages/Passport/Runtime/ThirdParty/org.nuget.voltrpc@3.1.0/netstandard2.1/VoltRpc.dll.meta
@@ -13,22 +13,70 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      Any:
+      : Any
     second:
-      enabled: 1
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 0
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 0
+        Exclude Win: 0
+        Exclude Win64: 0
+        Exclude WindowsStoreApps: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 0
+      settings:
+        CPU: ARMv7
+  - first:
+      Any: 
+    second:
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 1
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 1
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: None
   - first:
       Windows Store Apps: WindowsStoreApps
     second:
       enabled: 0
       settings:
         CPU: AnyCPU
+        DontProcess: false
+        PlaceholderPath: 
+        SDK: AnySDK
+        ScriptingBackend: AnyScriptingBackend
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/src/Packages/Passport/Tests/Runtime/Scripts/Core/BrowserCommunicationsManagerTests.cs
+++ b/src/Packages/Passport/Tests/Runtime/Scripts/Core/BrowserCommunicationsManagerTests.cs
@@ -5,8 +5,10 @@ using Immutable.Passport.Model;
 using UnityEngine;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
 using VoltstroStudios.UnityWebBrowser.Core;
 using VoltstroStudios.UnityWebBrowser.Events;
+#endif
 using Newtonsoft.Json;
 
 namespace Immutable.Passport.Core


### PR DESCRIPTION
* Wrap window's browser files in `UNITY_EDITOR_WIN` and `UNITY_STANDALONE_WIN` flags only, so no unnecessary compiler errors show up when trying to build for other platforms
* Set `*.dll` files to only work for Windows (check `.meta` files)
* Define `VoltstroStudios.UnityWebBrowser.Shared.dll` constraint to 2021.3 or newer only (check `VoltstroStudios.UnityWebBrowser.Shared.dll.meta`)