### PR TITLE
[DX-3465] fix: uwb dll platforms

### DIFF
--- a/sample/Tests/test/test.py
+++ b/sample/Tests/test/test.py
@@ -79,20 +79,20 @@ class UnityTest(unittest.TestCase):
 
         # Register off-chain
         # Wait up to 3 times for "Passport account already registered" to appear
-#         attempts = 0
-#         while attempts < 3:
-#            self.altdriver.find_object(By.NAME, "RegisterOffchainBtn").tap()
-#            self.assertEqual("Registering off-chain...", output.get_text())
-#            time.sleep(20)
-#            if "Passport account already registered" in output.get_text():
-#                break
-#            attempts += 1
-# 
-#         # Assert that the desired text is found after waiting
-#         self.assertTrue(
-#            "Passport account already registered" in output.get_text(),
-#            f"Expected 'Passport account already registered' not found. Actual output: '{output.get_text()}'"
-#         )
+        attempts = 0
+        while attempts < 3:
+           self.altdriver.find_object(By.NAME, "RegisterOffchainBtn").tap()
+           self.assertEqual("Registering off-chain...", output.get_text())
+           time.sleep(20)
+           if "Passport account already registered" in output.get_text():
+               break
+           attempts += 1
+
+        # Assert that the desired text is found after waiting
+        self.assertTrue(
+           "Passport account already registered" in output.get_text(),
+           f"Expected 'Passport account already registered' not found. Actual output: '{output.get_text()}'"
+        )
 
         # Get address
         self.altdriver.find_object(By.NAME, "GetAddressBtn").tap()

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/dev.voltstro.unitywebbrowser@2.2.5/Plugins/VoltstroStudios.UnityWebBrowser.Shared.dll.meta
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/dev.voltstro.unitywebbrowser@2.2.5/Plugins/VoltstroStudios.UnityWebBrowser.Shared.dll.meta
@@ -16,24 +16,24 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        Exclude Android: 0
+        Exclude Android: 1
         Exclude Editor: 0
         Exclude Linux64: 0
         Exclude OSXUniversal: 0
         Exclude WebGL: 1
         Exclude Win: 0
         Exclude Win64: 0
-        Exclude iOS: 0
+        Exclude iOS: 1
   - first:
       Android: Android
     second:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: ARMv7
   - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
@@ -81,7 +81,7 @@ PluginImporter:
   - first:
       iPhone: iOS
     second:
-      enabled: 1
+      enabled: 0
       settings:
         AddToEmbeddedBinaries: false
         CPU: AnyCPU

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/org.nuget.voltrpc@3.2.1/VoltRpc.dll.meta
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/org.nuget.voltrpc@3.2.1/VoltRpc.dll.meta
@@ -49,7 +49,7 @@ PluginImporter:
     second:
       enabled: 1
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
   - first:
       Standalone: OSXUniversal
     second:


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
- Made sure UnityWebBrowser dlls are only for Editor and Standalone platforms
- Uncomment register off-chain test case