### PR TITLE
[DX-2623] fix: gree browser does not load index file if path has spaces

### DIFF
--- a/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/GreeBrowserClient.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/GreeBrowserClient.cs
@@ -36,7 +36,8 @@ namespace Immutable.Browser.Gree
 #else
             string filePath = Constants.SCHEME_FILE + Path.GetFullPath(Application.dataPath) + Constants.PASSPORT_DATA_DIRECTORY_NAME + Constants.PASSPORT_HTML_FILE_NAME;
 #endif
-            webViewObject.LoadURL(filePath);
+            string escapedPath = filePath.Replace(" ", "%20");
+            webViewObject.LoadURL(escapedPath);
         }
 
         private void InvokeOnPostMessageError(string id, string message)


### PR DESCRIPTION
# Summary
The index file cannot be loaded by the Gree browser if there are spaces in the path.
Raised by https://github.com/immutable/unity-immutable-sdk/issues/159.

# Customer Impact
It is now possible for developers to use names with spaces in the titles of their macOS, Android, and iOS applications.

- [x] `N/A` Sample app is updated with new SDK changes
- [x] `N/A` Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unity) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unity))
- [x] `N/A` Sample game is updated with new SDK changes
- [x] Replied to GitHub issues
