### PR TITLE
[DX-2834] docs: update transaction receipt response docs, remove unnecessary code in sample app

### DIFF
--- a/sample/Assets/Scripts/AuthenticatedScript.cs
+++ b/sample/Assets/Scripts/AuthenticatedScript.cs
@@ -414,7 +414,6 @@ public class AuthenticatedScript : MonoBehaviour
 
             TransactionReceiptResponse response = await passport.ZkEvmGetTransactionReceipt(ZkGetTransactionReceiptHash.text);
             string status = "Transaction receipt status: ";
-            ShowOutput($"Transaction receipt status: {(response.status == "0x1" ? "Success" : "Failed")}");
             switch (response.status)
             {
                 case "0x1":

--- a/src/Packages/Passport/Runtime/Scripts/Private/Model/Response/TransactionReceiptResponse.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Model/Response/TransactionReceiptResponse.cs
@@ -24,15 +24,11 @@ namespace Immutable.Passport.Model
         /// Possible reponses:
         /// <list type="bullet">
         /// <item>
-        /// <description>Success: 0x0</description>
+        /// <description>Success: 0x1</description>
         /// </item>
         /// <item>
         /// <description>Failure: 0x0</description>
         /// </item>
-        /// <item>
-        /// <description>Null: Transaction is still processing</description>
-        /// </item>
-        /// </list>
         /// </summary>
         public string status;
 


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
- Updated docs for `TransactionReceiptResponse` status
- Removed unnecessary code in sample app


# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->
Updated documentation for `TransactionReceiptResponse` `status` field.

# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [x] Sample app is updated with new SDK changes
