### PR TITLE
[DX-2600] fix: custom tabs dismiss callback triggered before redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,5 @@ src/Packages/Passport/Runtime/Assets/ImmutableAndroid.androidlib/**/*.meta
 
 # WebView.bundle
 src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/WebView.bundle/**/*.meta
+
+*.idea


### PR DESCRIPTION
# Summary
If the user is logged into the browser and uses `LoginPKCE` / `ConnectImxPKCE`, Chrome Custom Tabs will immediately redirect them back to the game. However, there are instances when the Custom Tabs dismiss callback is called before the redirect, rendering the PKCE `CompletionSource` null. This means that the PKCE result cannot be returned to the game.

To prevent this issue, I have added some delay before calling `onCustomTabsDismissed`.

# Customer Impact
N/A

# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [x]  `N/A` Sample app is updated with new SDK changes
- [x] `N/A` Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unity) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unity))
- [x] `N/A` Sample game is updated with new SDK changes
- [x] `N/A` Replied to GitHub issues
