### PR TITLE
[ID-3737] fix: windows pkce cmd errors, protocol name, pkce docs

### DIFF
--- a/sample/Assets/Scenes/Passport/SelectAuthMethod.unity
+++ b/sample/Assets/Scenes/Passport/SelectAuthMethod.unity
@@ -1866,21 +1866,20 @@ MonoBehaviour:
 
 
     1.
-    Authorisation Code Flow with Proof Key for Code Exchange (PKCE) is available
-    for Android, iOS, macOS and WebGL (not officially supported). This method provides
+    Authorisation Code Flow with Proof Key for Code Exchange (PKCE): This method provides
     a seamless and secure authentication experience by opening a pop-up window on
-    macOS or an in-app browser on mobile devices. Players are automatically redirected
+    desktop or an in-app browser on mobile devices. Players are automatically redirected
     back to the game once authenticated, eliminating manual switching.
 
 
     2. Device
-    Code Authorisation is available for Windows, Android, iOS and macOS. This method
+    Code Authorisation: This method
     opens the player''s default browser and guides them through the authentication
     flow.
 
 
     Recommendation: Whenever possible, use the PKCE flow as it is the
-    most secure and seamless method for authentication on Android, iOS and macOS.'
+    most secure and seamless method for authentication.'
 --- !u!222 &1688502351
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/sample/Assets/Scripts/Passport/PassportInitialisation/PassportInitialisationScript.cs
+++ b/sample/Assets/Scripts/Passport/PassportInitialisation/PassportInitialisationScript.cs
@@ -56,7 +56,7 @@ public class PassportInitialisationScript : MonoBehaviour
     /// <summary>
     /// Initialises Passport.
     /// </summary>
-    /// <param name="redirectUri">(Android, iOS and macOS only) The URL to which auth will redirect the browser after 
+    /// <param name="redirectUri">The URL to which auth will redirect the browser after 
     /// authorisation has been granted by the user</param>
     /// <param name="logoutRedirectUri">The URL to which auth will redirect the browser
     /// after log out is complete</param>

--- a/sample/Assets/Scripts/Passport/_tutorials~/PassportInitialisation/tutorial.md
+++ b/sample/Assets/Scripts/Passport/_tutorials~/PassportInitialisation/tutorial.md
@@ -75,7 +75,7 @@ For PKCE authentication, the redirect URIs must be configured correctly based on
 ### Prerequisites
 - Create an Immutable Hub account and get your client ID from [Immutable Hub](https://hub.immutable.com)
 - Set up the Unity project with the Immutable Passport SDK
-- Configure your project for the appropriate platform (WebGL, Android, iOS, macOS, Windows)
+- Configure your project for the appropriate platform
 
 ### Steps to Run the Example
 1. Open the Unity project and load the sample scene for Passport Initialisation

--- a/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
@@ -137,7 +137,7 @@ namespace Immutable.Passport
         /// </summary>
         /// <param name="clientId">The client ID</param>
         /// <param name="environment">The environment to connect to</param>
-        /// <param name="redirectUri">(Android, iOS, and macOS only) The URL where the browser will redirect after successful authentication.</param>
+        /// <param name="redirectUri">The URL where the browser will redirect after successful authentication.</param>
         /// <param name="logoutRedirectUri">The URL where the browser will redirect after logout is complete.</param>
         /// <param name="engineStartupTimeoutMs">(Windows only) Timeout duration in milliseconds to wait for the default Windows browser engine to start.</param>
         /// <param name="webBrowserClient">(Windows only) Custom Windows browser to use instead of the default browser in the SDK.</param>

--- a/src/Packages/Passport/Samples~/SamplesScenesScripts/Scenes/Passport/SelectAuthMethod.unity
+++ b/src/Packages/Passport/Samples~/SamplesScenesScripts/Scenes/Passport/SelectAuthMethod.unity
@@ -1822,15 +1822,14 @@ MonoBehaviour:
 
 
     1.
-    Authorisation Code Flow with Proof Key for Code Exchange (PKCE) is available
-    for Android, iOS, macOS and WebGL (not officially supported). This method provides
+    Authorisation Code Flow with Proof Key for Code Exchange (PKCE): This method provides
     a seamless and secure authentication experience by opening a pop-up window on
     macOS or an in-app browser on mobile devices. Players are automatically redirected
     back to the game once authenticated, eliminating manual switching.
 
 
     2. Device
-    Code Authorisation is available for Windows, Android, iOS and macOS. This method
+    Code Authorisation: This method
     opens the player''s default browser and guides them through the authentication
     flow.
 

--- a/src/Packages/Passport/Samples~/SamplesScenesScripts/Scripts/Passport/SelectAuthMethodScript.cs
+++ b/src/Packages/Passport/Samples~/SamplesScenesScripts/Scripts/Passport/SelectAuthMethodScript.cs
@@ -56,7 +56,7 @@ public class SelectAuthMethodScript : MonoBehaviour
     /// <summary>
     /// Initialises Passport.
     /// </summary>
-    /// <param name="redirectUri">(Android, iOS and macOS only) The URL to which auth will redirect the browser after 
+    /// <param name="redirectUri">The URL to which auth will redirect the browser after 
     /// authorisation has been granted by the user</param>
     /// <param name="logoutRedirectUri">The URL to which auth will redirect the browser
     /// after log out is complete</param>


### PR DESCRIPTION
# Summary
- Fixed command prompt errors when printing logs during PKCE authentication on Windows  
- During browser redirection on Windows, the open prompt will display the correct app name without the `.cmd` extension  
- Corrected documentation related to PKCE  

# Customer Impact
- PKCE flow on Windows now logs cleanly without printing errors to the command prompt window  
- Updated Windows default protocol name to use the application name  
- Improved documentation makes PKCE setup and usage clearer

