### PR TITLE
[ID-3839] fix: uwb log level

### DIFF
--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/dev.voltstro.unitywebbrowser@2.2.5/Runtime/Logging/DefaultUnityWebBrowserLogger.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/dev.voltstro.unitywebbrowser@2.2.5/Runtime/Logging/DefaultUnityWebBrowserLogger.cs
@@ -7,6 +7,7 @@
 
 using System;
 using UnityEngine;
+using VoltstroStudios.UnityWebBrowser.Shared;
 
 namespace VoltstroStudios.UnityWebBrowser.Logging
 {
@@ -18,6 +19,8 @@ namespace VoltstroStudios.UnityWebBrowser.Logging
         private const string LoggingTag = "[UWB]";
 
         private readonly ILogger logger;
+
+        private LogSeverity logSeverity;
         
         /// <summary>
         /// A function that defines how sensitive data should be redacted.
@@ -25,25 +28,34 @@ namespace VoltstroStudios.UnityWebBrowser.Logging
         /// </summary>
         public Func<string, string>? redactionHandler;
 
-        public DefaultUnityWebBrowserLogger(Func<string, string>? redactionHandler = null)
+        public DefaultUnityWebBrowserLogger(LogSeverity logSeverity = LogSeverity.Info, Func<string, string>? redactionHandler = null)
         {
             logger = UnityEngine.Debug.unityLogger;
+            this.logSeverity = logSeverity;
             this.redactionHandler = redactionHandler;
         }
 
         public void Debug(object message)
         {
-            logger.Log(LogType.Log, LoggingTag, redactIfRequired(message));
+            if (ShouldLog(LogSeverity.Debug))
+                logger.Log(LogType.Log, LoggingTag, redactIfRequired(message));
         }
 
         public void Warn(object message)
         {
-            logger.LogWarning(LoggingTag, redactIfRequired(message));
+            if (ShouldLog(LogSeverity.Warn))
+                logger.LogWarning(LoggingTag, redactIfRequired(message));
         }
 
         public void Error(object message)
         {
-            logger.LogError(LoggingTag, redactIfRequired(message));
+            if (ShouldLog(LogSeverity.Error))
+                logger.LogError(LoggingTag, redactIfRequired(message));
+        }
+        
+        private bool ShouldLog(LogSeverity severity)
+        {
+            return severity >= logSeverity;
         }
 
         private object redactIfRequired(object message)

--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/dev.voltstro.unitywebbrowser@2.2.5/Runtime/UwbWebView.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/dev.voltstro.unitywebbrowser@2.2.5/Runtime/UwbWebView.cs
@@ -43,16 +43,17 @@ namespace VoltstroStudios.UnityWebBrowser
             webBrowserClient.noSandbox = true;
 
             // Log level
-            webBrowserClient.logSeverity = PassportLogger.CurrentLogLevel switch
+            var logSeverity = PassportLogger.CurrentLogLevel switch
             {
                 LogLevel.Debug => LogSeverity.Debug,
                 LogLevel.Warn => LogSeverity.Warn,
                 LogLevel.Error => LogSeverity.Error,
                 _ => LogSeverity.Info
             };
+            webBrowserClient.logSeverity = logSeverity;
 
             // Logger
-            webBrowserClient.Logger = new DefaultUnityWebBrowserLogger(redactionHandler: redactTokensInLogs ? redactionHandler : null);
+            webBrowserClient.Logger = new DefaultUnityWebBrowserLogger(logSeverity: logSeverity, redactionHandler: redactTokensInLogs ? redactionHandler : null);
 
             // Js
             webBrowserClient.jsMethodManager = new JsMethodManager { jsMethodsEnable = true };


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
Fixed an issue where the Windows WebView did not respect the log level configured in Passport when running in the Unity Editor, as reported in #513.

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->
Log filtering now works correctly in the Windows Unity Editor.

# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [x] Replied to GitHub issues
