### PR TITLE
[ID-3854] fix: windows uwb cache path

### DIFF
--- a/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/dev.voltstro.unitywebbrowser@2.2.5/Runtime/Helper/WebBrowserUtils.cs
+++ b/src/Packages/Passport/Runtime/ThirdParty/UnityWebBrowser/dev.voltstro.unitywebbrowser@2.2.5/Runtime/Helper/WebBrowserUtils.cs
@@ -43,10 +43,8 @@ namespace VoltstroStudios.UnityWebBrowser.Helper
         {
 #if UNITY_EDITOR
             return Path.GetFullPath(Path.Combine(Directory.GetParent(Application.dataPath)!.FullName, "Library"));
-#elif UNITY_STANDALONE_OSX
-            return Application.persistentDataPath;
 #else
-			return Application.dataPath;
+			return Application.persistentDataPath;
 #endif
         }
 


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
Fixes Windows WebView cache directory location to avoid requiring admin mode when games are installed via an installer or into Program Files.

[ID-3854](https://immutable.atlassian.net/browse/ID-3854)

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->
Fixed WebView cache issue on Windows that required admin mode when games are installed via an installer.
