### PR TITLE
feat(audience): MessageBuilder — wire-format message construction (SDK-129)

### DIFF
--- a/src/Packages/Audience/Runtime/Events/MessageBuilder.cs
+++ b/src/Packages/Audience/Runtime/Events/MessageBuilder.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+
+namespace Immutable.Audience
+{
+    internal static class MessageBuilder
+    {
+        internal static Dictionary<string, object> Track(
+            string eventName,
+            string anonymousId,
+            string userId,
+            string packageVersion,
+            Dictionary<string, object> properties = null)
+        {
+            var msg = BuildBase("track", packageVersion);
+            msg["eventName"] = Truncate(eventName, 256);
+
+            if (!string.IsNullOrEmpty(anonymousId))
+                msg["anonymousId"] = Truncate(anonymousId, 256);
+
+            if (!string.IsNullOrEmpty(userId))
+                msg["userId"] = Truncate(userId, 256);
+
+            if (properties != null && properties.Count > 0)
+                msg["properties"] = properties;
+
+            return msg;
+        }
+
+        internal static Dictionary<string, object> Identify(
+            string anonymousId,
+            string userId,
+            string identityType,
+            string packageVersion,
+            Dictionary<string, object> traits = null)
+        {
+            var msg = BuildBase("identify", packageVersion);
+
+            if (!string.IsNullOrEmpty(anonymousId))
+                msg["anonymousId"] = Truncate(anonymousId, 256);
+
+            if (!string.IsNullOrEmpty(userId))
+                msg["userId"] = Truncate(userId, 256);
+
+            if (!string.IsNullOrEmpty(identityType))
+                msg["identityType"] = identityType;
+
+            if (traits != null && traits.Count > 0)
+                msg["traits"] = traits;
+
+            return msg;
+        }
+
+        internal static Dictionary<string, object> Alias(
+            string fromId,
+            string fromType,
+            string toId,
+            string toType,
+            string packageVersion)
+        {
+            var msg = BuildBase("alias", packageVersion);
+            msg["fromId"] = Truncate(fromId, 256);
+            msg["fromType"] = fromType;
+            msg["toId"] = Truncate(toId, 256);
+            msg["toType"] = toType;
+            return msg;
+        }
+
+        private static Dictionary<string, object> BuildBase(string type, string packageVersion)
+        {
+            return new Dictionary<string, object>
+            {
+                ["type"] = type,
+                ["messageId"] = Guid.NewGuid().ToString(),
+                ["eventTimestamp"] = DateTime.UtcNow.ToString("o"),
+                ["context"] = new Dictionary<string, object>
+                {
+                    ["library"] = Constants.LibraryName,
+                    ["libraryVersion"] = Truncate(packageVersion, 256)
+                },
+                ["surface"] = Constants.Surface
+            };
+        }
+
+        private static string Truncate(string s, int maxLen)
+        {
+            if (s == null || s.Length <= maxLen)
+                return s;
+            return s.Substring(0, maxLen);
+        }
+    }
+}

--- a/src/Packages/Audience/Runtime/Events/MessageBuilder.cs
+++ b/src/Packages/Audience/Runtime/Events/MessageBuilder.cs
@@ -43,7 +43,7 @@ namespace Immutable.Audience
                 msg["userId"] = Truncate(userId, 256);
 
             if (!string.IsNullOrEmpty(identityType))
-                msg["identityType"] = identityType;
+                msg["identityType"] = Truncate(identityType, 256);
 
             if (traits != null && traits.Count > 0)
                 msg["traits"] = traits;
@@ -60,9 +60,9 @@ namespace Immutable.Audience
         {
             var msg = BuildBase("alias", packageVersion);
             msg["fromId"] = Truncate(fromId, 256);
-            msg["fromType"] = fromType;
+            msg["fromType"] = Truncate(fromType, 256);
             msg["toId"] = Truncate(toId, 256);
-            msg["toType"] = toType;
+            msg["toType"] = Truncate(toType, 256);
             return msg;
         }
 

