### PR TITLE
feat(audience): add DiskStore and EventQueue for persistent event batching (SDK-127)

### DIFF
--- a/src/Packages/Audience/Runtime/Transport.meta
+++ b/src/Packages/Audience/Runtime/Transport.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b7e3a1f2d4c548a89e5f6b7c8d9e0f1a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Runtime/Transport/DiskStore.cs
+++ b/src/Packages/Audience/Runtime/Transport/DiskStore.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Immutable.Audience
+{
+    /// <summary>
+    /// File-per-event persistent store. Each event is written as an atomic
+    /// <c>{ticks}_{uuid}.json</c> file inside <c>imtbl_audience/queue/</c>.
+    /// </summary>
+    internal sealed class DiskStore
+    {
+        private readonly string _queueDir;
+
+        internal DiskStore(string persistentDataPath)
+        {
+            _queueDir = Path.Combine(persistentDataPath, "imtbl_audience", "queue");
+            Directory.CreateDirectory(_queueDir);
+        }
+
+        /// <summary>Atomically writes <paramref name="json"/> as a new event file.</summary>
+        internal void Write(string json)
+        {
+            var fileName = $"{DateTime.UtcNow.Ticks}_{Guid.NewGuid():N}.json";
+            var finalPath = Path.Combine(_queueDir, fileName);
+            var tmpPath = finalPath + ".tmp";
+
+            File.WriteAllText(tmpPath, json);
+
+            try
+            {
+                File.Move(tmpPath, finalPath);
+            }
+            catch (IOException)
+            {
+                // Destination already exists (unlikely but safe to handle)
+                File.Delete(finalPath);
+                File.Move(tmpPath, finalPath);
+            }
+        }
+
+        /// <summary>
+        /// Returns up to <paramref name="maxSize"/> file paths, oldest first.
+        /// Files older than <see cref="Constants.StaleEventDays"/> days are deleted and excluded.
+        /// </summary>
+        internal IReadOnlyList<string> ReadBatch(int maxSize)
+        {
+            if (maxSize <= 0)
+                return Array.Empty<string>();
+
+            maxSize = Math.Min(maxSize, Constants.MaxBatchSize);
+
+            var cutoff = DateTime.UtcNow.AddDays(-Constants.StaleEventDays);
+
+            var result = new List<string>();
+
+            // Sort by filename (ticks prefix) → oldest first
+            var files = Directory.GetFiles(_queueDir, "*.json")
+                .OrderBy(f => Path.GetFileName(f), StringComparer.Ordinal);
+
+            foreach (var path in files)
+            {
+                if (result.Count >= maxSize)
+                    break;
+
+                // Stale check: parse ticks from filename prefix
+                var name = Path.GetFileNameWithoutExtension(path);
+                var underscoreIdx = name.IndexOf('_');
+                if (underscoreIdx > 0 && long.TryParse(name.Substring(0, underscoreIdx), out var ticks))
+                {
+                    var fileTime = new DateTime(ticks, DateTimeKind.Utc);
+                    if (fileTime < cutoff)
+                    {
+                        TryDelete(path);
+                        continue;
+                    }
+                }
+
+                result.Add(path);
+            }
+
+            return result;
+        }
+
+        /// <summary>Deletes the event files at <paramref name="paths"/>.</summary>
+        internal void Delete(IEnumerable<string> paths)
+        {
+            foreach (var path in paths)
+                TryDelete(path);
+        }
+
+        /// <summary>Returns the total number of event files currently on disk.</summary>
+        internal int Count() => Directory.GetFiles(_queueDir, "*.json").Length;
+
+        private static void TryDelete(string path)
+        {
+            try { File.Delete(path); }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+}

--- a/src/Packages/Audience/Runtime/Transport/DiskStore.cs.meta
+++ b/src/Packages/Audience/Runtime/Transport/DiskStore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8f4b2e1a3d547b09f6e7c8d9a0b1c2d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Runtime/Transport/EventQueue.cs
+++ b/src/Packages/Audience/Runtime/Transport/EventQueue.cs
@@ -26,7 +26,8 @@ namespace Immutable.Audience
         private readonly Thread _drainThread;
         private readonly ManualResetEventSlim _flushGate = new ManualResetEventSlim(false);
 
-        private bool _disposed;
+        // Volatile so all threads see the shutdown signal immediately.
+        private volatile bool _disposed;
 
         /// <param name="store">Pre-created <see cref="DiskStore"/> for this queue.</param>
         /// <param name="flushIntervalSeconds">How often to drain to disk regardless of batch size.</param>
@@ -73,11 +74,18 @@ namespace Immutable.Audience
         internal void Shutdown()
         {
             if (_disposed) return;
-            _cts.Cancel();
-            _flushGate.Set(); // Wake drain thread so it exits promptly
-            _drainThread.Join(TimeSpan.FromSeconds(5));
-            DrainMemoryToDisk(); // Final drain after thread stops
+
+            // Stop accepting new events first — closes the race window where
+            // events enqueued between Cancel and final drain would be lost.
             _disposed = true;
+
+            // Signal the drain thread to exit, then wait for it.
+            _cts.Cancel();
+            _flushGate.Set();
+            _drainThread.Join(TimeSpan.FromSeconds(5));
+
+            // Final drain: anything enqueued before _disposed was set.
+            DrainMemoryToDisk();
         }
 
         // -----------------------------------------------------------------

--- a/src/Packages/Audience/Runtime/Transport/EventQueue.cs
+++ b/src/Packages/Audience/Runtime/Transport/EventQueue.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Immutable.Audience
+{
+    /// <summary>
+    /// Thread-safe, disk-persistent batch event queue for the Audience SDK.
+    ///
+    /// <para>Enqueue is lock-free and safe to call from any thread. A background
+    /// drain thread moves events from the in-memory <see cref="ConcurrentQueue{T}"/>
+    /// to <see cref="DiskStore"/>, flushing either on a time interval or when the
+    /// in-memory batch reaches <see cref="AudienceConfig.FlushSize"/>.</para>
+    ///
+    /// <para>Call <see cref="Shutdown"/> before process exit to flush remaining events
+    /// and stop the drain thread cleanly.</para>
+    /// </summary>
+    internal sealed class EventQueue : IDisposable
+    {
+        private readonly DiskStore _store;
+        private readonly int _flushIntervalMs;
+        private readonly int _flushSize;
+
+        private readonly ConcurrentQueue<string> _memory = new ConcurrentQueue<string>();
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        private readonly Thread _drainThread;
+        private readonly ManualResetEventSlim _flushGate = new ManualResetEventSlim(false);
+
+        private bool _disposed;
+
+        /// <param name="store">Pre-created <see cref="DiskStore"/> for this queue.</param>
+        /// <param name="flushIntervalSeconds">How often to drain to disk regardless of batch size.</param>
+        /// <param name="flushSize">Drain to disk immediately when this many events are queued.</param>
+        internal EventQueue(DiskStore store, int flushIntervalSeconds, int flushSize)
+        {
+            _store = store ?? throw new ArgumentNullException(nameof(store));
+            _flushIntervalMs = Math.Max(1, flushIntervalSeconds) * 1000;
+            _flushSize = Math.Max(1, flushSize);
+
+            _drainThread = new Thread(DrainLoop)
+            {
+                IsBackground = true,
+                Name = "imtbl-audience-drain"
+            };
+            _drainThread.Start();
+        }
+
+        /// <summary>Enqueues a JSON-serialised event. Lock-free; safe from any thread.</summary>
+        internal void Enqueue(string json)
+        {
+            if (_disposed) return;
+
+            _memory.Enqueue(json);
+
+            // Signal the drain thread early if we've hit the flush-size threshold
+            if (_memory.Count >= _flushSize)
+                _flushGate.Set();
+        }
+
+        /// <summary>
+        /// Drains the in-memory queue and persists all events to disk immediately.
+        /// Blocks until the drain is complete.
+        /// </summary>
+        internal void FlushAsync()
+        {
+            DrainMemoryToDisk();
+        }
+
+        /// <summary>
+        /// Flushes all pending events to disk and stops the drain thread.
+        /// Safe to call multiple times.
+        /// </summary>
+        internal void Shutdown()
+        {
+            if (_disposed) return;
+            _cts.Cancel();
+            _flushGate.Set(); // Wake drain thread so it exits promptly
+            _drainThread.Join(TimeSpan.FromSeconds(5));
+            DrainMemoryToDisk(); // Final drain after thread stops
+            _disposed = true;
+        }
+
+        // -----------------------------------------------------------------
+        // Background drain loop
+        // -----------------------------------------------------------------
+
+        private void DrainLoop()
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                // Wait for flush gate or interval timeout
+                _flushGate.Wait(_flushIntervalMs);
+                _flushGate.Reset();
+
+                if (_cts.IsCancellationRequested)
+                    break;
+
+                DrainMemoryToDisk();
+            }
+        }
+
+        private void DrainMemoryToDisk()
+        {
+            while (_memory.TryDequeue(out var json))
+            {
+                try
+                {
+                    _store.Write(json);
+                }
+                catch (Exception)
+                {
+                    // Best-effort: if we can't write, discard rather than block the drain
+                }
+            }
+        }
+
+        // -----------------------------------------------------------------
+        // IDisposable
+        // -----------------------------------------------------------------
+
+        public void Dispose()
+        {
+            Shutdown();
+            _cts.Dispose();
+            _flushGate.Dispose();
+        }
+    }
+}

