### PR TITLE
[DX-2505] feat: connect imx use saved credentials if they exist so device flow is not triggered again

### DIFF
--- a/sample/Assets/Scripts/AuthenticatedScript.cs
+++ b/sample/Assets/Scripts/AuthenticatedScript.cs
@@ -84,7 +84,7 @@ public class AuthenticatedScript : MonoBehaviour
             // Use existing credentials to connect to Passport
             ShowOutput("Connecting into Passport using saved credentials...");
             ConnectButton.gameObject.SetActive(false);
-            bool connected = await passport.ConnectImx(useCachedSession: true);
+            bool connected = await passport.ConnectImx();
             if (connected)
             {
                 IsRegisteredOffchainButton.gameObject.SetActive(true);

--- a/sample/ProjectSettings/ProjectSettings.asset
+++ b/sample/ProjectSettings/ProjectSettings.asset
@@ -771,6 +771,7 @@ PlayerSettings:
   platformArchitecture: {}
   scriptingBackend:
     Android: 1
+    Standalone: 0
   il2cppCompilerConfiguration: {}
   managedStrippingLevel:
     EmbeddedLinux: 1

--- a/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
@@ -144,6 +144,19 @@ namespace Immutable.Passport
             }
             else
             {
+                // If the user called Login before and then ConnectImx, there is no point triggering device flow again
+                bool hasCredsSaved = await HasCredentialsSaved();
+                if (hasCredsSaved)
+                {
+                    bool reconnected = await Reconnect();
+                    if (reconnected)
+                    {
+                        // Successfully reconnected
+                        return reconnected;
+                    }
+                    // Otherwise fallback to device code flow
+                }
+
                 ConnectResponse connectResponse = await InitialiseDeviceCodeAuth(functionName);
                 if (connectResponse != null)
                 {


### PR DESCRIPTION
* Developers calling `Login` followed by `ConnectImx` should not trigger the device code auth flow twice. Updated `ConnectImx` to stored credentials if they exist before initiating device code auth.
* Updated sample app authenticated scene connect button to use `ConnectImx()` instead of `ConnectImx(useCachedSession: true)`