### PR TITLE
feat(audience): enforce required properties on Track(IEvent) predefined events (SDK-225)

### DIFF
--- a/src/Packages/Audience/Runtime/Events/TypedEvents.cs
+++ b/src/Packages/Audience/Runtime/Events/TypedEvents.cs
@@ -30,8 +30,9 @@ namespace Immutable.Audience
     // Player progressing through a world / level / stage.
     public class Progression : IEvent
     {
-        // Required.
-        public ProgressionStatus Status { get; set; }
+        // Required. Nullable so an unset caller produces a clear validation
+        // error at send time instead of silently shipping the enum default.
+        public ProgressionStatus? Status { get; set; }
         // Optional.
         public string? World { get; set; }
         public string? Level { get; set; }
@@ -43,9 +44,12 @@ namespace Immutable.Audience
 
         public Dictionary<string, object> ToProperties()
         {
+            if (Status is null)
+                throw new ArgumentException("Progression.Status is required — set it before calling Track(IEvent)");
+
             var props = new Dictionary<string, object>
             {
-                ["status"] = Status.ToLowercaseString()
+                ["status"] = Status.Value.ToLowercaseString()
             };
 
             if (World != null) props["world"] = World;
@@ -81,10 +85,12 @@ namespace Immutable.Audience
     // In-game currency earned or spent.
     public class Resource : IEvent
     {
-        // Required.
-        public ResourceFlow Flow { get; set; }
+        // Required. Nullable so an unset caller produces a clear validation
+        // error at send time instead of silently shipping the enum / zero
+        // default.
+        public ResourceFlow? Flow { get; set; }
         public string? Currency { get; set; }
-        public float Amount { get; set; }
+        public float? Amount { get; set; }
         // Optional.
         public string? ItemType { get; set; }
         public string? ItemId { get; set; }
@@ -93,14 +99,18 @@ namespace Immutable.Audience
 
         public Dictionary<string, object> ToProperties()
         {
+            if (Flow is null)
+                throw new ArgumentException("Resource.Flow is required — set it before calling Track(IEvent)");
             if (string.IsNullOrEmpty(Currency))
-                throw new ArgumentException("Resource.Currency must not be null or empty");
+                throw new ArgumentException("Resource.Currency is required — set a non-empty string before calling Track(IEvent)");
+            if (Amount is null)
+                throw new ArgumentException("Resource.Amount is required — set it before calling Track(IEvent)");
 
             var props = new Dictionary<string, object>
             {
-                ["flow"] = Flow.ToLowercaseString(),
+                ["flow"] = Flow.Value.ToLowercaseString(),
                 ["currency"] = Currency,
-                ["amount"] = Amount
+                ["amount"] = Amount.Value
             };
 
             if (ItemType != null) props["itemType"] = ItemType;
@@ -115,8 +125,10 @@ namespace Immutable.Audience
     {
         // Required. ISO 4217 three-letter uppercase currency code.
         public string? Currency { get; set; }
-        // Required.
-        public decimal Value { get; set; }
+        // Required. Nullable so an unset caller produces a clear validation
+        // error at send time instead of silently shipping a zero-value
+        // purchase that breaks attribution and conversion reporting.
+        public decimal? Value { get; set; }
         // Optional.
         public string? ItemId { get; set; }
         public string? ItemName { get; set; }
@@ -142,11 +154,13 @@ namespace Immutable.Audience
             if (Currency == null || !IsIso4217(Currency))
                 throw new ArgumentException(
                     $"Purchase.Currency '{Currency}' must be a three-letter uppercase ISO 4217 code");
+            if (Value is null)
+                throw new ArgumentException("Purchase.Value is required — set it before calling Track(IEvent)");
 
             var props = new Dictionary<string, object>
             {
                 ["currency"] = Currency,
-                ["value"] = Value
+                ["value"] = Value.Value
             };
 
             if (ItemId != null) props["itemId"] = ItemId;

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -138,11 +138,14 @@ namespace Immutable.Audience
 
         // Send a custom event.
         //
-        // For predefined event names (e.g. purchase), prefer the typed
-        // overload Track(new Purchase { ... }) — it enforces required fields
-        // and value types at compile time. This overload does not validate
-        // property shapes, so missing or mistyped fields can break
-        // attribution/conversion reporting.
+        // For predefined event names (e.g. purchase, progression, resource,
+        // milestone_reached), prefer the typed overload —
+        // Track(new Purchase { Currency = "USD", Value = 9.99m }) — which
+        // validates required fields at send time. This overload accepts any
+        // property shape and does not: Track("purchase", new Dictionary...)
+        // that omits currency or value still enqueues and ships, but breaks
+        // attribution and conversion reporting downstream because the
+        // payload is missing the fields CDP needs to reconstruct the event.
         public static void Track(string eventName, Dictionary<string, object>? properties = null)
         {
             if (!CanTrack()) return;

--- a/src/Packages/Audience/Tests/Runtime/Events/TypedEventTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Events/TypedEventTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 
 namespace Immutable.Audience.Tests
@@ -9,6 +10,15 @@ namespace Immutable.Audience.Tests
         public void Progression_EventName_IsProgression()
         {
             Assert.AreEqual("progression", new Progression().EventName);
+        }
+
+        [Test]
+        public void Progression_WithoutStatus_ThrowsOnToProperties()
+        {
+            var evt = new Progression { World = "tutorial" };
+
+            var ex = Assert.Throws<ArgumentException>(() => evt.ToProperties());
+            Assert.That(ex!.Message, Does.Contain("Status"));
         }
 
         [Test]
@@ -73,6 +83,33 @@ namespace Immutable.Audience.Tests
         }
 
         [Test]
+        public void Resource_WithoutFlow_ThrowsOnToProperties()
+        {
+            var evt = new Resource { Currency = "gold", Amount = 100 };
+
+            var ex = Assert.Throws<ArgumentException>(() => evt.ToProperties());
+            Assert.That(ex!.Message, Does.Contain("Flow"));
+        }
+
+        [Test]
+        public void Resource_WithoutCurrency_ThrowsOnToProperties()
+        {
+            var evt = new Resource { Flow = ResourceFlow.Source, Amount = 100 };
+
+            var ex = Assert.Throws<ArgumentException>(() => evt.ToProperties());
+            Assert.That(ex!.Message, Does.Contain("Currency"));
+        }
+
+        [Test]
+        public void Resource_WithoutAmount_ThrowsOnToProperties()
+        {
+            var evt = new Resource { Flow = ResourceFlow.Source, Currency = "gold" };
+
+            var ex = Assert.Throws<ArgumentException>(() => evt.ToProperties());
+            Assert.That(ex!.Message, Does.Contain("Amount"));
+        }
+
+        [Test]
         public void Purchase_ProducesCorrectProperties()
         {
             var evt = new Purchase
@@ -112,6 +149,24 @@ namespace Immutable.Audience.Tests
         public void Purchase_EventName_IsPurchase()
         {
             Assert.AreEqual("purchase", new Purchase().EventName);
+        }
+
+        [Test]
+        public void Purchase_WithoutCurrency_ThrowsOnToProperties()
+        {
+            var evt = new Purchase { Value = 9.99m };
+
+            var ex = Assert.Throws<ArgumentException>(() => evt.ToProperties());
+            Assert.That(ex!.Message, Does.Contain("Currency"));
+        }
+
+        [Test]
+        public void Purchase_WithoutValue_ThrowsOnToProperties()
+        {
+            var evt = new Purchase { Currency = "USD" };
+
+            var ex = Assert.Throws<ArgumentException>(() => evt.ToProperties());
+            Assert.That(ex!.Message, Does.Contain("Value"));
         }
 
         [Test]

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -106,6 +106,31 @@ namespace Immutable.Audience.Tests
         }
 
         [Test]
+        public void Track_IEventMissingRequiredField_DropsWithWarn()
+        {
+            ImmutableAudience.Init(MakeConfig());
+
+            var lines = new List<string>();
+            Log.Writer = lines.Add;
+            try
+            {
+                // Purchase with no Value set — ToProperties throws; Track must
+                // catch, warn, and drop rather than ship an incomplete event.
+                Assert.DoesNotThrow(() => ImmutableAudience.Track(new Purchase { Currency = "USD" }));
+                Assert.That(lines, Has.Some.Contains("Purchase"));
+                Assert.That(lines, Has.Some.Contains("Dropping"));
+            }
+            finally { Log.Writer = null; }
+
+            ImmutableAudience.Shutdown();
+            var queueDir = AudiencePaths.QueueDir(_testDir);
+            var contents = Directory.GetFiles(queueDir, "*.json")
+                .Select(File.ReadAllText).ToList();
+            Assert.IsFalse(contents.Any(c => c.Contains("\"purchase\"")),
+                "purchase event with missing required Value must be dropped, not enqueued");
+        }
+
+        [Test]
         public void Track_NullOrEmptyEventName_DoesNotEnqueue()
         {
             ImmutableAudience.Init(MakeConfig());


### PR DESCRIPTION
## Summary
- Flips required value-typed fields on the typed IEvent implementations to nullable — `Progression.Status`, `Resource.Flow`, `Resource.Amount`, `Purchase.Value` — so an unset caller is distinguishable from the enum / zero default.
- Each `ToProperties()` throws `ArgumentException` naming the missing field when a required property is null. The existing try/catch in `ImmutableAudience.Track(IEvent)` catches, logs, and drops the event — consistent with the never-crash convention on the game thread.
- Required fields already validated (`Resource.Currency`, `Purchase.Currency` via ISO 4217, `MilestoneReached.Name`) stay as-is — no behavior change there.
- Tightens the `Track(string)` doc comment with a concrete example (purchase without currency / value) so the attribution / conversion reporting risk is explicit, per Natalie's follow-up on the merged PR.
- 7 new tests: a missing-required-field case per predefined event, plus an integration test on `Track(IEvent)` confirming a malformed Purchase is caught, logged, and dropped (161 → 168).

## Rationale
Attribution and conversion pipelines depend on predefined events carrying their required fields. The C# compiler enforces field types but does not enforce that required fields are set to a non-default value, so `Track(new Purchase { Currency = "USD" })` was silently shipping a zero-value purchase and breaking downstream reporting.

Web SDK sidesteps this with TS conditional types at compile time. Unity C# cannot — required fields must be enforced at runtime instead. Natalie's explicit direction on Slack: "for Unity maybe we can only call out in the docs & comments for `Track(string...)` and enforce it in `Track(IEvent)`."

Field mapping matches the canonical schema in [Unity SDK Event Reference v1](https://immutable.atlassian.net/wiki/spaces/~84417537/pages/3883663502).

## Breaking change
Callers that read a required property directly — e.g. `decimal v = purchase.Value;` — need `purchase.Value!.Value` after this change. Construction patterns like `new Purchase { Value = 9.99m }` are unaffected because of implicit nullable conversion.

## Out of scope
- Runtime validation for `Track(string)` with a predefined event name — docs-only per Natalie's direction.
- Compile-time enforcement analogous to the Web SDK's TS conditional types — not possible in C#.

Linear: [SDK-225](https://linear.app/imtbl/issue/SDK-225/enforce-required-properties-at-runtime-on-trackievent-predefined)
Sister ticket: [SDK-222](https://linear.app/imtbl/issue/SDK-222/make-identitytype-mandatory-on-identify-and-alias-cdp-deletion) (PR #696)
Parent: [SDK-99](https://linear.app/imtbl/issue/SDK-99/unity-sdk-v1) Unity SDK v1