### PR TITLE
feat(audience): scaffold com.immutable.audience package

### DIFF
--- a/src/Packages/Audience/Runtime.meta
+++ b/src/Packages/Audience/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2511325fa9ee4969836f4998d41f3882
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -1,0 +1,12 @@
+namespace Immutable.Audience
+{
+    /// <summary>
+    /// Entry point for the Immutable Audience SDK.
+    /// Call Init once on startup, then use the static methods from any thread.
+    /// </summary>
+    public static class ImmutableAudience
+    {
+        // Core types (AudienceConfig, ConsentLevel, AudienceError) and Init
+        // are added in the next PR once those types exist. See SDK-119.
+    }
+}

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs.meta
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e8335985aa845dbb0edd341b6b4ecd4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/com.immutable.audience.asmdef
+++ b/src/Packages/Audience/Runtime/com.immutable.audience.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "Immutable.Audience.Runtime",
+    "rootNamespace": "Immutable.Audience",
+    "references": [],
+    "includePlatforms": ["Editor","LinuxStandalone64","macOSStandalone","WindowsStandalone64"],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/src/Packages/Audience/Runtime/com.immutable.audience.asmdef.meta
+++ b/src/Packages/Audience/Runtime/com.immutable.audience.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8971b777bbd7472ebd996d8bf0b7c15e
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests.meta
+++ b/src/Packages/Audience/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 251674eb0cf9421e8bf694129c6b451e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime.meta
+++ b/src/Packages/Audience/Tests/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 55f86f905be540d09df0fd6a690bdc9d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/com.immutable.audience.tests.asmdef
+++ b/src/Packages/Audience/Tests/Runtime/com.immutable.audience.tests.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "Immutable.Audience.Runtime.Tests",
+    "rootNamespace": "Immutable.Audience.Tests",
+    "references": ["Immutable.Audience.Runtime"],
+    "includePlatforms": ["Editor"],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/src/Packages/Audience/Tests/Runtime/com.immutable.audience.tests.asmdef.meta
+++ b/src/Packages/Audience/Tests/Runtime/com.immutable.audience.tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c35534c7dc7d4e22a35695430846d00d
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/package.json
+++ b/src/Packages/Audience/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "com.immutable.audience",
+  "version": "0.1.0",
+  "description": "Immutable Audience SDK for Unity.",
+  "displayName": "Immutable Audience",
+  "author": {"name": "Immutable", "url": "https://immutable.com"},
+  "keywords": ["unity", "immutable", "audience", "analytics"],
+  "unity": "2021.3"
+}

--- a/src/Packages/Audience/package.json.meta
+++ b/src/Packages/Audience/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e7ff7ed86c4d4f3bae6aad4cc6ba03f4
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

Adds `src/Packages/Audience/` — the `com.immutable.audience` UPM package alongside the existing Passport package. Scaffold only; no runtime logic.

Core types (`AudienceConfig`, `ConsentLevel`, `AudienceError`, `Constants`) follow in immutable/unity-immutable-sdk#682 to keep each change reviewable.

https://linear.app/imtbl/issue/SDK-118/scaffold-comimmutableaudience-package-structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)