### PR TITLE
[DX-3540] feat: make bridge url fromToken and toToken query params lowercase

### DIFF
--- a/src/Packages/Marketplace/Runtime/Bridge/Bridge.cs
+++ b/src/Packages/Marketplace/Runtime/Bridge/Bridge.cs
@@ -41,13 +41,13 @@ namespace Immutable.Marketplace.Bridge
             var queryParams = new Dictionary<string, string>();
 
             if (!string.IsNullOrEmpty(fromTokenAddress))
-                queryParams["fromToken"] = fromTokenAddress;
+                queryParams["fromToken"] = fromTokenAddress.ToLower();
 
             if (!string.IsNullOrEmpty(fromChain))
                 queryParams["fromChain"] = fromChain;
 
             if (!string.IsNullOrEmpty(toTokenAddress))
-                queryParams["toToken"] = toTokenAddress;
+                queryParams["toToken"] = toTokenAddress.ToLower();
 
             if (!string.IsNullOrEmpty(toChain))
                 queryParams["toChain"] = toChain;


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
At times, the bridge URL doesn't set the from/to tokens correctly. Changing them to lowercase resolves the issue.
