### PR TITLE
[DX-2503] chore: remove sample app macos url scheme

### DIFF
--- a/sample/ProjectSettings/ProjectSettings.asset
+++ b/sample/ProjectSettings/ProjectSettings.asset
@@ -219,8 +219,7 @@ PlayerSettings:
   iOSDeviceRequirements: []
   iOSURLSchemes:
   - imxsample
-  macOSURLSchemes:
-  - imxsample
+  macOSURLSchemes: []
   iOSBackgroundModes: 0
   iOSMetalForceHardShadows: 0
   metalEditorSupport: 1
@@ -792,7 +791,7 @@ PlayerSettings:
   allowUnsafeCode: 0
   useDeterministicCompilation: 1
   enableRoslynAnalyzers: 1
-  selectedPlatform: 2
+  selectedPlatform: 0
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
   gcIncremental: 1


### PR DESCRIPTION
Removed macOS URL scheme as we don't require it.

For macOS, we implemented [ASWebAuthenticationSession](https://github.com/immutable/unity-immutable-sdk/blob/698c5189e2bd4c0263bbdb3fff377686bf55a5dc/Plugins/Mac/Sources/WebView.mm#L334) using the `redirectUri` that is passed in from `Passport.Init`. This differs from iOS, which [uses the bundle identifier](https://github.com/immutable/unity-immutable-sdk/blob/698c5189e2bd4c0263bbdb3fff377686bf55a5dc/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/iOS/WebView.mm#L352) and therefore needs the `redirectUri` scheme to be set for deeplinking to work properly.