### PR TITLE
refactor: remove unused imports, nullables, update readmes

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -15,14 +15,6 @@ jobs:
         mode: strict
         tolerance: same
         output: LICENSE-diff.txt
-    - name: Check that the README files are the exact same
-      uses: LouisBrunner/diff-action@v2.0.0
-      with:
-        old: README.md
-        new: src/Packages/Passport/README.md
-        mode: strict
-        tolerance: same
-        output: README-diff.txt
     - name: Check that the CHANGELOG files are the exact same
       uses: LouisBrunner/diff-action@v2.0.0
       with:

--- a/src/Packages/Marketplace/README.md
+++ b/src/Packages/Marketplace/README.md
@@ -1,65 +1,17 @@
-# Immutable.Marketplace - C# library for Immutable X Marketplace
+<div align="center">
+  <p align="center">
+    <a  href="https://docs.x.immutable.com/docs">
+      <img src="https://cdn.dribbble.com/users/1299339/screenshots/7133657/media/837237d447d36581ebd59ec36d30daea.gif" width="280"/>
+    </a>
+  </p>
+</div>
 
-This C# library provides functionality for interacting with the Immutable X Marketplace, including on-ramp services.
+---
 
-## Version Support
+# Immutable Unity SDK - Marketplace  
 
-This library supports:
+The Immutable SDK Marketplace package for Unity simplifies integrating marketplace functionality, such as adding funds to a player's wallet.  
 
-- Unity 2020.3 (LTS) and up
-- .NET Standard 2.1 / .NET Framework
+## Documentation  
 
-## Dependencies
-
-- [UniTask](https://github.com/Cysharp/UniTask) - For asynchronous operations
-- Unity Engine
-
-## Installation
-
-Add the dependencies to your Unity project. You can do this through the Package Manager or by adding them to your `Packages/manifest.json`:
-
-```json
-{
-  "dependencies": {
-    "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
-    "com.unity.nuget.newtonsoft-json": "3.0.2"
-  }
-}
-```
-
-## Usage
-
-Here's an example of how to use the OnRamp functionality with Immutable Passport:
-
-```csharp
-using Immutable.Marketplace.OnRamp;
-using Immutable.Passport;
-using Immutable.Passport.Model;
-using System.Collections.Generic;
-using UnityEngine;
-
-public class MarketplaceExample : MonoBehaviour
-{
-    async void Start()
-    {
-        string environment = Environment.SANDBOX;
-        string email = await Passport.Instance.GetEmail();
-        List<string> walletAddresses = await Passport.Instance.ZkEvmRequestAccounts();
-        
-        OnRamp onRamp = new OnRamp(environment, email, walletAddresses.FirstOrDefault());
-        
-        try
-        {
-            string link = await onRamp.GetLink();
-            Debug.Log($"onRamp.GetOnRampLink: {link}");
-            
-            // Open the generated link in the default browser
-            Application.OpenURL(link);
-        }
-        catch (System.Exception e)
-        {
-            Debug.LogError($"Error getting on-ramp link: {e.Message}");
-        }
-    }
-}
-```
+- [Immutable zkEVM Documentation](https://docs.immutable.com/docs/zkEVM/sdks/unity)

--- a/src/Packages/Passport/README.md
+++ b/src/Packages/Passport/README.md
@@ -8,40 +8,11 @@
 
 ---
 
-# Immutable Unity SDK
+# Immutable Unity SDK - Passport
 
-The Immutable SDK for Unity helps you integrate your game with Immutable Passport.
+The Immutable SDK Passport package for Unity helps you integrate your game with Immutable Passport.
 
 # Documentation
 
 * [Immutable X](https://docs.immutable.com/docs/x/sdks/unity)
 * [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unity)
-
-## Contributing
-
-Thank you for your interest in contributing to our project! Here's a quick guide on how you can get started:
-
-1. **Fork this Repository**: Fork the repository to your GitHub account by clicking the "Fork" button at the top right of the repository page.
-2. **Create a Branch**: Once you've forked the repository, create a new branch in your forked repository where you'll be making your changes. Branch naming convention is enforced [according to patterns here](https://github.com/deepakputhraya/action-branch-name).
-3. **Make Changes**: Make the necessary changes in your branch. Ensure that your changes are clear, well-documented, and aligned with the project's guidelines.
-4. **Commit Changes**: Commit your changes with clear and descriptive messages following [commit message pattern here](https://github.com/conventional-changelog/commitlint?tab=readme-ov-file#what-is-commitlint). It follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#specification), which helps maintain a consistent and informative commit history. Read [here](https://www.conventionalcommits.org/en/v1.0.0/#why-use-conventional-commits) to learn more about the benefits of Conventional Commits.
-5. **Create a Pull Request (PR)**: After you've made and committed your changes, create a PR against the original repository. Provide a clear description of the changes you've made in the PR.
-6. **Example Contribution**: Refer to [this contribution](https://github.com/immutable/unity-immutable-sdk/pull/182) as an example.
-
-## Getting Help
-
-Immutable X is open to all to build on, with no approvals required. If you want to talk to us to learn more, or apply for developer grants, click below:
-
-[Contact us](https://www.immutable.com/contact)
-
-### Project Support
-
-To get help from other developers, discuss ideas, and stay up-to-date on what's happening, become a part of our community on Discord.
-
-[Join us on Discord](https://discord.gg/TkVumkJ9D6)
-
-#### Still need help?
-
-You can also apply for marketing support for your project. Or, if you need help with an issue related to what you're building with Immutable X, click below to submit an issue. Select _I have a question_ or _issue related to building on Immutable X_ as your issue type.
-
-[Contact support](https://support.immutable.com/hc/en-us/requests/new)

--- a/src/Packages/Passport/Runtime/Scripts/Private/Model/Request/InitRequest.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Model/Request/InitRequest.cs
@@ -1,5 +1,4 @@
 using System;
-using Immutable.Passport.Model;
 
 namespace Immutable.Passport.Model
 {

--- a/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
@@ -257,7 +257,7 @@ namespace Immutable.Passport
         /// <returns>
         /// Returns true if login is successful, otherwise false.
         /// </returns>
-        public async UniTask<bool> Login(bool useCachedSession = false, Nullable<long> timeoutMs = null)
+        public async UniTask<bool> Login(bool useCachedSession = false, long? timeoutMs = null)
         {
             return await GetPassportImpl().Login(useCachedSession, timeoutMs);
         }
@@ -268,7 +268,7 @@ namespace Immutable.Passport
         /// <param name="useCachedSession">If true, the saved access token or refresh token will be used to connect the user. If this fails, it will not fallback to device code auth.</param>
         /// <param name="timeoutMs">(Optional) The maximum time, in milliseconds, the function is allowed to take before a TimeoutException is thrown. If not set, the function will wait indefinitely.</param>
         /// </summary>
-        public async UniTask<bool> ConnectImx(bool useCachedSession = false, Nullable<long> timeoutMs = null)
+        public async UniTask<bool> ConnectImx(bool useCachedSession = false, long? timeoutMs = null)
         {
             return await GetPassportImpl().ConnectImx(useCachedSession, timeoutMs);
         }


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
- Updated the README for Passport and Marketplace packages
- Removed unused imports
- Simplified nullable values, marked private fields/arguments as nullable
- Only call get logout URL if `hardLogout` is true
- Don't compare the Passport package README with the Unity SDK README to ensure consistency, as we now have multiple packages.
