### PR TITLE
fix: game bridge path for ios device

### DIFF
--- a/src/Packages/Passport/Runtime/ThirdParty/ImmutableBrowserCore/GameBridge.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/ImmutableBrowserCore/GameBridge.cs
@@ -26,7 +26,7 @@ namespace Immutable.Browser.Core
             // macOS
             filePath = SCHEME_FILE + Path.GetFullPath(Application.dataPath) + MAC_DATA_DIRECTORY + PASSPORT_DATA_DIRECTORY_NAME + PASSPORT_HTML_FILE_NAME;
             filePath = filePath.Replace(" ", "%20");
-#elif UNITY_IPHONE
+#elif UNITY_IPHONE && !UNITY_EDITOR
             // iOS device
             filePath = Path.GetFullPath(Application.dataPath) + PASSPORT_DATA_DIRECTORY_NAME + PASSPORT_HTML_FILE_NAME;
 #elif UNITY_EDITOR_WIN


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
Fixed game bridge path for iOS.

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->
Fixed the issue where the SDK could not load the game bridge file when running in the Unity Editor and targeting iOS.