### PR TITLE
[DX-2641] fix: ios file path

### DIFF
--- a/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/GreeBrowserClient.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/GreeBrowserClient.cs
@@ -31,13 +31,13 @@ namespace Immutable.Browser.Gree
             string filePath = Constants.SCHEME_FILE + Path.GetFullPath(MAC_EDITOR_RESOURCES_DIRECTORY) + Constants.PASSPORT_HTML_FILE_NAME;
 #elif UNITY_STANDALONE_OSX
             string filePath = Constants.SCHEME_FILE + Path.GetFullPath(Application.dataPath) + MAC_DATA_DIRECTORY + Constants.PASSPORT_DATA_DIRECTORY_NAME + Constants.PASSPORT_HTML_FILE_NAME;
+            filePath = filePath.Replace(" ", "%20");
 #elif UNITY_IPHONE
             string filePath = Path.GetFullPath(Application.dataPath) + Constants.PASSPORT_DATA_DIRECTORY_NAME + Constants.PASSPORT_HTML_FILE_NAME;
 #else
             string filePath = Constants.SCHEME_FILE + Path.GetFullPath(Application.dataPath) + Constants.PASSPORT_DATA_DIRECTORY_NAME + Constants.PASSPORT_HTML_FILE_NAME;
 #endif
-            string escapedPath = filePath.Replace(" ", "%20");
-            webViewObject.LoadURL(escapedPath);
+            webViewObject.LoadURL(filePath);
         }
 
         private void InvokeOnPostMessageError(string id, string message)


### PR DESCRIPTION
# Summary
On certain iOS devices, if an app name contains a space, the SDK fails to locate the index.html file. The change was reverted, only escaping the file path for macOS standalone targets.

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->
Only some iOS devices will be impacted by this.

# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [x] ~~Sample app is updated with new SDK changes~~
- [x] ~~Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unity) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unity))~~
- [x] ~~Sample game is updated with new SDK changes~~
- [x] ~~Replied to GitHub issues~~
