### PR TITLE
ci: check branch name

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -1,0 +1,15 @@
+---
+name: 'Assert Branch Naming Convention'
+on: pull_request
+
+jobs:
+  branch-naming-rules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: deepakputhraya/action-branch-name@master
+        with:
+          regex: '([a-z])+\/([a-z0-9.-])+'
+          allowed_prefixes: 'feat,fix,build,chore,ci,docs,style,refactor,perf,test,revert'
+          ignore: main
+          min_length: 5
+          max_length: 50


### PR DESCRIPTION
Set up a GitHub Action to check pull request branch names so that the correct labels can be applied upon merge.