### PR TITLE
[DX-2665] feat: ability to target android/ios and run the sdk in the unity mac editor

### DIFF
--- a/sample/Assets/Scripts/AuthenticatedScript.cs
+++ b/sample/Assets/Scripts/AuthenticatedScript.cs
@@ -180,7 +180,7 @@ public class AuthenticatedScript : MonoBehaviour
     public async void Logout()
     {
         ShowOutput("Logging out...");
-#if UNITY_ANDROID || UNITY_IPHONE || (UNITY_STANDALONE_OSX && !UNITY_EDITOR_OSX)
+#if (UNITY_ANDROID && !UNITY_EDITOR_WIN) || (UNITY_IPHONE && !UNITY_EDITOR_WIN) || UNITY_STANDALONE_OSX
         await passport.LogoutPKCE();
 #else
         await passport.Logout();

--- a/sample/Assets/Scripts/UnauthenticatedScript.cs
+++ b/sample/Assets/Scripts/UnauthenticatedScript.cs
@@ -34,8 +34,7 @@ public class UnauthenticatedScript : MonoBehaviour
             string redirectUri = null;
             string logoutRedirectUri = null;
 
-            // macOS editor (play scene) does not support deeplinking
-#if UNITY_ANDROID || UNITY_IPHONE || (UNITY_STANDALONE_OSX && !UNITY_EDITOR_OSX)
+#if (UNITY_ANDROID && !UNITY_EDITOR_WIN) || (UNITY_IPHONE && !UNITY_EDITOR_WIN) || UNITY_STANDALONE_OSX
             redirectUri = "imxsample://callback";
             logoutRedirectUri = "imxsample://callback/logout";
 #endif
@@ -79,8 +78,7 @@ public class UnauthenticatedScript : MonoBehaviour
             ShowOutput("Called Login()...");
             LoginButton.gameObject.SetActive(false);
 
-            // macOS editor (play scene) does not support deeplinking
-#if UNITY_ANDROID || UNITY_IPHONE || (UNITY_STANDALONE_OSX && !UNITY_EDITOR_OSX)
+#if (UNITY_ANDROID && !UNITY_EDITOR_WIN) || (UNITY_IPHONE && !UNITY_EDITOR_WIN) || UNITY_STANDALONE_OSX
             await passport.LoginPKCE();
 #else
             await passport.Login();
@@ -109,9 +107,7 @@ public class UnauthenticatedScript : MonoBehaviour
 
             Debug.Log(error);
             ShowOutput(error);
-#if UNITY_ANDROID || UNITY_IPHONE || UNITY_STANDALONE_OSX
             LoginButton.gameObject.SetActive(true);
-#endif
         }
     }
 
@@ -149,8 +145,7 @@ public class UnauthenticatedScript : MonoBehaviour
             ShowOutput("Called Connect()...");
             ConnectButton.gameObject.SetActive(false);
 
-            // macOS editor (play scene) does not support deeplinking
-#if UNITY_ANDROID || UNITY_IPHONE || (UNITY_STANDALONE_OSX && !UNITY_EDITOR_OSX)
+#if (UNITY_ANDROID && !UNITY_EDITOR_WIN) || (UNITY_IPHONE && !UNITY_EDITOR_WIN) || UNITY_STANDALONE_OSX
             await passport.ConnectImxPKCE();
 #else
             await passport.ConnectImx();
@@ -179,9 +174,7 @@ public class UnauthenticatedScript : MonoBehaviour
 
             Debug.Log(error);
             ShowOutput(error);
-#if UNITY_ANDROID || UNITY_IPHONE || UNITY_STANDALONE_OSX
             ConnectButton.gameObject.SetActive(true);
-#endif
         }
     }
 

