### PR TITLE
feat: byoa complete login

### DIFF
--- a/src/Packages/Passport/Runtime/Scripts/Private/Core/Model/BrowserResponse.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Core/Model/BrowserResponse.cs
@@ -8,12 +8,12 @@ namespace Immutable.Passport.Core
         public string requestId;
         public bool success;
         public string errorType;
-        public string error;
+        public string? error;
     }
 
     public class StringResponse : BrowserResponse
     {
-        public string result;
+        public string? result;
     }
 
     public class StringListResponse : BrowserResponse

--- a/src/Packages/Passport/Runtime/Scripts/Private/Model/Response/TokenResponse.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/Model/Response/TokenResponse.cs
@@ -5,10 +5,10 @@ namespace Immutable.Passport.Model
     [Serializable]
     public class TokenResponse
     {
-        public string accessToken;
-        public string refreshToken;
-        public string idToken;
-        public string tokenType;
-        public int expiresIn;
+        public string access_token;
+        public string refresh_token;
+        public string id_token;
+        public string token_type;
+        public int expires_in;
     }
 }

--- a/src/Packages/Passport/Runtime/Scripts/Private/PassportFunction.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/PassportFunction.cs
@@ -14,6 +14,7 @@ namespace Immutable.Passport
         public const string GET_EMAIL = "getEmail";
         public const string GET_PASSPORT_ID = "getPassportId";
         public const string GET_LINKED_ADDRESSES = "getLinkedAddresses";
+        public const string STORE_TOKENS = "storeTokens";
         public static class IMX
         {
             public const string GET_ADDRESS = "getAddress";

--- a/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Private/PassportImpl.cs
@@ -519,6 +519,13 @@ namespace Immutable.Passport
             }
         }
 
+        public async UniTask<bool> CompleteLogin(TokenResponse request)
+        {
+            var json = JsonUtility.ToJson(request);
+            var callResponse = await _communicationsManager.Call(PassportFunction.STORE_TOKENS, json);
+            return callResponse.GetBoolResponse() ?? false;
+        }
+
         public async UniTask<string?> GetAddress()
         {
             var response = await _communicationsManager.Call(PassportFunction.IMX.GET_ADDRESS);

--- a/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
+++ b/src/Packages/Passport/Runtime/Scripts/Public/Passport.cs
@@ -314,6 +314,19 @@ namespace Immutable.Passport
         }
 
         /// <summary>
+        /// Completes the login process by storing tokens received from the Bring Your Own Auth API token exchange endpoint.
+        /// This method enables authentication using existing auth systems without requiring users to log in twice.q
+        /// </summary>
+        /// <param name="request">The token request</param>
+        /// <returns>
+        /// True if successful, otherwise false.
+        /// </returns>
+        public async UniTask<bool> CompleteLogin(TokenResponse request)
+        {
+            return await GetPassportImpl().CompleteLogin(request);
+        }
+
+        /// <summary>
         /// Gets the wallet address of the logged in user.
         /// <returns>
         /// The wallet address


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
Add `CompleteLogin` function to enable Bring Your Own Auth (BYOA) token-based authentication.

[ID-4021](https://immutable.atlassian.net/browse/ID-4021)

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->
Enables developers to authenticate users with tokens from existing auth systems, eliminating the need for double login when integrating Passport.

Notes: This is a preview version of BYOA and may be subject to change.

# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [x] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unity) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unity))


[ID-4021]: https://immutable.atlassian.net/browse/ID-4021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