### PR TITLE
[DX-2618] docs: add documentation and changelog to passport package

### DIFF
--- a/src/Packages/Passport/CHANGELOG.md
+++ b/src/Packages/Passport/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+Please see https://github.com/immutable/unity-immutable-sdk/releases

--- a/src/Packages/Passport/Documentation~/DOCUMENTATION.md
+++ b/src/Packages/Passport/Documentation~/DOCUMENTATION.md
@@ -1,0 +1,4 @@
+# Documentation
+
+* [Immutable X](https://docs.immutable.com/docs/x/sdks/unity)
+* [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unity)


### PR DESCRIPTION
# Summary
Add the Documentation and Changelog files to the Passport package, so if developers add the package from the Git URL, these files are also included.

# Customer Impact
N/A