### PR TITLE
[DX-3575] test: fix mac ui requiring keychain access

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -83,6 +83,16 @@ jobs:
       - uses: actions/checkout@v3
         with:
           lfs: true
+      - name: Create temporary keychain
+        if: ${{ matrix.targetPlatform == 'StandaloneOSX' }}
+        run: |
+          security list-keychains
+          security delete-keychain temporary || true
+          security list-keychains
+          security create-keychain -p "" temporary
+          security default-keychain -s temporary
+          security unlock-keychain -p "" temporary
+          security set-keychain-settings -lut 600 temporary
       - uses: actions/download-artifact@v4
         with:
           name: Build-${{ matrix.targetPlatform }}
@@ -114,6 +124,13 @@ jobs:
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
         working-directory: sample/Tests
         run: ${{ matrix.test_script }}
+      - name: Remove temporary keychain
+        if: ${{ matrix.targetPlatform == 'StandaloneOSX' }}
+        run: |
+          security list-keychains
+          security default-keychain -s ~/Library/Keychains/login.keychain-db
+          security delete-keychain temporary
+          security list-keychains
 #   test-ios:
 #     name: Run iOS UI tests 🧪
 #     runs-on: [ self-hosted, macOS ]

--- a/sample/Tests/test/test.py
+++ b/sample/Tests/test/test.py
@@ -49,13 +49,11 @@ class UnityTest(unittest.TestCase):
         # Get access token
         self.altdriver.find_object(By.NAME, "GetAccessTokenBtn").tap()
         text = output.get_text()
-        print(f"GetAccessTokenBtn output: {text}")
         self.assertTrue(len(text) > 50)
 
         # Get ID token
         self.altdriver.find_object(By.NAME, "GetIdTokenBtn").tap()
         text = output.get_text()
-        print(f"GetIdTokenBtn output: {text}")
         self.assertTrue(len(text) > 50)
 
         # Get email


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
- Our SDK needs access to the keychain to retrieve stored tokens. This means that when UI tests are executed, a prompt for the login password appears, which, so far, needs to be entered manually to continue the tests. This PR is to create and use a temporary keychain instead.
- Avoid printing access and ID tokens in tests, even if they're obfuscated by GitHub.