### PR TITLE
[DX-2731] feat: ability to target android or ios and run sdk in windows unity editor

### DIFF
--- a/sample/Assets/Scripts/UnauthenticatedScript.cs
+++ b/sample/Assets/Scripts/UnauthenticatedScript.cs
@@ -40,7 +40,7 @@ public class UnauthenticatedScript : MonoBehaviour
 #endif
 
             passport = await Passport.Init(
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
                 clientId, environment, redirectUri, logoutRedirectUri, 10000
 #else
                 clientId, environment, redirectUri, logoutRedirectUri

--- a/src/Packages/Passport/Editor/PassportPostprocess.cs
+++ b/src/Packages/Passport/Editor/PassportPostprocess.cs
@@ -19,7 +19,7 @@ namespace Immutable.Passport.Editor
 
         public void OnPostprocessBuild(BuildReport report)
         {
-            Debug.Log("Passport post-processing...");
+            Debug.Log($"Passport post-processing...");
 
             if (report.summary.result is BuildResult.Failed || report.summary.result is BuildResult.Cancelled)
                 return;

--- a/src/Packages/Passport/Runtime/Scripts/Private/Core/BrowserCommunicationsManager.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Core/BrowserCommunicationsManager.cs
@@ -2,7 +2,7 @@ using System.Net;
 using System;
 using Cysharp.Threading.Tasks;
 using System.Collections.Generic;
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 using VoltstroStudios.UnityWebBrowser.Core;
 #else
 using Immutable.Browser.Gree;

--- a/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System;
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 using VoltstroStudios.UnityWebBrowser.Core;
 #else
 using Immutable.Browser.Gree;
@@ -21,7 +21,7 @@ namespace Immutable.Passport
 
         public static Passport Instance { get; private set; }
 
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
         private readonly IWebBrowserClient webBrowserClient = new WebBrowserClient();
 #else
         private readonly IWebBrowserClient webBrowserClient = new GreeBrowserClient();
@@ -36,7 +36,7 @@ namespace Immutable.Passport
 
         private Passport()
         {
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
             Application.quitting += OnQuit;
 #elif UNITY_IPHONE || UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
             Application.deepLinkActivated += OnDeepLinkActivated;
@@ -57,7 +57,7 @@ namespace Immutable.Passport
         /// <param name="logoutRedirectUri">(Android, iOS and macOS only) The URL to which auth will redirect the browser after log out is complete</param>
         /// <param name="engineStartupTimeoutMs">(Windows only) Timeout time for waiting for the engine to start (in milliseconds)</param>
         public static UniTask<Passport> Init(
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
             string clientId, string environment, string redirectUri = null, string logoutRedirectUri = null, int engineStartupTimeoutMs = 4000
 #else
             string clientId, string environment, string redirectUri = null, string logoutRedirectUri = null
@@ -70,7 +70,7 @@ namespace Immutable.Passport
                 Instance = new Passport();
                 // Wait until we get a ready signal
                 return Instance.Initialise(
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
                         engineStartupTimeoutMs
 #endif
                     )
@@ -101,7 +101,7 @@ namespace Immutable.Passport
         }
 
         private async UniTask Initialise(
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
             int engineStartupTimeoutMs
 #endif
         )
@@ -110,7 +110,7 @@ namespace Immutable.Passport
             {
                 BrowserCommunicationsManager communicationsManager = new BrowserCommunicationsManager(webBrowserClient);
                 communicationsManager.OnReady += () => readySignalReceived = true;
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
                 await ((WebBrowserClient)webBrowserClient).Init(engineStartupTimeoutMs);
 #endif
                 passportImpl = new PassportImpl(communicationsManager);
@@ -125,7 +125,7 @@ namespace Immutable.Passport
             }
         }
 
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
         private void OnQuit()
         {
             // Need to clean up UWB resources when quitting the game in the editor

--- a/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/WebViewObject.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/Gree/Assets/Plugins/WebViewObject.cs
@@ -295,7 +295,7 @@ public class WebViewObject
         if (webView == IntPtr.Zero)
             return;
         _CWebViewPlugin_LaunchAuthURL(webView, url, redirectUri != null ? redirectUri : "");
-#elif UNITY_IPHONE
+#elif UNITY_IPHONE && !UNITY_EDITOR_WIN
         if (webView == IntPtr.Zero)
             return;
         _CWebViewPlugin_LaunchAuthURL(webView, url);

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/AssemblyInfo.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Communication/CommunicationLayer.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Communication/CommunicationLayer.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Communication/TCPCommunicationLayer.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Communication/TCPCommunicationLayer.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/BaseUwbClientManager.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/BaseUwbClientManager.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Engine.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Engine.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/EngineConfiguration.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/EngineConfiguration.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserArgsBuilder.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserArgsBuilder.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
@@ -248,6 +248,10 @@ namespace VoltstroStudios.UnityWebBrowser.Core
 
         public WebBrowserClient()
         {
+#if (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
+            UnityEngine.Debug.LogWarning("Native Android and iOS WebViews cannot run in the Editor, so the Windows WebView is currently used to save your development time." + 
+                " Testing your game on an actual device or emulator is recommended to ensure proper functionality.");
+#endif
         }
 
         /// <summary>
@@ -312,7 +316,7 @@ namespace VoltstroStudios.UnityWebBrowser.Core
 #if UNITY_EDITOR
             filePath = Constants.SCHEME_FILE + Path.GetFullPath($"{PASSPORT_PACKAGE_RESOURCES_DIRECTORY}{Constants.PASSPORT_HTML_FILE_NAME}");
 #else
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
             filePath = Constants.SCHEME_FILE + Path.GetFullPath(Application.dataPath) + Constants.PASSPORT_DATA_DIRECTORY_NAME + Constants.PASSPORT_HTML_FILE_NAME;
 #endif     
 #endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserCommunicationsManager.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserCommunicationsManager.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Editor/EngineManagement/EngineManager.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Editor/EngineManagement/EngineManager.cs
@@ -3,7 +3,7 @@
 // 
 // This project is under the MIT license. See the LICENSE.md file for more details.
 
-#if UNITY_EDITOR && UNITY_STANDALONE_WIN
+#if UNITY_EDITOR && (UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN))
 
 using System.IO;
 using System.Linq;

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnFullscreenChange.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnFullscreenChange.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadFinish.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadFinish.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadStart.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadStart.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadingProgressChange.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnLoadingProgressChange.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnTitleChange.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnTitleChange.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnUrlChange.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Events/OnUrlChange.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Helper/ProcessExtensions.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Helper/ProcessExtensions.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Helper/WebBrowserUtils.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Helper/WebBrowserUtils.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios
@@ -83,7 +83,7 @@ namespace VoltstroStudios.UnityWebBrowser.Helper
             return EngineManager.GetEngineProcessFullPath(engine);
 #else
             string path = $"{GetBrowserEnginePath(null)}/{engine.GetEngineExecutableName()}";
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
             path += ".exe";
 #endif
             return  Path.GetFullPath(path);

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputHandler.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputHandler.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputHelper.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputHelper.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputSystemHandler.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserInputSystemHandler.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserOldInputHandler.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Input/WebBrowserOldInputHandler.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/DefaultUnityWebBrowserLogger.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/DefaultUnityWebBrowserLogger.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/IWebBrowserLogger.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/IWebBrowserLogger.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 ﻿// UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/JsonLogSeverityConverter.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/JsonLogSeverityConverter.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/JsonLogStructure.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/JsonLogStructure.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/ProcessLogHandler.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Logging/ProcessLogHandler.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsConnectedException.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsConnectedException.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsNotConnectedException.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsNotConnectedException.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsNotReadyException.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/UwbIsNotReadyException.cs
@@ -1,4 +1,4 @@
-#if UNITY_STANDALONE_WIN
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
 
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2022 Voltstro-Studios


### PR DESCRIPTION
# Summary
Previously, when setting the build target to Android or iOS on the Windows Unity Editor, the Unity SDK would not run due to the lack of support for web view. With this update, the SDK now leverages the Windows WebView instead, if the target is Android or iOS and the Unity Editor is on Windows.

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->
To save development time, customers can target Android or iOS and run the SDK on the Windows Unity Editor. However, it's important to keep in mind that native Android and iOS WebViews are not compatible with the editor, thus the Windows WebView is used instead. Therefore, we highly recommend testing the game on an actual device or emulator to ensure that it works properly.

Additionally, when using the SDK on the Windows Editor, the PKCE login flow is not available for Android or iOS build targets. However, the Device Code Auth flow is unaffected.

# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [x] Sample app is updated with new SDK changes
- [x] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unity) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unity))
