### PR TITLE
[DX-2713] feat: ability to skip logging out of auth0 in the browser

### DIFF
--- a/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
@@ -520,14 +520,17 @@ namespace Immutable.Passport
             }
         }
 
-        public async UniTask Logout()
+        public async UniTask Logout(bool hardLogout = true)
         {
             try
             {
                 SendAuthEvent(PassportAuthEvent.LoggingOut);
 
                 string logoutUrl = await GetLogoutUrl();
-                OpenUrl(logoutUrl);
+                if (hardLogout)
+                {
+                    OpenUrl(logoutUrl);
+                }
 
                 Track(PassportAnalytics.EventName.COMPLETE_LOGOUT, success: true);
                 SendAuthEvent(PassportAuthEvent.LogoutSuccess);
@@ -544,7 +547,7 @@ namespace Immutable.Passport
             }
         }
 
-        public UniTask LogoutPKCE()
+        public UniTask LogoutPKCE(bool hardLogout = true)
         {
             try
             {
@@ -552,7 +555,7 @@ namespace Immutable.Passport
 
                 UniTaskCompletionSource<bool> task = new UniTaskCompletionSource<bool>();
                 pkceCompletionSource = task;
-                LaunchLogoutPKCEUrl();
+                LaunchLogoutPKCEUrl(hardLogout);
                 return task.Task;
             }
             catch (Exception ex)
@@ -579,15 +582,21 @@ namespace Immutable.Passport
             pkceCompletionSource = null;
         }
 
-        private async void LaunchLogoutPKCEUrl()
+        private async void LaunchLogoutPKCEUrl(bool hardLogout)
         {
             string logoutUrl = await GetLogoutUrl();
-
+            if (hardLogout)
+            {
 #if UNITY_ANDROID && !UNITY_EDITOR
-            LaunchAndroidUrl(logoutUrl);
+                LaunchAndroidUrl(logoutUrl);
 #else
-            communicationsManager.LaunchAuthURL(logoutUrl, logoutRedirectUri);
+                communicationsManager.LaunchAuthURL(logoutUrl, logoutRedirectUri);
 #endif
+            }
+            else
+            {
+                HandleLogoutPKCESuccess();
+            }
         }
 
         public async UniTask<bool> HasCredentialsSaved()

--- a/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
@@ -199,18 +199,20 @@ namespace Immutable.Passport
         /// Logs the user out of Passport and removes any stored credentials.
         /// Recommended to use when logging in using device auth flow - ConnectImx()
         /// </summary>
-        public async UniTask Logout()
+        /// <param name="hardLogout">If false, the user will not be logged out of Passport in the browser. The default is true.</param>
+        public async UniTask Logout(bool hardLogout = true)
         {
-            await GetPassportImpl().Logout();
+            await GetPassportImpl().Logout(hardLogout);
         }
 
         /// <summary>
         /// Logs the user out of Passport and removes any stored credentials.
         /// Recommended to use when logging in using PKCE flow - ConnectImxPKCE()
         /// </summary>
-        public async UniTask LogoutPKCE()
+        /// <param name="hardLogout">If false, the user will not be logged out of Passport in the browser. The default is true.</param>
+        public async UniTask LogoutPKCE(bool hardLogout = true)
         {
-            await GetPassportImpl().LogoutPKCE();
+            await GetPassportImpl().LogoutPKCE(hardLogout);
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
The SDK's current logout function performs a local logout and also opens the browser to log them out of the browser session. However, some customers might find the browser popup undesirable. To address this issue, a change has been made to allow users to skip logging out of the browser step and only perform a local logout:
* To skip the Auth0 logout and only perform a local logout, set `hardLogout` to `false` when calling `Logout()` or `LogoutPKCE()`.
* To perform local and Auth0 logout, set the `hardLogout` parameter to `true` when calling the `Logout()` or `LogoutPKCE()` function. This is the default.

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->
Customers can now choose not to display the browser pop-up when logging out. However, if they choose this option, they will remain logged into Passport in the browser until the browser session expires.

e.g.
* User logs into Passport with Google Account A
* User logs out without the browser popup (`hardLogout` is set to `false`)
* User tries to log into Passport again
* If the Passport session in the browser is:
   * still valid, the user will be automatically logged in as Google Account A
   * no longer valid, the user will go through the full Passport login flow again (choose Google/Email/etc.)

# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [x] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unity) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unity))
