### PR TITLE
[DX-2496] fix: xcode 15 incorrect ios html file path

### DIFF
--- a/sample/Assets/Scripts/UnauthenticatedScript.cs
+++ b/sample/Assets/Scripts/UnauthenticatedScript.cs
@@ -33,7 +33,7 @@ public class UnauthenticatedScript : MonoBehaviour
 #endif
 
             passport = await Passport.Init(
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
                 clientId, environment, engineStartupTimeoutMs: 10000
 #else
                 clientId, environment, redirectUri

--- a/src/Packages/Passport/Runtime/Scripts/Private/Core/BrowserCommunicationsManager.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Core/BrowserCommunicationsManager.cs
@@ -2,7 +2,7 @@ using System.Net;
 using System;
 using Cysharp.Threading.Tasks;
 using System.Collections.Generic;
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 using VoltstroStudios.UnityWebBrowser.Core;
 #else
 using Immutable.Browser.Gree;

--- a/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System;
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 using VoltstroStudios.UnityWebBrowser.Core;
 #else
 using Immutable.Browser.Gree;
@@ -19,7 +19,7 @@ namespace Immutable.Passport
 
         public static Passport Instance { get; private set; }
 
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
         private readonly IWebBrowserClient webBrowserClient = new WebBrowserClient();
 #else
         private readonly IWebBrowserClient webBrowserClient = new GreeBrowserClient();
@@ -32,7 +32,7 @@ namespace Immutable.Passport
 
         private Passport()
         {
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
             Application.quitting += OnQuit;
 #elif UNITY_IPHONE || UNITY_ANDROID || UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
             Application.deepLinkActivated += OnDeepLinkActivated;
@@ -52,7 +52,7 @@ namespace Immutable.Passport
         /// <param name="redirectUri">(Android, iOS and macOS only) The URL to which auth will redirect the browser after authorisation has been granted by the user</param>
         /// <param name="engineStartupTimeoutMs">(Windows only) Timeout time for waiting for the engine to start (in milliseconds)</param>
         public static UniTask<Passport> Init(
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
             string clientId, string environment, string redirectUri = null, int engineStartupTimeoutMs = 4000
 #else
             string clientId, string environment, string redirectUri = null
@@ -65,7 +65,7 @@ namespace Immutable.Passport
                 Instance = new Passport();
                 // Wait until we get a ready signal
                 return Instance.Initialise(
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
                         engineStartupTimeoutMs
 #endif
                     )
@@ -96,7 +96,7 @@ namespace Immutable.Passport
         }
 
         private async UniTask Initialise(
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
             int engineStartupTimeoutMs
 #endif
         )
@@ -105,7 +105,7 @@ namespace Immutable.Passport
             {
                 BrowserCommunicationsManager communicationsManager = new BrowserCommunicationsManager(webBrowserClient);
                 communicationsManager.OnReady += () => readySignalReceived = true;
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
                 await ((WebBrowserClient)webBrowserClient).Init(engineStartupTimeoutMs);
 #endif
                 passportImpl = new PassportImpl(communicationsManager);
@@ -119,7 +119,7 @@ namespace Immutable.Passport
             }
         }
 
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
         private void OnQuit()
         {
             // Need to clean up UWB resources when quitting the game in the editor

--- a/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
@@ -65,12 +65,13 @@ namespace Immutable.Passport
                 Instance = new Passport();
                 // Wait until we get a ready signal
                 return Instance.Initialise(
-#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
                         engineStartupTimeoutMs
 #endif
                     )
                     .ContinueWith(async () =>
                     {
+                        Debug.Log($"{TAG} Waiting for ready signal...");
                         await UniTask.WaitUntil(() => readySignalReceived == true);
                     })
                     .ContinueWith(async () =>
@@ -95,7 +96,7 @@ namespace Immutable.Passport
         }
 
         private async UniTask Initialise(
-#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
+#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
             int engineStartupTimeoutMs
 #endif
         )

--- a/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/GreeBrowserClient.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/GreeBrowserClient.cs
@@ -30,6 +30,8 @@ namespace Immutable.Browser.Gree
             string filePath = Constants.SCHEME_FILE + Path.GetFullPath(MAC_EDITOR_RESOURCES_DIRECTORY) + Constants.PASSPORT_HTML_FILE_NAME;
 #elif UNITY_STANDALONE_OSX
             string filePath = Constants.SCHEME_FILE + Path.GetFullPath(Application.dataPath) + MAC_DATA_DIRECTORY + Constants.PASSPORT_DATA_DIRECTORY_NAME + Constants.PASSPORT_HTML_FILE_NAME;
+#elif UNITY_IPHONE
+            string filePath = Path.GetFullPath(Application.dataPath) + Constants.PASSPORT_DATA_DIRECTORY_NAME + Constants.PASSPORT_HTML_FILE_NAME;
 #else
             string filePath = Constants.SCHEME_FILE + Path.GetFullPath(Application.dataPath) + Constants.PASSPORT_DATA_DIRECTORY_NAME + Constants.PASSPORT_HTML_FILE_NAME;
 #endif

--- a/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/iOS/WebView.mm
+++ b/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/iOS/WebView.mm
@@ -333,7 +333,7 @@ static ASWebAuthenticationSession *_authSession;
         
     WKWebView *_webView = (WKWebView *)webView;
     NSString *urlStr = [NSString stringWithUTF8String:url];
-    NSURL *nsurl = [NSURL URLWithString:urlStr];
+    NSURL *nsurl = [[NSURL alloc] initFileURLWithPath:urlStr];
     NSURLRequest *request = [NSURLRequest requestWithURL:nsurl];
     [_webView load:request];
 }

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/AssemblyInfo.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Communication/CommunicationLayer.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Communication/CommunicationLayer.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Communication/TCPCommunicationLayer.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Communication/TCPCommunicationLayer.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/BaseUwbClientManager.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/BaseUwbClientManager.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Engine.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Engine.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/EngineConfiguration.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/EngineConfiguration.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserArgsBuilder.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserArgsBuilder.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserCommunicationsManager.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserCommunicationsManager.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Editor/EngineManagement/EngineManager.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Editor/EngineManagement/EngineManager.cs
@@ -1,11 +1,9 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
-
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
 // 
 // This project is under the MIT license. See the LICENSE.md file for more details.
 
-#if UNITY_EDITOR
+#if UNITY_EDITOR && UNITY_STANDALONE_WIN
 
 using System.IO;
 using System.Linq;
@@ -65,7 +63,5 @@ namespace VoltstroStudios.UnityWebBrowser.Editor.EngineManagement
         }
     }
 }
