### PR TITLE
[DX-2753] fix: add voltstro unity web browser fixes for engine timeout

### DIFF
--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Plugins/VoltstroStudios.UnityWebBrowser.Shared.dll
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Plugins/VoltstroStudios.UnityWebBrowser.Shared.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:668a01c66bf4bd9c89cb1c393fcfaca294766ba9077d389ff575a0a54a2a4eef
+oid sha256:28795420fd282716cf4e7c58ebf7bfee64f3d98b3fbac4dcdce94b964d6ae2ee
 size 23040

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/EngineProcess.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/EngineProcess.cs
@@ -1,0 +1,80 @@
+// UnityWebBrowser (UWB)
+// Copyright (c) 2021-2024 Voltstro-Studios
+// 
+// This project is under the MIT license. See the LICENSE.md file for more details.
+
+using System;
+using System.Diagnostics;
+using VoltstroStudios.UnityWebBrowser.Core.Engines.Process;
+using VoltstroStudios.UnityWebBrowser.Helper;
+using VoltstroStudios.UnityWebBrowser.Logging;
+
+namespace VoltstroStudios.UnityWebBrowser.Core.Engines
+{
+    /// <summary>
+    ///     Handler for the engine process
+    /// </summary>
+    internal sealed class EngineProcess : IDisposable
+    {
+        private readonly IProcess processHandle;
+        private readonly Engine engine;
+        private readonly IWebBrowserLogger logger;
+        
+        /// <summary>
+        ///     Creates a new <see cref="EngineProcess"/> instance
+        /// </summary>
+        /// <param name="engine"></param>
+        /// <param name="logger"></param>
+        public EngineProcess(Engine engine, IWebBrowserLogger logger)
+        {
+#if UNITY_STANDALONE_WIN
+            processHandle = new WindowProcess();
+#elif UNITY_STANDALONE_LINUX
+            processHandle = new LinuxProcess(logger);
+#endif
+            
+            this.engine = engine;
+            this.logger = logger;
+        }
+
+        /// <summary>
+        ///     Has the process exited?
+        /// </summary>
+        public bool HasExited => processHandle.HasExited;
+
+        /// <summary>
+        ///     What was the exit code of the process
+        /// </summary>
+        public int ExitCode => processHandle.ExitCode;
+
+        /// <summary>
+        ///     Starts the engine process
+        /// </summary>
+        /// <param name="arguments"></param>
+        /// <param name="onLogEvent"></param>
+        /// <param name="onErrorLogEvent"></param>
+        public void StartProcess(string arguments, DataReceivedEventHandler onLogEvent, DataReceivedEventHandler onErrorLogEvent)
+        {
+            string engineFullProcessPath = WebBrowserUtils.GetBrowserEngineProcessPath(engine);
+            string engineDirectory = WebBrowserUtils.GetBrowserEnginePath(engine);
+            
+            logger.Debug($"Process Path: '{engineFullProcessPath}'\nWorking: '{engineDirectory}'");
+            logger.Debug($"Arguments: '{arguments}'");
+            
+            processHandle.StartProcess(engineFullProcessPath, engineDirectory, arguments, onLogEvent, onErrorLogEvent);
+        }
+
+        /// <summary>
+        ///     Kills the engine process
+        /// </summary>
+        public void KillProcess()
+        {
+            processHandle.KillProcess();
+        }
+        
+        public void Dispose()
+        {
+            processHandle.Dispose();
+        }
+    }
+}

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/EngineProcess.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/EngineProcess.cs
@@ -1,3 +1,5 @@
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2024 Voltstro-Studios
 // 