--- a/src/Packages/Audience/Runtime/Transport/EventQueue.cs
+++ b/src/Packages/Audience/Runtime/Transport/EventQueue.cs
@@ -62,7 +62,7 @@ namespace Immutable.Audience
         /// Drains the in-memory queue and persists all events to disk immediately.
         /// Blocks until the drain is complete.
         /// </summary>
-        internal void FlushAsync()
+        internal void FlushSync()
         {
             DrainMemoryToDisk();
         }

--- a/src/Packages/Audience/Runtime/Transport/EventQueue.cs.meta
+++ b/src/Packages/Audience/Runtime/Transport/EventQueue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d9e5c3f2b4e658c10a7f8d9e0b1c2d3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Tests/Runtime/DiskStoreTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/DiskStoreTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+
+namespace Immutable.Audience.Tests
+{
+    [TestFixture]
+    internal class DiskStoreTests
+    {
+        private string _testDir;
+        private DiskStore _store;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _testDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(_testDir);
+            _store = new DiskStore(_testDir);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(_testDir))
+                Directory.Delete(_testDir, recursive: true);
+        }
+
+        [Test]
+        public void Write_CreatesJsonFile_InQueueDirectory()
+        {
+            _store.Write("{\"event\":\"test\"}");
+
+            var queueDir = Path.Combine(_testDir, "imtbl_audience", "queue");
+            var files = Directory.GetFiles(queueDir, "*.json");
+            Assert.AreEqual(1, files.Length, "should have written exactly one event file");
+        }
+
+        [Test]
+        public void Write_FileContents_MatchInputJson()
+        {
+            const string json = "{\"event\":\"pageview\",\"userId\":\"u1\"}";
+            _store.Write(json);
+
+            var queueDir = Path.Combine(_testDir, "imtbl_audience", "queue");
+            var file = Directory.GetFiles(queueDir, "*.json").Single();
+            Assert.AreEqual(json, File.ReadAllText(file));
+        }
+
+        [Test]
+        public void ReadBatch_ReturnsOldestFirst()
+        {
+            // Write events with a small delay to guarantee different ticks in filenames
+            _store.Write("{\"seq\":1}");
+            Thread.Sleep(10);
+            _store.Write("{\"seq\":2}");
+            Thread.Sleep(10);
+            _store.Write("{\"seq\":3}");
+
+            var batch = _store.ReadBatch(10);
+
+            Assert.AreEqual(3, batch.Count);
+            // Filenames are {ticks}_{uuid}.json — lexicographic sort == oldest first
+            var names = batch.Select(Path.GetFileName).ToList();
+            Assert.That(names, Is.Ordered.Ascending);
+        }
+
+        [Test]
+        public void ReadBatch_RespectsMaxSize()
+        {
+            for (var i = 0; i < 5; i++)
+            {
+                _store.Write($"{{\"i\":{i}}}");
+                Thread.Sleep(5);
+            }
+
+            var batch = _store.ReadBatch(3);
+            Assert.AreEqual(3, batch.Count);
+        }
+
+        [Test]
+        public void ReadBatch_ClampsToMaxBatchSize()
+        {
+            for (var i = 0; i < Constants.MaxBatchSize + 10; i++)
+                _store.Write($"{{\"i\":{i}}}");
+
+            var batch = _store.ReadBatch(Constants.MaxBatchSize + 10);
+            Assert.LessOrEqual(batch.Count, Constants.MaxBatchSize);
+        }
+
+        [Test]
+        public void ReadBatch_ExcludesAndDeletesStaleFiles()
+        {
+            _store.Write("{\"fresh\":true}");
+
+            // Manually plant a stale file (ticks from 31 days ago)
+            var staleTime = DateTime.UtcNow.AddDays(-(Constants.StaleEventDays + 1));
+            var staleName = $"{staleTime.Ticks}_{Guid.NewGuid():N}.json";
+            var queueDir = Path.Combine(_testDir, "imtbl_audience", "queue");
+            File.WriteAllText(Path.Combine(queueDir, staleName), "{\"stale\":true}");
+
+            var batch = _store.ReadBatch(10);
+
+            Assert.AreEqual(1, batch.Count, "stale file should be excluded from batch");
+            Assert.IsFalse(File.Exists(Path.Combine(queueDir, staleName)), "stale file should be deleted");
+        }
+
+        [Test]
+        public void Delete_RemovesSpecifiedFiles()
+        {
+            _store.Write("{\"a\":1}");
+            _store.Write("{\"b\":2}");
+
+            var batch = _store.ReadBatch(10);
+            Assert.AreEqual(2, batch.Count);
+
+            _store.Delete(batch);
+
+            Assert.AreEqual(0, _store.Count());
+        }
+
+        [Test]
+        public void Count_ReflectsNumberOfFilesOnDisk()
+        {
+            Assert.AreEqual(0, _store.Count());
+
+            _store.Write("{\"x\":1}");
+            _store.Write("{\"x\":2}");
+
+            Assert.AreEqual(2, _store.Count());
+        }
+
+        [Test]
+        public void ReadBatch_EmptyQueue_ReturnsEmpty()
+        {
+            var batch = _store.ReadBatch(10);
+            Assert.AreEqual(0, batch.Count);
+        }
+
+        [Test]
+        public void ReadBatch_ZeroMaxSize_ReturnsEmpty()
+        {
+            _store.Write("{\"x\":1}");
+            var batch = _store.ReadBatch(0);
+            Assert.AreEqual(0, batch.Count);
+        }
+
+        [Test]
+        public void CrashRecovery_PicksUpFilesFromPreviousRun()
+        {
+            // Simulate a previous run by writing a file directly
+            var queueDir = Path.Combine(_testDir, "imtbl_audience", "queue");
+            var survivingName = $"{DateTime.UtcNow.Ticks}_{Guid.NewGuid():N}.json";
+            File.WriteAllText(Path.Combine(queueDir, survivingName), "{\"survived\":true}");
+
+            // Create a new DiskStore instance pointing at the same path (simulates restart)
+            var store2 = new DiskStore(_testDir);
+            var batch = store2.ReadBatch(10);
+
+            Assert.AreEqual(1, batch.Count, "crash-surviving file should be picked up on next init");
+        }
+    }
+}