--- a/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
@@ -370,7 +370,7 @@ namespace Immutable.Passport
                 if (response != null && response.success == true && response.result != null)
                 {
                     string url = response.result.Replace(" ", "+");
-#if UNITY_ANDROID
+#if UNITY_ANDROID && !UNITY_EDITOR
                     loginPKCEUrl = url;
                     SendAuthEvent(pkceLoginOnly ? PassportAuthEvent.LoginPKCELaunchingCustomTabs : PassportAuthEvent.ConnectImxPKCELaunchingCustomTabs);
                     LaunchAndroidUrl(url);
@@ -583,7 +583,7 @@ namespace Immutable.Passport
         {
             string logoutUrl = await GetLogoutUrl();
 
-#if UNITY_ANDROID
+#if UNITY_ANDROID && !UNITY_EDITOR
             LaunchAndroidUrl(logoutUrl);
 #else
             communicationsManager.LaunchAuthURL(logoutUrl, logoutRedirectUri);

--- a/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/GreeBrowserClient.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/GreeBrowserClient.cs
@@ -17,6 +17,10 @@ namespace Immutable.Browser.Gree
 
         public GreeBrowserClient()
         {
+#if (UNITY_ANDROID && UNITY_EDITOR_OSX) || (UNITY_IPHONE && UNITY_EDITOR_OSX)
+            Debug.LogWarning("Native Android and iOS WebViews cannot run in the Editor, so the macOS WebView is currently used to save your development time." + 
+                " Testing your game on an actual device or emulator is recommended to ensure proper functionality.");
+#endif
             webViewObject = new WebViewObject();
             webViewObject.Init(
                 cb: InvokeOnUnityPostMessage,
@@ -25,7 +29,7 @@ namespace Immutable.Browser.Gree
                 auth: InvokeOnAuthPostMessage,
                 log: InvokeOnLogMessage
             );
-#if UNITY_ANDROID
+#if UNITY_ANDROID && !UNITY_EDITOR
             string filePath = Constants.SCHEME_FILE + ANDROID_DATA_DIRECTORY + Constants.PASSPORT_DATA_DIRECTORY_NAME + Constants.PASSPORT_HTML_FILE_NAME;
 #elif UNITY_EDITOR_OSX
             string filePath = Constants.SCHEME_FILE + Path.GetFullPath(MAC_EDITOR_RESOURCES_DIRECTORY) + Constants.PASSPORT_HTML_FILE_NAME;

--- a/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/WebViewObject.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/WebViewObject.cs
@@ -74,7 +74,7 @@ public class WebViewObject
     ErrorCallback onHttpError;
     Callback onAuth;
     Callback onLog;
-#if UNITY_ANDROID
+#if UNITY_ANDROID && !UNITY_EDITOR
     class AndroidCallback : AndroidJavaProxy
     {
         private Action<string> callback;
@@ -94,7 +94,7 @@ public class WebViewObject
     IntPtr webView;
 #endif
 
-#if UNITY_IPHONE
+#if UNITY_IPHONE && !UNITY_EDITOR
     [DllImport("__Internal")]
     private static extern IntPtr _CWebViewPlugin_Init(string ua);
     [DllImport("__Internal")]
@@ -113,7 +113,7 @@ public class WebViewObject
     private static extern void _CWebViewPlugin_ClearCache(IntPtr instance, bool includeDiskFiles);
     [DllImport("__Internal")]
     private static extern void _CWebViewPlugin_ClearStorage(IntPtr instance);
-#elif UNITY_STANDALONE_OSX
+#elif UNITY_STANDALONE_OSX || (UNITY_ANDROID && UNITY_EDITOR_OSX) || (UNITY_IPHONE && UNITY_EDITOR_OSX)
     [DllImport("WebView")]
     private static extern IntPtr _CWebViewPlugin_Init(string ua);
     [DllImport("WebView")]
@@ -228,7 +228,7 @@ public class WebViewObject
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || UNITY_EDITOR_LINUX
         //TODO: UNSUPPORTED
         Debug.LogError("Webview is not supported on this platform.");
-#elif UNITY_IPHONE || UNITY_STANDALONE_OSX
+#elif UNITY_IPHONE || UNITY_STANDALONE_OSX || (UNITY_ANDROID && UNITY_EDITOR_OSX)
         webView = _CWebViewPlugin_Init(ua);
         Singleton.Instance.onJS = ((message) => CallFromJS(message));
         Singleton.Instance.onError = ((id, message) => CallOnError(id, message));
@@ -257,7 +257,7 @@ public class WebViewObject
         Application.ExternalCall("unityWebView.loadURL", url);
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || UNITY_EDITOR_LINUX
         //TODO: UNSUPPORTED
-#elif UNITY_STANDALONE_OSX || UNITY_IPHONE
+#elif UNITY_STANDALONE_OSX || UNITY_IPHONE || (UNITY_ANDROID && UNITY_EDITOR_OSX)
         if (webView == IntPtr.Zero)
             return;
         _CWebViewPlugin_LoadURL(webView, url);
@@ -278,7 +278,7 @@ public class WebViewObject
         Application.ExternalCall("unityWebView.evaluateJS", js);
 #elif UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || UNITY_EDITOR_LINUX
         //TODO: UNSUPPORTED
-#elif UNITY_STANDALONE_OSX || UNITY_IPHONE
+#elif UNITY_STANDALONE_OSX || UNITY_IPHONE || (UNITY_ANDROID && UNITY_EDITOR_OSX)
         if (webView == IntPtr.Zero)
             return;
         _CWebViewPlugin_EvaluateJS(webView, js);
@@ -291,7 +291,7 @@ public class WebViewObject
 
     public void LaunchAuthURL(string url, string redirectUri)
     {
-#if UNITY_STANDALONE_OSX
+#if UNITY_STANDALONE_OSX || (UNITY_ANDROID && UNITY_EDITOR_OSX) || (UNITY_IPHONE && UNITY_EDITOR_OSX)
         if (webView == IntPtr.Zero)
             return;
         _CWebViewPlugin_LaunchAuthURL(webView, url, redirectUri != null ? redirectUri : "");
@@ -332,7 +332,7 @@ public class WebViewObject
     {
         if (onJS != null)
         {
-#if !UNITY_ANDROID
+#if !(UNITY_ANDROID && !UNITY_EDITOR)
 #if UNITY_2018_4_OR_NEWER
             message = UnityWebRequest.UnEscapeURL(message.Replace("+", "%2B"));
 #else // UNITY_2018_4_OR_NEWER


### PR DESCRIPTION
# Summary
In the past, setting the build target to Android or iOS on the Mac Unity Editor would prevent the Unity SDK from running because the web view was not supported. With this update, the SDK now uses the macOS WebView instead if the target is Android or iOS and the Unity Editor is on Mac.

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->
Customers can save development time by targeting Android or iOS and running the SDK on the Mac Unity Editor. However, it's important to note that native Android and iOS WebViews cannot run in the editor, so the macOS WebView is used instead. Therefore, we highly recommend testing the game on an actual device or emulator to ensure it functions properly.

# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [x] Sample app is updated with new SDK changes
- [x] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unity) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unity))