@@ -27,11 +29,7 @@ namespace VoltstroStudios.UnityWebBrowser.Core.Engines
         /// <param name="logger"></param>
         public EngineProcess(Engine engine, IWebBrowserLogger logger)
         {
-#if UNITY_STANDALONE_WIN
             processHandle = new WindowProcess();
-#elif UNITY_STANDALONE_LINUX
-            processHandle = new LinuxProcess(logger);
-#endif
             
             this.engine = engine;
             this.logger = logger;
@@ -78,3 +76,5 @@ namespace VoltstroStudios.UnityWebBrowser.Core.Engines
         }
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/EngineProcess.cs.meta
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/EngineProcess.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9bf8ca69b1a115c4aa677e6822fc52ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Process.meta
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Process.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9ef4f922c61fbd949b0035d10e8e4295
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Process/IProcess.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Process/IProcess.cs
@@ -1,0 +1,21 @@
+// UnityWebBrowser (UWB)
+// Copyright (c) 2021-2024 Voltstro-Studios
+// 
+// This project is under the MIT license. See the LICENSE.md file for more details.
+
+using System;
+using System.Diagnostics;
+
+namespace VoltstroStudios.UnityWebBrowser.Core.Engines.Process
+{
+    internal interface IProcess : IDisposable
+    {
+        public void StartProcess(string executable, string workingDir, string arguments, DataReceivedEventHandler onLogEvent, DataReceivedEventHandler onErrorLogEvent);
+
+        public void KillProcess();
+
+        public bool HasExited { get; }
+
+        public int ExitCode { get; }
+    }
+}

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Process/IProcess.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Process/IProcess.cs
@@ -1,3 +1,5 @@
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2024 Voltstro-Studios
 // 