--- a/src/Packages/Audience/Tests/Runtime/DiskStoreTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/DiskStoreTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e0f6d4a3b5c769d21b8e9f0a1b2c3d4e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Tests/Runtime/EventQueueTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/EventQueueTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.IO;
+using System.Threading;
+using NUnit.Framework;
+
+namespace Immutable.Audience.Tests
+{
+    [TestFixture]
+    internal class EventQueueTests
+    {
+        private string _testDir;
+        private DiskStore _store;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _testDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(_testDir);
+            _store = new DiskStore(_testDir);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(_testDir))
+                Directory.Delete(_testDir, recursive: true);
+        }
+
+        [Test]
+        public void Enqueue_ThenFlushAsync_PersistesEventToDisk()
+        {
+            using var queue = new EventQueue(_store, flushIntervalSeconds: 60, flushSize: 100);
+
+            queue.Enqueue("{\"event\":\"track\"}");
+            queue.FlushAsync();
+
+            Assert.AreEqual(1, _store.Count(), "event should be on disk after FlushAsync");
+        }
+
+        [Test]
+        public void Enqueue_MultipleEvents_AllPersistedAfterFlush()
+        {
+            using var queue = new EventQueue(_store, flushIntervalSeconds: 60, flushSize: 100);
+
+            for (var i = 0; i < 10; i++)
+                queue.Enqueue($"{{\"i\":{i}}}");
+
+            queue.FlushAsync();
+
+            Assert.AreEqual(10, _store.Count());
+        }
+
+        [Test]
+        public void FlushSize_Trigger_DrainsToDiskAutomatically()
+        {
+            const int flushSize = 5;
+            using var queue = new EventQueue(_store, flushIntervalSeconds: 60, flushSize: flushSize);
+
+            for (var i = 0; i < flushSize; i++)
+                queue.Enqueue($"{{\"i\":{i}}}");
+
+            // Give the background thread time to drain
+            var deadline = DateTime.UtcNow.AddSeconds(3);
+            while (_store.Count() < flushSize && DateTime.UtcNow < deadline)
+                Thread.Sleep(20);
+
+            Assert.AreEqual(flushSize, _store.Count(),
+                "reaching FlushSize should trigger automatic drain without explicit FlushAsync");
+        }
+
+        [Test]
+        public void Shutdown_FlushesRemainingEvents()
+        {
+            var queue = new EventQueue(_store, flushIntervalSeconds: 60, flushSize: 100);
+
+            queue.Enqueue("{\"event\":\"a\"}");
+            queue.Enqueue("{\"event\":\"b\"}");
+
+            queue.Shutdown();
+
+            Assert.AreEqual(2, _store.Count(), "Shutdown should flush all remaining in-memory events");
+        }
+
+        [Test]
+        public void Shutdown_CalledTwice_DoesNotThrow()
+        {
+            var queue = new EventQueue(_store, flushIntervalSeconds: 60, flushSize: 100);
+            queue.Shutdown();
+            Assert.DoesNotThrow(() => queue.Shutdown());
+        }
+
+        [Test]
+        public void Enqueue_AfterShutdown_IsIgnored()
+        {
+            var queue = new EventQueue(_store, flushIntervalSeconds: 60, flushSize: 100);
+            queue.Shutdown();
+
+            queue.Enqueue("{\"event\":\"ignored\"}");
+
+            Assert.AreEqual(0, _store.Count(), "events enqueued after Shutdown should be discarded");
+        }
+
+        [Test]
+        public void IntervalFlush_DrainsToDiskWithoutExplicitCall()
+        {
+            // Very short interval to make the test fast
+            using var queue = new EventQueue(_store, flushIntervalSeconds: 1, flushSize: 100);
+
+            queue.Enqueue("{\"event\":\"interval_flush\"}");
+
+            // Wait slightly longer than the flush interval
+            var deadline = DateTime.UtcNow.AddSeconds(4);
+            while (_store.Count() < 1 && DateTime.UtcNow < deadline)
+                Thread.Sleep(50);
+
+            Assert.AreEqual(1, _store.Count(), "interval flush should have persisted event to disk");
+        }
+
+        [Test]
+        public void Dispose_FlushesAndStopsDrainThread()
+        {
+            using (var queue = new EventQueue(_store, flushIntervalSeconds: 60, flushSize: 100))
+            {
+                queue.Enqueue("{\"event\":\"dispose_test\"}");
+            } // Dispose called here
+
+            Assert.AreEqual(1, _store.Count(), "Dispose should flush events to disk");
+        }
+    }
+}