--- a/src/Packages/Audience/Tests/Runtime/MessageBuilderTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/MessageBuilderTests.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Immutable.Audience.Tests
+{
+    [TestFixture]
+    public class MessageBuilderTests
+    {
+        private const string PackageVersion = "1.2.3";
+
+        [Test]
+        public void Track_RequiredFieldsPresent()
+        {
+            var result = MessageBuilder.Track("level_complete", "anon-1", null, PackageVersion);
+
+            Assert.AreEqual("track", result["type"]);
+            Assert.IsTrue(result.ContainsKey("messageId"));
+            Assert.IsTrue(result.ContainsKey("eventTimestamp"));
+            Assert.IsTrue(result.ContainsKey("context"));
+            Assert.IsTrue(result.ContainsKey("surface"));
+            Assert.AreEqual("level_complete", result["eventName"]);
+        }
+
+        [Test]
+        public void Track_EventNameLongerThan256Chars_TruncatedTo256()
+        {
+            var longName = new string('x', 300);
+
+            var result = MessageBuilder.Track(longName, null, null, PackageVersion);
+
+            Assert.AreEqual(256, ((string)result["eventName"]).Length);
+        }
+
+        [Test]
+        public void Track_NullUserId_NotPresentInDict()
+        {
+            var result = MessageBuilder.Track("evt", "anon-1", null, PackageVersion);
+
+            Assert.IsFalse(result.ContainsKey("userId"));
+        }
+
+        [Test]
+        public void Track_NonNullUserId_PresentInDict()
+        {
+            var result = MessageBuilder.Track("evt", "anon-1", "user-99", PackageVersion);
+
+            Assert.IsTrue(result.ContainsKey("userId"));
+            Assert.AreEqual("user-99", result["userId"]);
+        }
+
+        [Test]
+        public void Identify_TypeAndIdentityFieldsPresent()
+        {
+            var result = MessageBuilder.Identify("anon-42", "user-42", "steam", PackageVersion);
+
+            Assert.AreEqual("identify", result["type"]);
+            Assert.AreEqual("anon-42", result["anonymousId"]);
+            Assert.AreEqual("user-42", result["userId"]);
+            Assert.AreEqual("steam", result["identityType"]);
+        }
+
+        [Test]
+        public void Alias_AllFourFieldsPresent()
+        {
+            var result = MessageBuilder.Alias("from-id", "email", "to-id", "steam", PackageVersion);
+
+            Assert.AreEqual("alias", result["type"]);
+            Assert.AreEqual("from-id", result["fromId"]);
+            Assert.AreEqual("email", result["fromType"]);
+            Assert.AreEqual("to-id", result["toId"]);
+            Assert.AreEqual("steam", result["toType"]);
+        }
+
+        [Test]
+        public void AllMessages_ContextContainsLibraryAndLibraryVersion()
+        {
+            var track = MessageBuilder.Track("evt", null, null, PackageVersion);
+            var identify = MessageBuilder.Identify(null, "u1", null, PackageVersion);
+            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", PackageVersion);
+
+            foreach (var msg in new[] { track, identify, alias })
+            {
+                var ctx = (Dictionary<string, object>)msg["context"];
+                Assert.AreEqual(Constants.LibraryName, ctx["library"]);
+                Assert.AreEqual(PackageVersion, ctx["libraryVersion"]);
+            }
+        }
+
+        [Test]
+        public void AllMessages_SurfaceIsUnity()
+        {
+            var track = MessageBuilder.Track("evt", null, null, PackageVersion);
+            var identify = MessageBuilder.Identify(null, "u1", null, PackageVersion);
+            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", PackageVersion);
+
+            Assert.AreEqual("unity", track["surface"]);
+            Assert.AreEqual("unity", identify["surface"]);
+            Assert.AreEqual("unity", alias["surface"]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `MessageBuilder.cs` to `Runtime/Events/` — builds wire-format `Dictionary<string, object>` payloads matching backend OAS schema
- Supports `track`, `identify`, and `alias` message types
- Auto-sets required fields on every message: `messageId`, `eventTimestamp`, `context`, `surface`
- Field truncation enforced per backend constraints (256 char limits)

## Test plan
- [ ] Track: required fields present, truncation applied
- [ ] Identify: identity fields set correctly
- [ ] Alias: from/to fields set correctly
- [ ] All messages: context.library, context.libraryVersion, surface present

Linear: SDK-129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new isolated message-construction utility and tests without modifying existing runtime behavior; risk is mainly schema/field-mapping correctness.
> 
> **Overview**
> Adds a new internal `MessageBuilder` that constructs wire-format `Dictionary<string, object>` payloads for `track`, `identify`, and `alias` events, including shared metadata (`messageId`, `eventTimestamp`, `context.library`/`libraryVersion`, and `surface`).
> 
> Applies 256-character truncation to key string fields and omits optional identifiers/traits/properties when null or empty. Adds NUnit coverage to verify required fields, truncation behavior, and consistent `context`/`surface` across message types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 415a800a635f0d8a9d7d909782eb7b4bd7fb8d2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->