@@ -19,3 +21,5 @@ namespace VoltstroStudios.UnityWebBrowser.Core.Engines.Process
         public int ExitCode { get; }
     }
 }
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Process/IProcess.cs.meta
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Process/IProcess.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94b34c15c19c65c4a94a047310ff3c7d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Process/WindowProcess.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Process/WindowProcess.cs
@@ -1,0 +1,169 @@
+// UnityWebBrowser (UWB)
+// Copyright (c) 2021-2024 Voltstro-Studios
+// 
+// This project is under the MIT license. See the LICENSE.md file for more details.
+
+#if UNITY_STANDALONE_WIN
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace VoltstroStudios.UnityWebBrowser.Core.Engines.Process
+{
+    internal sealed class WindowProcess : IProcess
+    {
+        private readonly System.Diagnostics.Process process;
+        private readonly IntPtr jobHandle;
+
+        public WindowProcess()
+        {
+            //Job handle code from SO
+            //https://stackoverflow.com/questions/3342941/kill-child-process-when-parent-process-is-killed
+            string jobName = "UWBChildProcesses" + System.Diagnostics.Process.GetCurrentProcess().Id;
+            jobHandle = CreateJobObject(IntPtr.Zero, jobName);
+            
+            JOBOBJECT_BASIC_LIMIT_INFORMATION info = new()
+            {
+                // This is the key flag. When our process is killed, Windows will automatically
+                //  close the job handle, and when that happens, we want the child processes to
+                //  be killed, too.
+                LimitFlags = JOBOBJECTLIMIT.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+            };
+
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION extendedInfo = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+                {
+                    BasicLimitInformation = info
+                };
+
+            int length = Marshal.SizeOf(typeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+            IntPtr extendedInfoPtr = Marshal.AllocHGlobal(length);
+            try
+            {
+                Marshal.StructureToPtr(extendedInfo, extendedInfoPtr, false);
+
+                if (!SetInformationJobObject(jobHandle, JobObjectInfoType.ExtendedLimitInformation,
+                        extendedInfoPtr, (uint)length))
+                {
+                    throw new Win32Exception();
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(extendedInfoPtr);
+            }
+            
+            process = new System.Diagnostics.Process();
+        }
+        
+        public void StartProcess(string executable, string workingDir, string arguments, DataReceivedEventHandler onLogEvent, DataReceivedEventHandler onErrorLogEvent)
+        {
+            ProcessStartInfo startInfo = new(executable, arguments)
+            {
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                WorkingDirectory = workingDir
+            };
+
+            process.StartInfo = startInfo;
+            process.OutputDataReceived += onLogEvent;
+            process.ErrorDataReceived += onErrorLogEvent;
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            
+            //Assign this process to the job handle
+            bool success = AssignProcessToJobObject(jobHandle, process.Handle);
+            if (!success && !process.HasExited)
+                throw new Win32Exception();
+        }
+
+        public void KillProcess()
+        {
+            TerminateJobObject(jobHandle, 0);
+        }
+
+        public bool HasExited => process.HasExited;
+        public int ExitCode => process.ExitCode;
+
+        public void Dispose()
+        {
+            process.Dispose();
+        }
+
+        #region WIN32 Native
+        
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr CreateJobObject(IntPtr lpJobAttributes, string name);
+
+        [DllImport("kernel32.dll")]
+        private static extern bool SetInformationJobObject(IntPtr job, JobObjectInfoType infoType,
+            IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool TerminateJobObject(IntPtr job, uint exitCode);
+
+        public enum JobObjectInfoType
+        {
+            AssociateCompletionPortInformation = 7,
+            BasicLimitInformation = 2,
+            BasicUIRestrictions = 4,
+            EndOfJobTimeInformation = 6,
+            ExtendedLimitInformation = 9,
+            SecurityLimitInformation = 5,
+            GroupInformation = 11
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+        {
+            public Int64 PerProcessUserTimeLimit;
+            public Int64 PerJobUserTimeLimit;
+            public JOBOBJECTLIMIT LimitFlags;
+            public UIntPtr MinimumWorkingSetSize;
+            public UIntPtr MaximumWorkingSetSize;
+            public UInt32 ActiveProcessLimit;
+            public Int64 Affinity;
+            public UInt32 PriorityClass;
+            public UInt32 SchedulingClass;
+        }
+
+        [Flags]
+        public enum JOBOBJECTLIMIT : uint
+        {
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct IO_COUNTERS
+        {
+            public UInt64 ReadOperationCount;
+            public UInt64 WriteOperationCount;
+            public UInt64 OtherOperationCount;
+            public UInt64 ReadTransferCount;
+            public UInt64 WriteTransferCount;
+            public UInt64 OtherTransferCount;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+        {
+            public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+            public IO_COUNTERS IoInfo;
+            public UIntPtr ProcessMemoryLimit;
+            public UIntPtr JobMemoryLimit;
+            public UIntPtr PeakProcessMemoryUsed;
+            public UIntPtr PeakJobMemoryUsed;
+        }
+
+        #endregion
+    }
+}
+
+#endif

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Process/WindowProcess.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Process/WindowProcess.cs
@@ -1,9 +1,9 @@
+#if UNITY_STANDALONE_WIN || (UNITY_ANDROID && UNITY_EDITOR_WIN) || (UNITY_IPHONE && UNITY_EDITOR_WIN)
+
 // UnityWebBrowser (UWB)
 // Copyright (c) 2021-2024 Voltstro-Studios
 // 
 // This project is under the MIT license. See the LICENSE.md file for more details.
-
-#if UNITY_STANDALONE_WIN
 
 using System;
 using System.ComponentModel;

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Process/WindowProcess.cs.meta
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/Engines/Process/WindowProcess.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 549b75cae21559e49b5de16f115c6e0b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Core/WebBrowserClient.cs
@@ -138,7 +138,7 @@ namespace VoltstroStudios.UnityWebBrowser.Core
         ///     Timeout time for waiting for the engine to start (in milliseconds)
         /// </summary>
         [Tooltip("Timeout time for waiting for the engine to start (in milliseconds)")]
-        public int engineStartupTimeout = 4000;
+        public int engineStartupTimeout = 30000;
 
         /// <summary>
         ///     The log severity. Only messages of this severity level or higher will be logged
@@ -263,7 +263,7 @@ namespace VoltstroStudios.UnityWebBrowser.Core
         ///     Inits the browser client
         /// </summary>
         /// <exception cref="FileNotFoundException"></exception>
-        public async UniTask Init(int engineStartupTimeout = 4000)
+        public async UniTask Init(int engineStartupTimeout = 30000)
         {
             this.engineStartupTimeout = engineStartupTimeout;
             UnityEngine.Debug.Log($"{TAG} Engine startup timeout: {engineStartupTimeout}");

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/VoltstroStudios.UnityWebBrowser.asmdef
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/VoltstroStudios.UnityWebBrowser.asmdef
@@ -3,7 +3,6 @@
     "rootNamespace": "VoltstroStudios.UnityWebBrowser",
     "references": [
         "UniTask",
-        "Unity.InputSystem",
         "Immutable.Browser.Core"
     ],
     "includePlatforms": [


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
- Added Voltstros' fixes to attempt to resolve the Windows UnityWebBrowser engine start-up timeout issue. For more details, see https://github.com/Voltstro-Studios/UnityWebBrowser/issues/166.
- Increased Windows UnityWebBrowser engine startup timeout.


# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->
When starting the SDK, some Windows users may experience the engine start-up timeout issue. Added Volstros' fixes to attempt to resolve the timeout issue.
