### PR TITLE
feat(audience-consent): add CanTrack and CanIdentify predicates on ConsentLevel (SDK-226)

### DIFF
--- a/src/Packages/Audience/Runtime/ConsentLevel.cs
+++ b/src/Packages/Audience/Runtime/ConsentLevel.cs
@@ -5,18 +5,16 @@ namespace Immutable.Audience
     // How much data the Audience SDK is allowed to collect.
     public enum ConsentLevel
     {
-        // No tracking.
+        // No tracking
         None,
-        // Anonymous tracking only.
+        // Anonymous tracking only
         Anonymous,
-        // Full tracking, including identity.
+        // Full tracking
         Full
     }
 
     internal static class ConsentLevelExtensions
     {
-        // Throws on unknown casts rather than emitting null: a null value
-        // would poison the backend consent log.
         internal static string ToLowercaseString(this ConsentLevel level) => level switch
         {
             ConsentLevel.None => "none",
@@ -25,5 +23,9 @@ namespace Immutable.Audience
             _ => throw new System.ArgumentOutOfRangeException(
                 nameof(level), level, "Unhandled ConsentLevel"),
         };
+
+        internal static bool CanTrack(this ConsentLevel level) => level != ConsentLevel.None;
+
+        internal static bool CanIdentify(this ConsentLevel level) => level == ConsentLevel.Full;
     }
 }

--- a/src/Packages/Audience/Runtime/Core/Identity.cs
+++ b/src/Packages/Audience/Runtime/Core/Identity.cs
@@ -63,7 +63,7 @@ namespace Immutable.Audience
         internal static string? GetOrCreate(string persistentDataPath, ConsentLevel consent)
         {
             // No ID until the player grants at least anonymous consent.
-            if (consent == ConsentLevel.None)
+            if (!consent.CanTrack())
                 return null;
 
             // Fast path — already loaded this session, no lock needed.

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -192,7 +192,7 @@ namespace Immutable.Audience
                 Log.Warn("Identify called with null or empty userId — dropping.");
                 return;
             }
-            if (_consent != ConsentLevel.Full)
+            if (!_consent.CanIdentify())
             {
                 Log.Warn($"Identify discarded — requires Full consent, current is {_consent}");
                 return;
@@ -227,7 +227,7 @@ namespace Immutable.Audience
                 Log.Warn("Alias called with null or empty fromId/toId — dropping.");
                 return;
             }
-            if (_consent != ConsentLevel.Full)
+            if (!_consent.CanIdentify())
             {
                 Log.Warn($"Alias discarded — requires Full consent, current is {_consent}");
                 return;
@@ -556,7 +556,7 @@ namespace Immutable.Audience
 
         private static bool CanTrack()
         {
-            return _initialized && _consent != ConsentLevel.None;
+            return _initialized && _consent.CanTrack();
         }
 
         // Shallow-copy the caller's dict so a post-call mutation cannot race the drain-thread serialiser.
@@ -570,7 +570,7 @@ namespace Immutable.Audience
 
             // Re-check consent inside the drain lock so a SetConsent(None) racing
             // the caller's CanTrack cannot leak this event past the purge.
-            queue.EnqueueChecked(msg, () => _consent != ConsentLevel.None);
+            queue.EnqueueChecked(msg, () => _consent.CanTrack());
         }
 
         private static void SendBatch()
@@ -632,7 +632,7 @@ namespace Immutable.Audience
         // landing between Init returning and here still drops the event.
         private static void FireGameLaunch(AudienceConfig config, ConsentLevel consentAtInit)
         {
-            if (consentAtInit == ConsentLevel.None) return;
+            if (!consentAtInit.CanTrack()) return;
 
             var properties = new Dictionary<string, object>();
 

--- a/src/Packages/Audience/Tests/Runtime/ConsentLevelTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ConsentLevelTests.cs
@@ -1,0 +1,57 @@
+using System;
+using NUnit.Framework;
+
+namespace Immutable.Audience.Tests
+{
+    [TestFixture]
+    internal class ConsentLevelTests
+    {
+        [TestCase(ConsentLevel.None, "none")]
+        [TestCase(ConsentLevel.Anonymous, "anonymous")]
+        [TestCase(ConsentLevel.Full, "full")]
+        public void ToLowercaseString_MapsEachEnumValueToLowercaseBackendString(ConsentLevel level, string expected)
+        {
+            Assert.AreEqual(expected, level.ToLowercaseString());
+        }
+
+        [Test]
+        public void ToLowercaseString_UnknownValue_Throws()
+        {
+            var invalid = (ConsentLevel)999;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => invalid.ToLowercaseString());
+        }
+
+        [TestCase(ConsentLevel.None, false)]
+        [TestCase(ConsentLevel.Anonymous, true)]
+        [TestCase(ConsentLevel.Full, true)]
+        public void CanTrack_TrueForAnonymousAndFull(ConsentLevel level, bool expected)
+        {
+            Assert.AreEqual(expected, level.CanTrack());
+        }
+
+        [Test]
+        public void CanTrack_UnknownValue_ReturnsTrue()
+        {
+            var invalid = (ConsentLevel)999;
+
+            Assert.IsTrue(invalid.CanTrack());
+        }
+
+        [TestCase(ConsentLevel.None, false)]
+        [TestCase(ConsentLevel.Anonymous, false)]
+        [TestCase(ConsentLevel.Full, true)]
+        public void CanIdentify_TrueOnlyForFull(ConsentLevel level, bool expected)
+        {
+            Assert.AreEqual(expected, level.CanIdentify());
+        }
+
+        [Test]
+        public void CanIdentify_UnknownValue_ReturnsFalse()
+        {
+            var invalid = (ConsentLevel)999;
+
+            Assert.IsFalse(invalid.CanIdentify());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ConsentLevel.CanTrack()` and `ConsentLevel.CanIdentify()` extension predicates as the single source of truth for the SDK's consent gates.
- Adopts both predicates at six internal call sites that previously inlined the rule (five in `ImmutableAudience.cs`, one in `Identity.cs`).
- `ConsentLevelExtensions` stays `internal`, matching the convention used by `IdentityTypeExtensions`.
- `Tests/Runtime/ConsentLevelTests.cs` pins each enum value plus the out-of-range cast against both predicates.

Linear:
- [SDK-226](https://linear.app/imtbl/issue/SDK-226) — primary
- [SDK-143](https://linear.app/imtbl/issue/SDK-143) — contributes consent gates: `Identify`/`Alias` require Full, `Track` requires Anonymous+