### PR TITLE
[DX-2502] fix: ios and macos converting plus signs in json response to spaces

### DIFF
--- a/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/WebViewObject.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/WebViewObject.cs
@@ -319,9 +319,9 @@ public class WebViewObject
         {
 #if !UNITY_ANDROID
 #if UNITY_2018_4_OR_NEWER
-            message = UnityWebRequest.UnEscapeURL(message);
+            message = UnityWebRequest.UnEscapeURL(message.Replace("+", "%2B"));
 #else // UNITY_2018_4_OR_NEWER
-            message = WWW.UnEscapeURL(message);
+            message = WWW.UnEscapeURL(message.Replace("+", "%2B"));
 #endif // UNITY_2018_4_OR_NEWER
 #endif // !UNITY_ANDROID
             onJS(message);


### PR DESCRIPTION
* On macOS and iOS, plus signs in the JSON response are converted into spaces