### PR TITLE
[DX-2981] ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
     workflows: ["Tag Release"]
     types:
       - completed
+    status: success
 
 jobs:
   release:


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
The [Create Release](https://github.com/immutable/unity-immutable-sdk/actions/workflows/release.yml) workflow was previously triggered after the [Tag Release](https://github.com/immutable/unity-immutable-sdk/actions/workflows/tag.yml) workflow completes, regardless of whether all steps in the Tag Release workflow succeeded.

This PR updates the Create Release workflow only to run if the Tag Release workflow completes with a success status. This ensures that the release process only proceeds when the tagging process is successful.