### PR TITLE
[DX-3571] ci: update version gh action to handle alpha releases

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,4 +1,3 @@
----
 name: "Update SDK version"
 
 on:
@@ -13,9 +12,15 @@ on:
           # - major
         required: true
         default: patch
+      mark_as_alpha:
+        type: boolean
+        description: Mark as alpha release
+        required: false
+        default: false
 
 env:
   UPGRADE_TYPE: ${{ github.event.inputs.upgrade_type || 'patch' }}
+  MARK_AS_ALPHA: ${{ github.event.inputs.mark_as_alpha || false }}
 
 jobs:
   update:
@@ -30,7 +35,6 @@ jobs:
       id: check_team
       run: |
         ./.github/scripts/check_team_membership.sh "${{ github.actor }}" "${{ secrets.UNITY_IMMUTABLE_SDK_GITHUB_TOKEN }}"
-        # shellcheck disable=SC1090
         source "$GITHUB_ENV"
         echo "${{ github.actor }} is a member of the SDK team: $IS_MEMBER"
         if [[ "$IS_MEMBER" != "true" ]]; then
@@ -49,33 +53,49 @@ jobs:
     - name: Update Version in package.json
       id: replace_version
       run: |
+        echo "start replacing..."
         PASSPORT_FILE=./src/Packages/Passport/package.json
         MARKETPLACE_FILE=./src/Packages/Marketplace/package.json
         
         CURRENT_VERSION=$(jq -r '.version' $PASSPORT_FILE)
         IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
 
-        # Increment version based on UPGRADE_TYPE
-        case "$UPGRADE_TYPE" in
-          major)
-            MAJOR=$((MAJOR + 1))
-            MINOR=0
-            PATCH=0
-            ;;
-          minor)
+        echo "CURRENT_VERSION $CURRENT_VERSION"
+
+        HAS_ALPHA=$(echo "$CURRENT_VERSION" | grep -o '\.alpha')
+
+        echo "HAS_ALPHA $HAS_ALPHA"
+
+        NEW_VERSION=""
+
+        echo "Check $NEW_VERSION"
+
+        if [[ -n "$HAS_ALPHA" ]]; then
+          # If version is alpha and upgrade type is patch, don't increment patch
+          if [ "$UPGRADE_TYPE" == "patch" ]; then
+            NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+          elif [ "$UPGRADE_TYPE" == "minor" ]; then
             MINOR=$((MINOR + 1))
             PATCH=0
-            ;;
-          patch)
+            NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+          fi
+        else
+          if [ "$UPGRADE_TYPE" == "patch" ]; then
             PATCH=$((PATCH + 1))
-            ;;
-          *)
-            echo "Invalid upgrade type: $UPGRADE_TYPE"
-            exit 1
-            ;;
-        esac
+          elif [ "$UPGRADE_TYPE" == "minor" ]; then
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          fi
+          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+        fi
 
-        NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+        echo "New version $NEW_VERSION"
+
+        if [[ "$MARK_AS_ALPHA" == "true" && -z "$HAS_ALPHA" ]]; then
+          NEW_VERSION="$NEW_VERSION.alpha"
+        fi
+
+        echo "Handled alpha $NEW_VERSION"
 
         # Update Passport package.json
         jq --arg version "$NEW_VERSION" '.version = $version' $PASSPORT_FILE > tmp.$$.json && mv tmp.$$.json $PASSPORT_FILE


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
This PR updates the GitHub Actions workflow to include a new "Mark as alpha release" checkbox. When selected, the updated version will have the `.alpha` suffix unless it already exists.

- Added a `mark_as_alpha` input (boolean checkbox).  
- Adjusted version bumping logic:  
  - If **not marked as alpha**, `.alpha` is removed if present.  
  - If **marked as alpha**, `.alpha` is added if not already present.  
- Ensured correct version increments for both **patch** and **minor** updates. 

Example:

| Current Version | Upgrade Type | Mark as Alpha | New Version |  
|----------------|-------------|---------------|-------------|  
| 1.3.0.alpha   | Patch       | No            | 1.3.0       |  
| 1.3.0.alpha   | Minor       | No            | 1.4.0       |  
| 1.3.0         | Patch       | No            | 1.3.1       |  
| 1.3.0         | Minor       | No            | 1.4.0       |  
| 1.3.0.alpha   | Patch       | Yes           | 1.3.1.alpha |  
| 1.3.0.alpha   | Minor       | Yes           | 1.4.0.alpha |  
| 1.3.0         | Patch       | Yes           | 1.3.1.alpha |  
| 1.3.0         | Minor       | Yes           | 1.4.0.alpha |  