### PR TITLE
[DX-2524] feat: simplify httputility

### DIFF
--- a/sample/Assets/Scripts/UnauthenticatedScript.cs
+++ b/sample/Assets/Scripts/UnauthenticatedScript.cs
@@ -25,17 +25,15 @@ public class UnauthenticatedScript : MonoBehaviour
             ConnectButton.gameObject.SetActive(false);
             TryAgainButton.gameObject.SetActive(false);
 
+            string clientId = "ZJL7JvetcDFBNDlgRs5oJoxuAUUl6uQj";
             string environment = Immutable.Passport.Model.Environment.SANDBOX;
             string redirectUri = null;
             string logoutRedirectUri = null;
 
-            // Different client ID is required for device and PKCE flow
+            // macOS editor (play scene) does not support deeplinking
 #if UNITY_ANDROID || UNITY_IPHONE || (UNITY_STANDALONE_OSX && !UNITY_EDITOR_OSX)
-            string clientId = "WiuxIUEYUyF67ANAbfbipX9mSbg9lb2P";
             redirectUri = "imxsample://callback";
             logoutRedirectUri = "imxsample://callback/logout";
-#else
-            string clientId = "GbuQTnIdQmd2lnzkeWeeKlSHtqSAD5sQ";
 #endif
 
             passport = await Passport.Init(

--- a/src/Packages/Passport/Runtime/Scripts/Private/Core/BrowserCommunicationsManager.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Core/BrowserCommunicationsManager.cs
@@ -12,7 +12,7 @@ using Immutable.Passport.Model;
 using UnityEngine;
 using Immutable.Passport;
 using UnityEngine.Scripting;
-using Immutable.Passport.Json;
+using Immutable.Passport.Helpers;
 
 namespace Immutable.Passport.Core
 {

--- a/src/Packages/Passport/Runtime/Scripts/Private/Core/Model/BrowserResponse.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Core/Model/BrowserResponse.cs
@@ -1,6 +1,6 @@
 using System;
 using UnityEngine;
-using Immutable.Passport.Json;
+using Immutable.Passport.Helpers;
 
 namespace Immutable.Passport.Core
 {

--- a/src/Packages/Passport/Runtime/Scripts/Private/Helpers.meta
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Helpers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 330f0f6bdd62f4796803f8b331fc7473
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Passport/Runtime/Scripts/Private/Helpers/JsonHelpers.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Helpers/JsonHelpers.cs
@@ -1,7 +1,7 @@
 using System;
 using UnityEngine;
 
-namespace Immutable.Passport.Json
+namespace Immutable.Passport.Helpers
 {
     public static class JsonExtensions
     {

--- a/src/Packages/Passport/Runtime/Scripts/Private/Helpers/JsonHelpers.cs.meta
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Helpers/JsonHelpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea262f0f6741c4c468c28ab6b7312043
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Passport/Runtime/Scripts/Private/Helpers/UriHelpers.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Helpers/UriHelpers.cs
@@ -1,0 +1,33 @@
+using System;
+using UnityEngine;
+
+namespace Immutable.Passport.Helpers
+{
+    public static class UriExtensions
+    {
+        /// <summary>
+        /// Gets the specified query parameter from the given URI
+        /// </summary> 
+        public static string GetQueryParameter(this Uri uri, string key)
+        {
+            try
+            {
+                string query = uri.Query;
+                string[] queryParameters = query.Split(new char[] { '?', '&' });
+                for (int i = 0; i < queryParameters.Length; i++)
+                {
+                    string[] keyValue = queryParameters[i].Split('=');
+                    if (keyValue[0] == key)
+                    {
+                        return keyValue[1];
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.Log($"Failed to get query parameter {key}: {e.Message}");
+            }
+            return null;
+        }
+    }
+}

--- a/src/Packages/Passport/Runtime/Scripts/Private/Helpers/UriHelpers.cs.meta
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Helpers/UriHelpers.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a68ea34d838464e47a2f6d21eab53d12
+guid: 95c847b15483649ccb91342b1f9ebec0
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
@@ -3,11 +3,10 @@ using System;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.Networking;
-using Immutable.Passport.Json;
 using Immutable.Passport.Model;
 using Immutable.Passport.Core;
+using Immutable.Passport.Helpers;
 using Cysharp.Threading.Tasks;
-using System.Web;
 using System.Threading;
 #if UNITY_ANDROID
 using UnityEngine.Android;
@@ -206,10 +205,9 @@ namespace Immutable.Passport
 #endif
             try
             {
-                var uri = new Uri(uriString);
-                var query = HttpUtility.ParseQueryString(uri.Query);
-                var state = query.Get("state");
-                var authCode = query.Get("code");
+                Uri uri = new Uri(uriString);
+                string state = uri.GetQueryParameter("state");
+                string authCode = uri.GetQueryParameter("code");
 
                 if (String.IsNullOrEmpty(state) || String.IsNullOrEmpty(authCode))
                 {

--- a/src/Packages/Passport/Tests/Runtime/Scripts/Core/BrowserCommunicationsManagerTests.cs
+++ b/src/Packages/Passport/Tests/Runtime/Scripts/Core/BrowserCommunicationsManagerTests.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 using VoltstroStudios.UnityWebBrowser.Core;
 using VoltstroStudios.UnityWebBrowser.Events;
 #endif
-using Immutable.Passport.Json;
+using Immutable.Passport.Helpers;
 
 namespace Immutable.Passport.Core
 {

--- a/src/Packages/Passport/Tests/Runtime/Scripts/Helpers.meta
+++ b/src/Packages/Passport/Tests/Runtime/Scripts/Helpers.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0adc2b8a02ff21c4982da23a0b468813
+guid: 8f0fcfdb564cb41188796efb9f707026
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/src/Packages/Passport/Tests/Runtime/Scripts/Helpers/UriHelpersTests.cs
+++ b/src/Packages/Passport/Tests/Runtime/Scripts/Helpers/UriHelpersTests.cs
@@ -1,0 +1,42 @@
+using System;
+using NUnit.Framework;
+using Immutable.Passport.Helpers;
+
+namespace Immutable.Passport.Core
+{
+    [TestFixture]
+    public class UriHelpersTests
+    {
+        private const string DOMAIN = "https://auth.immutable.com";
+        private const string QUERY_PARAMETER_KEY1 = "state";
+        private const string QUERY_PARAMETER_VALUE1 = "state-value";
+        private const string QUERY_PARAMETER_KEY2 = "code";
+        private const string QUERY_PARAMETER_VALUE2 = "code%20value";
+
+        [Test]
+        public void GetQueryParameter_Success()
+        {
+            Uri uri = new Uri($"{DOMAIN}?{QUERY_PARAMETER_KEY1}={QUERY_PARAMETER_VALUE1}&{QUERY_PARAMETER_KEY2}={QUERY_PARAMETER_VALUE2}");
+            Assert.True(uri.GetQueryParameter(QUERY_PARAMETER_KEY1) == QUERY_PARAMETER_VALUE1);
+            Assert.True(uri.GetQueryParameter(QUERY_PARAMETER_KEY2) == QUERY_PARAMETER_VALUE2);
+        }
+
+        [Test]
+        public void GetQueryParameter_NoQueryParameterWithKey()
+        {
+            Uri uri = new Uri($"{DOMAIN}?noKey=some-value");
+            Assert.Null(uri.GetQueryParameter(QUERY_PARAMETER_KEY1));
+        }
+
+        [Test]
+        public void GetQueryParameter_NoQueryParameters()
+        {
+            Uri uri = new Uri(DOMAIN);
+            Assert.Null(uri.GetQueryParameter(QUERY_PARAMETER_KEY1));
+            uri = new Uri($"{DOMAIN}?");
+            Assert.Null(uri.GetQueryParameter(QUERY_PARAMETER_KEY1));
+            uri = new Uri($"{DOMAIN}/?");
+            Assert.Null(uri.GetQueryParameter(QUERY_PARAMETER_KEY1));
+        }
+    }
+}

--- a/src/Packages/Passport/Tests/Runtime/Scripts/Helpers/UriHelpersTests.cs.meta
+++ b/src/Packages/Passport/Tests/Runtime/Scripts/Helpers/UriHelpersTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 038acdbbb3f9641d8ac2396846251399
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* Removed the need for HttpUtility to get query parameters
* Refactored JSON helper to Helper directory
* Simplified sample app client ID as logout redirect URI depends on what we set in the Passport config not in the Hub