### PR TITLE
[DX-2793] fix: nullables not working for unity 2019

### DIFF
--- a/src/Packages/Passport/Runtime/Scripts/Private/Event/AnalyticsEvent.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Event/AnalyticsEvent.cs
@@ -42,7 +42,7 @@ namespace Immutable.Passport.Event
         }
 
         public async UniTask Track(IBrowserCommunicationsManager communicationsManager, string eventName,
-            bool? success = null, Dictionary<string, object>? properties = null)
+            bool? success = null, Dictionary<string, object> properties = null)
         {
             try
             {

--- a/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
@@ -22,7 +22,7 @@ namespace Immutable.Passport
     {
         private const string TAG = "[Passport Implementation]";
         public readonly IBrowserCommunicationsManager communicationsManager;
-        private PassportAnalytics analytics = new();
+        private PassportAnalytics analytics = new PassportAnalytics();
 
         // Used for device code auth
         private DeviceConnectResponse deviceConnectResponse;
@@ -829,7 +829,7 @@ namespace Immutable.Passport
         }
 #endif
 
-        protected virtual async void Track(string eventName, bool? success = null, Dictionary<string, object>? properties = null)
+        protected virtual async void Track(string eventName, bool? success = null, Dictionary<string, object> properties = null)
         {
             await analytics.Track(communicationsManager, eventName, success, properties);
         }

--- a/src/Packages/Passport/Tests/Runtime/Scripts/PassportTests.cs
+++ b/src/Packages/Passport/Tests/Runtime/Scripts/PassportTests.cs
@@ -24,7 +24,7 @@ namespace Immutable.Passport
             urlsOpened.Add(url);
         }
 
-        protected override void Track(string eventName, bool? success = null, Dictionary<string, object>? properties = null)
+        protected override void Track(string eventName, bool? success = null, Dictionary<string, object> properties = null)
         {
         }
     }


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
Fix nullability errors that show up in older Unity versions.

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->
Customers using older Unity versions can now integrate the SDK without encountering nullability errors.