--- a/src/Packages/Audience/Tests/Runtime/EventQueueTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/EventQueueTests.cs
@@ -27,14 +27,14 @@ namespace Immutable.Audience.Tests
         }
 
         [Test]
-        public void Enqueue_ThenFlushAsync_PersistesEventToDisk()
+        public void Enqueue_ThenFlushSync_PersistesEventToDisk()
         {
             using var queue = new EventQueue(_store, flushIntervalSeconds: 60, flushSize: 100);
 
             queue.Enqueue("{\"event\":\"track\"}");
-            queue.FlushAsync();
+            queue.FlushSync();
 
-            Assert.AreEqual(1, _store.Count(), "event should be on disk after FlushAsync");
+            Assert.AreEqual(1, _store.Count(), "event should be on disk after FlushSync");
         }
 
         [Test]
@@ -45,7 +45,7 @@ namespace Immutable.Audience.Tests
             for (var i = 0; i < 10; i++)
                 queue.Enqueue($"{{\"i\":{i}}}");
 
-            queue.FlushAsync();
+            queue.FlushSync();
 
             Assert.AreEqual(10, _store.Count());
         }
@@ -65,7 +65,7 @@ namespace Immutable.Audience.Tests
                 Thread.Sleep(20);
 
             Assert.AreEqual(flushSize, _store.Count(),
-                "reaching FlushSize should trigger automatic drain without explicit FlushAsync");
+                "reaching FlushSize should trigger automatic drain without explicit FlushSync");
         }
 
         [Test]

