### PR TITLE
[DX-2700] fix: android login and connect pkce not working if minify is enabled in sample app

### DIFF
--- a/sample/Assets/Plugins/Android/proguard-user.txt
+++ b/sample/Assets/Plugins/Android/proguard-user.txt
@@ -1,0 +1,7 @@
+-dontwarn com.immutable.**
+-keep class com.immutable.** { *; }
+-keep interface com.immutable.** { *; }
+
+-dontwarn androidx.**
+-keep class androidx.** { *; }
+-keep interface androidx.** { *; }

--- a/sample/Assets/Plugins/Android/proguard-user.txt.meta
+++ b/sample/Assets/Plugins/Android/proguard-user.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 99a65e87aa7b349cfa3882d4ca648674
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/sample/Assets/Scripts/UnauthenticatedScript.cs
+++ b/sample/Assets/Scripts/UnauthenticatedScript.cs
@@ -102,7 +102,11 @@ public class UnauthenticatedScript : MonoBehaviour
             {
                 error = $"Login() error: {ex.Message}";
                 // Restart everything
+#if (UNITY_ANDROID && !UNITY_EDITOR_WIN) || (UNITY_IPHONE && !UNITY_EDITOR_WIN) || UNITY_STANDALONE_OSX
                 await passport.Logout();
+#else
+                await passport.LogoutPKCE();
+#endif
             }
 
             Debug.Log(error);
@@ -169,7 +173,11 @@ public class UnauthenticatedScript : MonoBehaviour
             {
                 error = $"Connect() error: {ex.Message}";
                 // Restart everything
+#if (UNITY_ANDROID && !UNITY_EDITOR_WIN) || (UNITY_IPHONE && !UNITY_EDITOR_WIN) || UNITY_STANDALONE_OSX
                 await passport.Logout();
+#else
+                await passport.LogoutPKCE();
+#endif
             }
 
             Debug.Log(error);

--- a/sample/ProjectSettings/ProjectSettings.asset
+++ b/sample/ProjectSettings/ProjectSettings.asset
@@ -245,7 +245,7 @@ PlayerSettings:
   useCustomLauncherGradleManifest: 0
   useCustomBaseGradleTemplate: 0
   useCustomGradlePropertiesTemplate: 0
-  useCustomProguardFile: 0
+  useCustomProguardFile: 1
   AndroidTargetArchitectures: 2
   AndroidTargetDevices: 0
   AndroidSplashScreenScale: 0


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
As pointed out by https://github.com/immutable/unity-immutable-sdk/issues/172, the `LoginPKCE` and `ConnectImxPKCE` functions do not work on Android if Minify is enabled. This PR added an example demonstrating how to configure Proguard with Minify enabled in the sample game.

Also, fixed the sample application to log out using the appropriate method if the login or connection attempt fails.

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->
If you enable Minify in your game, please follow the instructions in our documentation [here](https://docs.immutable.com/docs/x/sdks/unity/#proguard).

# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [x] Sample app is updated with new SDK changes
- [x] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unity) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unity))
- [ ] Sample game is updated with new SDK changes
- [x] Replied to GitHub issues
