### PR TITLE
[DX-2784] docs: transaction receipt response status field docs, sample app transaction status check

### DIFF
--- a/sample/Assets/Scripts/AuthenticatedScript.cs
+++ b/sample/Assets/Scripts/AuthenticatedScript.cs
@@ -413,7 +413,21 @@ public class AuthenticatedScript : MonoBehaviour
             ShowOutput($"Getting zkEVM transaction receipt status...");
 
             TransactionReceiptResponse response = await passport.ZkEvmGetTransactionReceipt(ZkGetTransactionReceiptHash.text);
+            string status = "Transaction receipt status: ";
             ShowOutput($"Transaction receipt status: {(response.status == "0x1" ? "Success" : "Failed")}");
+            switch (response.status)
+            {
+                case "0x1":
+                    status += "Success";
+                    break;
+                case "0x0":
+                    status += "Failed";
+                    break;
+                case null:
+                    status += "Still processing";
+                    break;
+            }
+            ShowOutput(status);
         }
         catch (Exception ex)
         {

--- a/src/Packages/Passport/Runtime/Scripts/Private/Model/Response/TransactionReceiptResponse.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Model/Response/TransactionReceiptResponse.cs
@@ -21,7 +21,18 @@ namespace Immutable.Passport.Model
         public string logsBloom;
 
         /// <summary>
-        ///     Either 1 (success) or 0 (failure) encoded as a hexadecimal.
+        /// Possible reponses:
+        /// <list type="bullet">
+        /// <item>
+        /// <description>Success: 0x0</description>
+        /// </item>
+        /// <item>
+        /// <description>Failure: 0x0</description>
+        /// </item>
+        /// <item>
+        /// <description>Null: Transaction is still processing</description>
+        /// </item>
+        /// </list>
         /// </summary>
         public string status;
 


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
- Updated the `TransactionReceiptResonse` `status` docs to show all possible values.
- Fixed how the sample app checks the status of a transaction.

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->
When calling `ZkEvmGetTransactionReceipt`, customers can now easily understand each transaction status.