-
-#endif
 
 #endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Editor/EngineManagement/EngineManagerPostprocess.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Editor/EngineManagement/EngineManagerPostprocess.cs
@@ -3,7 +3,7 @@
 // 
 // This project is under the MIT license. See the LICENSE.md file for more details.
 
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_EDITOR && UNITY_STANDALONE_WIN
 
 using System.Collections.Generic;
 using System.IO;

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnFullscreenChange.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnFullscreenChange.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadFinish.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadFinish.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadStart.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadStart.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadingProgressChange.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadingProgressChange.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnTitleChange.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnTitleChange.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnUrlChange.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnUrlChange.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Helper/ProcessExtensions.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Helper/ProcessExtensions.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Helper/WebBrowserUtils.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Helper/WebBrowserUtils.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputHandler.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputHandler.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputHelper.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputHelper.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputSystemHandler.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputSystemHandler.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserOldInputHandler.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserOldInputHandler.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/DefaultUnityWebBrowserLogger.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/DefaultUnityWebBrowserLogger.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/IWebBrowserLogger.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/IWebBrowserLogger.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/JsonLogSeverityConverter.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/JsonLogSeverityConverter.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/JsonLogStructure.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/JsonLogStructure.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/ProcessLogHandler.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/ProcessLogHandler.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsConnectedException.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsConnectedException.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsNotConnectedException.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsNotConnectedException.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsNotReadyException.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsNotReadyException.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Tests/Runtime/Scripts/Core/BrowserCommunicationsManagerTests.cs
+++ b/src/Packages/Passport/Tests/Runtime/Scripts/Core/BrowserCommunicationsManagerTests.cs
@@ -5,7 +5,7 @@ using Immutable.Passport.Model;
 using UnityEngine;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-#if UNITY_EDITOR_WIN && UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN
 using VoltstroStudios.UnityWebBrowser.Core;
 using VoltstroStudios.UnityWebBrowser.Events;
 #endif


### PR DESCRIPTION
* iOS HTML path is incorrect on newer Unity and Xcode versions (see [Issue #116](https://github.com/immutable/unity-immutable-sdk/issues/116))
  * Removed `file://` prefix
  * New file path works on all other Unity versions `NSURL *nsurl = [[NSURL alloc] initFileURLWithPath:urlStr];`
* Fixed Windows compilation flags