### PR TITLE
[DX-3348] fix: tcp timeout

### DIFF
--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Communication/TCPCommunicationLayer.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/Runtime/Communication/TCPCommunicationLayer.cs
@@ -48,13 +48,13 @@ namespace VoltstroStudios.UnityWebBrowser.Communication
         public override Client CreateClient()
         {
             IPEndPoint ipEndPoint = new(IPAddress.Loopback, inPort);
-            return new TCPClient(ipEndPoint, connectionTimeout);
+            return new TCPClient(ipEndPoint, int.MaxValue);
         }
 
         public override Host CreateHost()
         {
             IPEndPoint ipEndPoint = new(IPAddress.Loopback, outPort);
-            return new TCPHost(ipEndPoint);
+            return new TCPHost(ipEndPoint, int.MaxValue, int.MaxValue);
         }
 
         public override void GetIpcSettings(out object outLocation, out object inLocation, out string assemblyLocation)


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
Change Voltstro UnityWebBrowser TCP timeouts to max allowed based on how Voltstro fixed [this](https://github.com/Voltstro-Studios/UnityWebBrowser/issues/300) issue.

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->
With increased Voltstro UnityWebBrowser TCP timeouts, customers should not see errors like `System.IO.IOException: Unable to write data to the transport connection: An established connection was aborted by the software in your host machine.`.