### PR TITLE
fix: login failures on window il2cpp builds

### DIFF
--- a/src/Packages/Passport/Runtime/Scripts/Private/Helpers/WindowsDeepLink.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Helpers/WindowsDeepLink.cs
@@ -275,6 +275,8 @@ namespace Immutable.Passport.Helpers
             if (suffix == ".exe")
             {
                 // Get the path of the currently running executable
+#if !ENABLE_IL2CPP
+                // Process.MainModule is only supported in Mono builds, not in IL2CPP, and will cause a crash
                 try
                 {
                     var process = System.Diagnostics.Process.GetCurrentProcess();
@@ -291,6 +293,7 @@ namespace Immutable.Passport.Helpers
                 {
                     PassportLogger.Warn($"Process inaccessible: {ex.Message}. Using fallback method.");
                 }
+#endif
 
                 // Fallback: Use command line args
                 var args = System.Environment.GetCommandLineArgs();


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
Fix login crash in Windows IL2CPP builds. By replacing unsupported `Process.MainModule` API with IL2CPP-compatible `Environment.GetCommandLineArgs()`

Jira: [ID-3951](https://immutable.atlassian.net/browse/ID-3951)

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->
This fix resolves login failures that prevent the SDK from working in Windows Standalone IL2CPP builds. Customers can now successfully use the login functionality in production Windows IL2CPP builds without crashing.

<!-- Remove the H2 sections as required -->
## Added 
<!-- Section for new features. -->


## Changed
<!-- Section for changes in existing functionality. -->


## Deprecated
<!-- Section for soon-to-be removed features. -->


## Removed
<!-- Section for now removed features. -->


## Fixed
<!-- Section for any bug fixes. -->
- Fixed IL2CPP crash during login caused by unsupported `Process.MainModule` API



## Security
<!-- Section in case of vulnerabilities. -->




# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [ ] Sample app is updated with new SDK changes
- [ ] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unity) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unity))
- [ ] Sample game is updated with new SDK changes
- [ ] Replied to GitHub issues


[ID-3951]: https://immutable.atlassian.net/browse/ID-3951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