--- a/src/Packages/Audience/Tests/Runtime/EventQueueTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/EventQueueTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f1a7e5b4c6d870e32c9f0a1b2c3d4e5f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Adds `DiskStore` (`Runtime/Transport/DiskStore.cs`): file-per-event persistent store writing `{ticks}_{uuid}.json` files atomically to `imtbl_audience/queue/`; supports `ReadBatch` (oldest-first, max 100, stale-event pruning after 30 days), `Delete`, and `Count`; crash-safe (survives restarts by scanning the queue directory on init)
- Adds `EventQueue` (`Runtime/Transport/EventQueue.cs`): wraps `ConcurrentQueue<string>` with a background drain thread; flushes to `DiskStore` every `FlushIntervalSeconds` or when `FlushSize` events accumulate; `FlushAsync()` for on-demand drain; `Shutdown()`/`Dispose()` for clean exit with final flush
- Adds `DiskStoreTests` and `EventQueueTests` covering write, batch read, stale pruning, crash recovery, size-triggered flush, interval flush, shutdown, and post-shutdown enqueue

## Test plan
- [ ] `DiskStoreTests`: write creates file, contents match JSON, batch returns oldest first, max size respected, clamped to `MaxBatchSize`, stale files excluded and deleted, `Delete` removes files, `Count` tracks file count, empty/zero cases, crash recovery
- [ ] `EventQueueTests`: enqueue + `FlushAsync` persists, multiple events, `FlushSize` auto-drain, `Shutdown` flushes remainder, double-shutdown safe, enqueue-after-shutdown ignored, interval auto-flush, `Dispose` flushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new background-thread and on-disk persistence behavior that can affect event delivery reliability and performance (timing, race conditions, and file I/O edge cases), though changes are additive and covered by tests.
> 
> **Overview**
> Adds a disk-backed batching layer to the Audience SDK by introducing `DiskStore` (file-per-event persistence under `imtbl_audience/queue/`, batched reads capped to `Constants.MaxBatchSize`, and automatic pruning of events older than `Constants.StaleEventDays`) and `EventQueue` (thread-safe in-memory enqueue with a background drain thread that flushes by size threshold or time interval, plus `Shutdown`/`Dispose` for final flush).
> 
> Includes new NUnit runtime tests covering atomic writes, ordering and batch sizing, stale-file cleanup and crash recovery for `DiskStore`, plus flush triggers, interval draining, and shutdown/dispose behavior for `EventQueue`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14b57a1e3d24d35a0141aee860e313c85eaf3f0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->