### PR TITLE
[DX-3426] chore: update zkevm api package version

### DIFF
--- a/src/Packages/ZkEvmApi/package.json
+++ b/src/Packages/ZkEvmApi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.immutable.api.zkevm",
-  "version": "0.1.0-alpha",
+  "version": "0.2.0-alpha",
   "description": "Immutable zkEVM API package for the Immutable SDK for Unity",
   "displayName": "Immutable zkEVM API",
   "author": {


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
Bumped up zkEVM API package to Alpha v0.2.0, as NFT metadata endpoints have been updated. This is manual until we move to a stable/non-alpha version.

# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [x] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unity) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unity))
- [x] Sample game is updated with new SDK changes