### PR TITLE
Minor Code Comment & Cleanup

### DIFF
--- a/sample/Assets/Editor/iOSPostBuildProcessor.cs
+++ b/sample/Assets/Editor/iOSPostBuildProcessor.cs
@@ -27,7 +27,7 @@ public class iOSPostBuildProcessor
     private static bool IsCommandLineBuild()
     {
         string[] args = System.Environment.GetCommandLineArgs();
-        return args.Contains("--ciBuild"); // Check for the --ciBuild flag
+        return args.Contains("--ciBuild"); // Checks for the --ciBuild flag
     }
 
     private static void ModifyInfoPlist(string pathToBuiltProject)


### PR DESCRIPTION
Replaced the word:

Check ➝ Checks
Reason: The comment now matches the subject of the sentence — return args.Contains(...) is a statement that "checks", not an imperative instruction "check".