### PR TITLE
ci: set up release github action

### DIFF
--- a/.github/pr-labeler/config.yml
+++ b/.github/pr-labeler/config.yml
@@ -1,0 +1,2 @@
+feature: 'feat/*'
+fix: fix/*

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,21 @@
+---
+name: PR Labeler
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/pr-labeler/config.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+---
+name: 'Create Release'
+on:
+  push:
+    tags:
+        - '*'
+
+jobs:
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Changelog
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@v3
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          configurationJson: |
+            {
+              "pr_template": "- #{{TITLE}} (##{{NUMBER}})",
+              "categories": [
+                {
+                    "title": "## Features",
+                    "labels": ["feature", "feat"]
+                },
+                {
+                    "title": "## Fixes",
+                    "labels": ["fix"]
+                }
+              ]
+            }
+      - name: Create Release
+        uses: mikepenz/action-gh-release@v0.2.0-a03
+        with:
+            body: ${{steps.github_release.outputs.changelog}}
+            
+      

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,3 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [0.2.0] - 2023-08-18
-
-### Added
-
-- Ability to specify the environment on initialisation
-
-## [0.1.0] - 2023-08-15
-
-### Added
-
-- Initial release
+Please see https://github.com/immutable/unity-immutable-sdk/releases

--- a/README.md
+++ b/README.md
@@ -17,53 +17,6 @@ The Immutable SDK for Unity helps you integrate your game with Immutable Passpor
 * [Immutable X](https://docs.immutable.com/docs/x/sdks/unity)
 * [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unity)
 
-## Changelog Management
-
-The following headings should be used as appropriate.
-
-- Added
-- Changed
-- Deprecated
-- Removed
-- Fixed
-
-What follows is an example with all the change headings, for real world use only use headings when appropriate.
-This goes at the top of the CHANGELOG.md above the most recent release.
-
-```markdown
-...
-
-## [Unreleased]
-
-### Added
-
-for new features.
-
-### Changed
-
-for changes in existing functionality.
-
-### Deprecated
-
-for soon-to-be removed features.
-
-### Removed
-
-for now removed features.
-
-### Fixed
-
-for any bug fixes.
-
-...
-```
-
-The package's `package.json` will hold the value of the previous release (e.g. `src/Packages/Passport`)
-
-```json
-"version": "0.1.0",
-```
-
 ## Contributing
 
 If you would like to contribute, please read the following:


### PR DESCRIPTION
* Set up release workflow when a tag is pushed
* Label closed and merged PRs so release Github Action can build a change log
* Link CHANGELOG file to releases
* Remove change log section from README as it is now automated