### PR TITLE
[DX-3581] fix: game bridge file cannot be loaded with path has a space

### DIFF
--- a/sample/Packages/packages-lock.json
+++ b/sample/Packages/packages-lock.json
@@ -88,7 +88,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.nuget.newtonsoft-json": {
-      "version": "3.2.1",
+      "version": "3.2.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {},

--- a/sample/ProjectSettings/ProjectSettings.asset
+++ b/sample/ProjectSettings/ProjectSettings.asset
@@ -156,7 +156,7 @@ PlayerSettings:
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
     Android: com.immutable.ImmutableSample
-    Standalone: com.immutable.unitysample
+    Standalone: com.immutable.Immutable-Sample
     iPhone: com.immutable.Immutable-Sample
   buildNumber:
     Standalone: 0
@@ -804,7 +804,7 @@ PlayerSettings:
   allowUnsafeCode: 0
   useDeterministicCompilation: 1
   enableRoslynAnalyzers: 1
-  selectedPlatform: 3
+  selectedPlatform: 0
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
   gcIncremental: 1

--- a/src/Packages/Passport/Runtime/ThirdParty/ImmutableBrowserCore/GameBridge.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/ImmutableBrowserCore/GameBridge.cs
@@ -26,7 +26,6 @@ namespace Immutable.Browser.Core
 #elif UNITY_STANDALONE_OSX
             // macOS
             filePath = SCHEME_FILE + Path.GetFullPath(Application.dataPath) + MAC_DATA_DIRECTORY + PASSPORT_DATA_DIRECTORY_NAME + PASSPORT_HTML_FILE_NAME;
-            filePath = filePath.Replace(" ", "%20");
 #elif UNITY_IPHONE && !UNITY_EDITOR
             // iOS device
             filePath = Path.GetFullPath(Application.dataPath) + PASSPORT_DATA_DIRECTORY_NAME + PASSPORT_HTML_FILE_NAME;
@@ -39,6 +38,7 @@ namespace Immutable.Browser.Core
 #else
             filePath = SCHEME_FILE + Path.GetFullPath(Application.dataPath) + PASSPORT_DATA_DIRECTORY_NAME + PASSPORT_HTML_FILE_NAME;
 #endif
+            filePath = filePath.Replace(" ", "%20");
             return filePath;
         }
     }


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
Resolved game bridge file issue where it wouldn’t load if the project path contained spaces.