### PR TITLE
[DX-2634] ci: set up stale github action for issues

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,21 @@
+---
+name: 'Close stale issues'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          days-before-issue-stale: 30
+          days-before-pr-stale: -1
+          days-before-issue-close: 5
+          days-before-pr-close: -1
+          stale-issue-labe: 'stale'


### PR DESCRIPTION
# Summary
Automate adding labels and closing stale issues with Github Actions.


# Customer Impact
N/A

- [x] `N/A` Sample app is updated with new SDK changes
- [x] `N/A` Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unity) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unity))
- [x] `N/A` Sample game is updated with new SDK changes
- [x] `N/A` Replied to GitHub issues
