### PR TITLE
[DX-3221] feat: allow logout redirect uri to be set for device code auth

### DIFF
--- a/sample/Assets/Scripts/SelectAuthMethodScript.cs
+++ b/sample/Assets/Scripts/SelectAuthMethodScript.cs
@@ -44,7 +44,7 @@ public class SelectAuthMethodScript : MonoBehaviour
     public void UseDeviceCodeAuth()
     {
         SampleAppManager.UsePKCE = false;
-        InitialisePassport();
+        InitialisePassport(logoutRedirectUri: "https://www.immutable.com");
     }
 
     /// <summary>
@@ -61,7 +61,7 @@ public class SelectAuthMethodScript : MonoBehaviour
     /// </summary>
     /// <param name="redirectUri">(Android, iOS and macOS only) The URL to which auth will redirect the browser after 
     /// authorisation has been granted by the user</param>
-    /// <param name="logoutRedirectUri">(Android, iOS and macOS only) The URL to which auth will redirect the browser
+    /// <param name="logoutRedirectUri">The URL to which auth will redirect the browser
     /// after log out is complete</param>
     private async void InitialisePassport(string redirectUri = null, string logoutRedirectUri = null)
     {

--- a/src/Packages/Passport/Runtime/Scripts/Private/Model/Request/InitRequest.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Model/Request/InitRequest.cs
@@ -18,6 +18,7 @@ namespace Immutable.Passport.Model
     {
         public string clientId;
         public string environment;
+        public string logoutRedirectUri;
         public VersionInfo engineVersion;
     }
 }

--- a/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
@@ -71,7 +71,7 @@ namespace Immutable.Passport
             };
 
             string initRequest;
-            if (redirectUri != null && logoutRedirectUri != null)
+            if (redirectUri != null)
             {
                 InitRequestWithRedirectUri requestWithRedirectUri = new InitRequestWithRedirectUri()
                 {
@@ -89,6 +89,7 @@ namespace Immutable.Passport
                 {
                     clientId = clientId,
                     environment = environment,
+                    logoutRedirectUri = logoutRedirectUri,
                     engineVersion = versionInfo
                 };
                 initRequest = JsonUtility.ToJson(request);


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
Allow `logoutRedirectUri` to be set even when `redirectUri` is not set.


# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->
Previously, logging out using the Device Code Auth flow redirected users to a localhost page. With this PR, users can now set a `logoutRedirectUri` without needing to configure the `redirectUri` (typically used in the PKCE flow), allowing them to choose the page they are redirected to after a successful logout.

# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [x] Sample app is updated with new SDK changes
- [x] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unity) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unity))
