### PR TITLE
[DX-3630] ci: disable out mobile ui tests

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -73,9 +73,9 @@ jobs:
           - targetPlatform: StandaloneWindows64
             runs-on: [self-hosted, windows]
             test_script: pytest -xs test/test_windows.py::WindowsTest
-          - targetPlatform: Android
-            runs-on: [ self-hosted, macOS ]
-            test_script: browserstack-sdk pytest -s ./test/test_android.py --browserstack.config "browserstack.android.yml"
+          # - targetPlatform: Android
+          #   runs-on: [ self-hosted, macOS ]
+          #   test_script: browserstack-sdk pytest -s ./test/test_android.py --browserstack.config "browserstack.android.yml"
     concurrency:
       group: test-${{ matrix.targetPlatform }}
     runs-on: ${{ matrix.runs-on }}
@@ -142,16 +142,16 @@ jobs:
       - name: Build iOS app
         working-directory: sample
         run: ./build_ios.sh
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: Install dependencies
-        run: pip install -r "sample/Tests/requirements-mobile.txt"
-      - name: Run UI tests
-        env:
-          MAILSLURP_API_KEY: ${{ secrets.MAILSLURP_API_KEY }}
-          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
-          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-        working-directory: sample/Tests/test/ios
-        run: browserstack-sdk pytest -xs ./test_ios.py --browserstack.config "browserstack.ios.yml"
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: "3.10"
+  #     - name: Install dependencies
+  #       run: pip install -r "sample/Tests/requirements-mobile.txt"
+  #     - name: Run UI tests
+  #       env:
+  #         MAILSLURP_API_KEY: ${{ secrets.MAILSLURP_API_KEY }}
+  #         BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+  #         BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+  #       working-directory: sample/Tests/test/ios
+  #       run: browserstack-sdk pytest -xs ./test_ios.py --browserstack.config "browserstack.ios.yml"
       


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
Disable Mobile UI tests until we upgrade our BrowserStack license.