### PR TITLE
[DX-3019] feat: nullify passport on quit

### DIFF
--- a/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
@@ -132,6 +132,7 @@ namespace Immutable.Passport
             // as the child engine process would still be alive
             Debug.Log($"{TAG} Quitting the Player");
             ((WebBrowserClient)webBrowserClient).Dispose();
+            Instance = null;
         }
 #endif
 


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
Nullify Passport Instance upon application exit on Windows.

# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [ ] Sample app is updated with new SDK changes
- [ ] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unity) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unity))
- [ ] Sample game is updated with new SDK changes
- [ ] Replied to GitHub issues
