### PR TITLE
fix(audience): atomic ConsentState for Full→Anonymous userId race (SDK-233)

### DIFF
--- a/src/Packages/Audience/Runtime/Core/ConsentState.cs
+++ b/src/Packages/Audience/Runtime/Core/ConsentState.cs
@@ -2,16 +2,17 @@
 
 namespace System.Runtime.CompilerServices
 {
-    // Polyfill: record { init } properties compile to init-only setters that
-    // reference IsExternalInit. .NET Standard 2.1 (Unity) doesn't ship it.
+    // Unity's .NET runtime doesn't include this type, but the C# compiler
+    // needs it to exist to build the ConsentState record below. Declaring
+    // an empty one here gives the compiler what it looks for.
     internal static class IsExternalInit { }
 }
 
 namespace Immutable.Audience
 {
-    // Immutable consent + userId pair. Stored as a volatile reference so
-    // readers observe both fields atomically — a SetConsent(Full → Anonymous)
-    // swap cannot be observed as Anonymous+oldUserId.
+    // Pairs the consent level with the user id so the two always move
+    // together. Updates swap the whole pair at once — a reader never sees
+    // the new consent level alongside a leftover user id.
     internal sealed record ConsentState(ConsentLevel Level, string? UserId)
     {
         internal static readonly ConsentState None = new(ConsentLevel.None, null);

--- a/src/Packages/Audience/Runtime/Core/ConsentState.cs
+++ b/src/Packages/Audience/Runtime/Core/ConsentState.cs
@@ -1,0 +1,19 @@
+#nullable enable
+
+namespace System.Runtime.CompilerServices
+{
+    // Polyfill: record { init } properties compile to init-only setters that
+    // reference IsExternalInit. .NET Standard 2.1 (Unity) doesn't ship it.
+    internal static class IsExternalInit { }
+}
+
+namespace Immutable.Audience
+{
+    // Immutable consent + userId pair. Stored as a volatile reference so
+    // readers observe both fields atomically — a SetConsent(Full → Anonymous)
+    // swap cannot be observed as Anonymous+oldUserId.
+    internal sealed record ConsentState(ConsentLevel Level, string? UserId)
+    {
+        internal static readonly ConsentState None = new(ConsentLevel.None, null);
+    }
+}

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -15,9 +15,9 @@ namespace Immutable.Audience
         // Reference fields are written inside _initLock; readers check the
         // `volatile _initialized` flag first so they never see a half-initialised state.
         // _state (consent level + userId) and _session are volatile so a write
-        // on one thread is visible on any other. Writes happen under _initLock
-        // (Identify / Reset / SetConsent also take it) so level and userId
-        // always move together — callers never observe (Anonymous, oldUserId).
+        // on one thread is visible on any other. Every _state write happens
+        // under _initLock so level and userId always move together — callers
+        // never observe (Anonymous, oldUserId).
         //
         // Init / Shutdown / Reset / SetConsent hold _initLock only to flip state
         // and capture references; they release the lock before running blocking
@@ -789,7 +789,7 @@ namespace Immutable.Audience
             timer.Change(nextMs, sendIntervalMs);
         }
 
-        // consentAtInit only gates the launch; Track still checks live _consent via CanTrack.
+        // consentAtInit only gates the launch; Track still checks live _state via CanTrack.
         private static void FireGameLaunch(AudienceConfig config, ConsentLevel consentAtInit)
         {
             if (!consentAtInit.CanTrack()) return;

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -710,13 +710,7 @@ namespace Immutable.Audience
         // Private
         // -----------------------------------------------------------------
 
-        private static bool CanTrack()
-        {
-            return _initialized && _state.Level.CanTrack();
-        }
-
-        // Copy the dictionary so the caller editing it later can't corrupt the
-        // message while the background thread is writing it to disk.
+        // Shallow-copy the caller's dict so a post-call mutation cannot race the drain-thread serialiser.
         private static Dictionary<string, object>? SnapshotCallerDict(Dictionary<string, object>? src) =>
             src != null ? new Dictionary<string, object>(src) : null;
 

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -14,9 +14,10 @@ namespace Immutable.Audience
     {
         // Reference fields are written inside _initLock; readers check the
         // `volatile _initialized` flag first so they never see a half-initialised state.
-        // _consent and _session are written only inside _initLock but read outside,
-        // so they stay `volatile` to make writes visible across threads.
-        // _userId is written outside the lock (Identify) — `volatile` for the same reason.
+        // _state (consent level + userId) and _session are volatile: writes
+        // happen inside _initLock, reads happen outside. A ConsentState swap
+        // publishes level + userId together so callers never observe
+        // (Anonymous, oldUserId).
         //
         // Init / Shutdown / Reset / SetConsent hold _initLock only to flip state
         // and capture references; they release the lock before running blocking
@@ -30,8 +31,7 @@ namespace Immutable.Audience
         private static HttpClient? _controlClient;
         private static CancellationTokenSource? _shutdownCancellationSource;
         private static Timer? _sendTimer;
-        private static volatile ConsentLevel _consent;
-        private static volatile string? _userId;
+        private static volatile ConsentState _state = ConsentState.None;
         private static volatile bool _initialized;
         private static readonly object _initLock = new object();
 
@@ -76,7 +76,8 @@ namespace Immutable.Audience
                 _config = config;
                 Log.Enabled = config.Debug;
                 // Persisted consent overrides the config default (prior downgrade survives restart).
-                _consent = ConsentStore.Load(config.PersistentDataPath) ?? config.Consent;
+                var initialLevel = ConsentStore.Load(config.PersistentDataPath) ?? config.Consent;
+                _state = new ConsentState(initialLevel, null);
 
                 _store = new DiskStore(config.PersistentDataPath);
                 _queue = new EventQueue(_store, config.FlushIntervalSeconds, config.FlushSize);
@@ -94,11 +95,11 @@ namespace Immutable.Audience
                 _initialized = true;
 
                 // Snapshot so a racing SetConsent(None) can't drop the launch event.
-                consentAtInit = _consent;
+                consentAtInit = initialLevel;
 
                 // Session created under the lock; Start() deferred until after
                 // release because session_start → Track takes its own locks.
-                if (consentAtInit.CanTrack())
+                if (initialLevel.CanTrack())
                     _session = new Session(Track);
 
                 // Captured reference: a later SetConsent(None) may dispose this
@@ -136,7 +137,8 @@ namespace Immutable.Audience
         // IEvent implementations validate required fields at compile time.
         public static void Track(IEvent evt)
         {
-            if (!CanTrack()) return;
+            var state = _state;
+            if (!_initialized || !state.Level.CanTrack()) return;
             if (evt == null)
             {
                 Log.Warn("Track(IEvent) called with null event — dropping.");
@@ -166,10 +168,11 @@ namespace Immutable.Audience
                 return;
             }
 
-            var anonymousId = Identity.GetOrCreate(config.PersistentDataPath!, _consent);
+            var anonymousId = Identity.GetOrCreate(config.PersistentDataPath!, state.Level);
             // ToProperties returns a fresh dict per call, so no snapshot needed.
-            var msg = MessageBuilder.Track(eventName, anonymousId, _userId, config.PackageVersion, properties);
-            Enqueue(msg);
+            var userId = state.Level == ConsentLevel.Full ? state.UserId : null;
+            var msg = MessageBuilder.Track(eventName, anonymousId, userId, config.PackageVersion, properties);
+            EnqueueTrack(msg);
         }
 
         // Sends a custom event. For predefined names (purchase, progression,
@@ -177,7 +180,8 @@ namespace Immutable.Audience
         // validates required fields.
         public static void Track(string eventName, Dictionary<string, object>? properties = null)
         {
-            if (!CanTrack()) return;
+            var state = _state;
+            if (!_initialized || !state.Level.CanTrack()) return;
             if (string.IsNullOrEmpty(eventName))
             {
                 Log.Warn("Track(string) called with null or empty event name — dropping.");
@@ -187,10 +191,11 @@ namespace Immutable.Audience
             var config = _config;
             if (config == null) return;
 
-            var anonymousId = Identity.GetOrCreate(config.PersistentDataPath!, _consent);
-            var msg = MessageBuilder.Track(eventName, anonymousId, _userId, config.PackageVersion,
+            var anonymousId = Identity.GetOrCreate(config.PersistentDataPath!, state.Level);
+            var userId = state.Level == ConsentLevel.Full ? state.UserId : null;
+            var msg = MessageBuilder.Track(eventName, anonymousId, userId, config.PackageVersion,
                 SnapshotCallerDict(properties));
-            Enqueue(msg);
+            EnqueueTrack(msg);
         }
 
         // -----------------------------------------------------------------
@@ -213,21 +218,29 @@ namespace Immutable.Audience
                 Log.Warn("Identify called with null or empty userId — dropping.");
                 return;
             }
-            if (!_consent.CanIdentify())
+
+            AudienceConfig? config;
+            ConsentLevel level;
+            // Update _state under _initLock so (consent, userId) stays a consistent pair.
+            lock (_initLock)
             {
-                Log.Warn($"Identify discarded — requires Full consent, current is {_consent}");
-                return;
+                if (!_initialized) return;
+                var current = _state;
+                level = current.Level;
+                if (!level.CanIdentify())
+                {
+                    Log.Warn($"Identify discarded — requires Full consent, current is {level}");
+                    return;
+                }
+                config = _config;
+                if (config == null) return;
+                _state = current with { UserId = userId };
             }
 
-            var config = _config;
-            if (config == null) return;
-
-            _userId = userId;
-
-            var anonymousId = Identity.GetOrCreate(config.PersistentDataPath!, _consent);
+            var anonymousId = Identity.GetOrCreate(config.PersistentDataPath!, level);
             var msg = MessageBuilder.Identify(anonymousId, userId, identityType, config.PackageVersion,
                 SnapshotCallerDict(traits));
-            Enqueue(msg);
+            EnqueueIdentity(msg);
         }
 
         // Links two user ids for the same player.
@@ -245,9 +258,10 @@ namespace Immutable.Audience
                 Log.Warn("Alias called with null or empty fromId/toId — dropping.");
                 return;
             }
-            if (!_consent.CanIdentify())
+            var state = _state;
+            if (!state.Level.CanIdentify())
             {
-                Log.Warn($"Alias discarded — requires Full consent, current is {_consent}");
+                Log.Warn($"Alias discarded — requires Full consent, current is {state.Level}");
                 return;
             }
 
@@ -255,7 +269,7 @@ namespace Immutable.Audience
             if (config == null) return;
 
             var msg = MessageBuilder.Alias(fromId, fromType, toId, toType, config.PackageVersion);
-            Enqueue(msg);
+            EnqueueIdentity(msg);
         }
 
         // Logs out the current player. Clears userId, discards queued events,
@@ -264,9 +278,10 @@ namespace Immutable.Audience
         // and then purged). Call FlushAsync() first to preserve queued events.
         public static void Reset()
         {
-            // Phase 1 under _initLock: swap _session and clear _userId. Blocking
-            // work (session drain, disk purge, identity wipe, new session_start)
-            // runs outside the lock so callers racing on _initLock don't wait.
+            // Phase 1 under _initLock: atomic _state.UserId clear + _session swap.
+            // Blocking work (session drain, disk purge, identity wipe, new
+            // session_start) runs outside the lock so callers racing on
+            // _initLock don't wait.
             AudienceConfig? config;
             Session? oldSession;
             Session? newSession = null;
@@ -280,11 +295,11 @@ namespace Immutable.Audience
 
                 oldSession = _session;
                 queueForPurge = _queue;
-                _userId = null;
+                _state = _state with { UserId = null };
 
                 // Swap under the lock so racing SetConsent/OnPause/OnResume see
                 // either the old, the new, or null — never a torn reference.
-                _session = _consent.CanTrack() ? new Session(Track) : null;
+                _session = _state.Level.CanTrack() ? new Session(Track) : null;
                 newSession = _session;
             }
 
@@ -378,13 +393,13 @@ namespace Immutable.Audience
             if (config == null) return;
 
             // Snapshot check before any I/O: no-op if already at target consent.
-            var snapshotPrevious = _consent;
+            var snapshotPrevious = _state.Level;
             if (level == snapshotPrevious) return;
 
             // Capture anonymousId for the PUT audit trail outside _initLock.
             // Identity methods hold their own _sync lock; disk I/O on a cold
             // cache (None → Anonymous/Full upgrade creates the UUID file) does
-            // not block _initLock. A racing SetConsent may change _consent
+            // not block _initLock. A racing SetConsent may change _state
             // between this read and our lock acquire — acceptable, the racing
             // call fires its own PUT and our slightly-stale ID still
             // identifies the user.
@@ -392,7 +407,7 @@ namespace Immutable.Audience
                 ? Identity.GetOrCreate(config.PersistentDataPath!, level)
                 : Identity.Get(config.PersistentDataPath!);
 
-            // Phase 1 under _initLock: flip _consent and swap _session / _userId.
+            // Phase 1 under _initLock: atomic _state swap and _session swap.
             // Phase 2 outside the lock runs the blocking side effects (persist,
             // dispose, purge, downgrade, backend sync, new session_start) so a
             // concurrent Shutdown / Init / Reset isn't held waiting on them.
@@ -410,10 +425,16 @@ namespace Immutable.Audience
                 queue = _queue;
                 if (config == null) return;
 
-                previous = _consent;
+                var previousState = _state;
+                previous = previousState.Level;
                 if (level == previous) return;
 
-                _consent = level;
+                // Atomic swap: Level + UserId publish together. Drop UserId on
+                // any downgrade out of Full so a racing Track/Identify cannot
+                // observe (Anonymous, oldUserId).
+                _state = new ConsentState(
+                    level,
+                    level == ConsentLevel.Full ? previousState.UserId : null);
 
                 if (level == ConsentLevel.None)
                 {
@@ -425,7 +446,6 @@ namespace Immutable.Audience
                 }
                 else if (previous == ConsentLevel.Full && level == ConsentLevel.Anonymous)
                 {
-                    _userId = null;
                     downgradeFullToAnonymous = true;
                 }
                 else if (previous == ConsentLevel.None && _session == null)
@@ -599,7 +619,7 @@ namespace Immutable.Audience
 
                 _config = null;
                 _store = null;
-                _userId = null;
+                _state = _state with { UserId = null };
             }
 
             // Phase 2 outside _initLock: end session, drain timers, flush, dispose.
@@ -667,7 +687,7 @@ namespace Immutable.Audience
 
             lock (_initLock)
             {
-                _consent = ConsentLevel.None;
+                _state = ConsentState.None;
                 // Defensive: Shutdown nulls _session too, but a future refactor
                 // that bails before that null must not leak a stale Session.
                 _session = null;
@@ -675,7 +695,7 @@ namespace Immutable.Audience
             }
         }
 
-        internal static ConsentLevel CurrentConsentForTesting => _consent;
+        internal static ConsentLevel CurrentConsentForTesting => _state.Level;
 
         internal static void FlushQueueToDiskForTesting() => _queue?.FlushSync();
 
@@ -691,7 +711,7 @@ namespace Immutable.Audience
 
         private static bool CanTrack()
         {
-            return _initialized && _consent.CanTrack();
+            return _initialized && _state.Level.CanTrack();
         }
 
         // Copy the dictionary so the caller editing it later can't corrupt the
@@ -699,13 +719,25 @@ namespace Immutable.Audience
         private static Dictionary<string, object>? SnapshotCallerDict(Dictionary<string, object>? src) =>
             src != null ? new Dictionary<string, object>(src) : null;
 
-        private static void Enqueue(Dictionary<string, object>? msg)
+        // Re-reads _state under _drainLock to close the Track-races-SetConsent
+        // window: drops on downgrade to None, strips userId on downgrade to Anonymous.
+        private static void EnqueueTrack(Dictionary<string, object>? msg)
         {
-            var queue = _queue;
-            if (queue == null) return;
+            _queue?.EnqueueChecked(msg, m =>
+            {
+                var state = _state;
+                if (!state.Level.CanTrack()) return null;
+                if (state.Level != ConsentLevel.Full)
+                    m.Remove(MessageFields.UserId);
+                return m;
+            });
+        }
 
-            // Re-check consent inside _drainLock so a racing SetConsent(None) can't leak past the purge.
-            queue.EnqueueChecked(msg, () => _consent.CanTrack());
+        // Identify / Alias require Full; drop if consent has downgraded.
+        private static void EnqueueIdentity(Dictionary<string, object>? msg)
+        {
+            _queue?.EnqueueChecked(msg, m =>
+                _state.Level == ConsentLevel.Full ? m : null);
         }
 
         private static void SendBatch()

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -14,10 +14,10 @@ namespace Immutable.Audience
     {
         // Reference fields are written inside _initLock; readers check the
         // `volatile _initialized` flag first so they never see a half-initialised state.
-        // _state (consent level + userId) and _session are volatile: writes
-        // happen inside _initLock, reads happen outside. A ConsentState swap
-        // publishes level + userId together so callers never observe
-        // (Anonymous, oldUserId).
+        // _state (consent level + userId) and _session are volatile so a write
+        // on one thread is visible on any other. Writes happen under _initLock
+        // (Identify / Reset / SetConsent also take it) so level and userId
+        // always move together — callers never observe (Anonymous, oldUserId).
         //
         // Init / Shutdown / Reset / SetConsent hold _initLock only to flip state
         // and capture references; they release the lock before running blocking
@@ -221,7 +221,8 @@ namespace Immutable.Audience
 
             AudienceConfig? config;
             ConsentLevel level;
-            // Update _state under _initLock so (consent, userId) stays a consistent pair.
+            // Update consent + userId under the init lock so they always move
+            // together — another thread reading _state never sees one half-updated.
             lock (_initLock)
             {
                 if (!_initialized) return;
@@ -719,8 +720,9 @@ namespace Immutable.Audience
         private static Dictionary<string, object>? SnapshotCallerDict(Dictionary<string, object>? src) =>
             src != null ? new Dictionary<string, object>(src) : null;
 
-        // Re-reads _state under _drainLock to close the Track-races-SetConsent
-        // window: drops on downgrade to None, strips userId on downgrade to Anonymous.
+        // Checks the current consent inside the drain lock. If consent has
+        // since dropped to None the message is discarded. If it dropped to
+        // Anonymous the userId is stripped.
         private static void EnqueueTrack(Dictionary<string, object>? msg)
         {
             _queue?.EnqueueChecked(msg, m =>

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -489,6 +489,7 @@ namespace Immutable.Audience
 
             newSession?.Start();
 
+
             SyncConsentToBackend(config, level, anonymousIdForPut);
         }
 

--- a/src/Packages/Audience/Runtime/Transport/EventQueue.cs
+++ b/src/Packages/Audience/Runtime/Transport/EventQueue.cs
@@ -64,11 +64,12 @@ namespace Immutable.Audience
                 _flushGate.Set();
         }
 
-        // Enqueues under _drainLock, giving the caller a transform callback
-        // that runs inside the lock. The transform returns the (possibly
-        // mutated) message or null to drop. Serialises the decision against
-        // PurgeAll / ApplyAnonymousDowngrade so consent-race leaks and stale
-        // userIds can be dropped or stripped atomically.
+        // Queues the message under the drain lock. The caller supplies a
+        // transform that runs while the lock is held — it can edit the
+        // message or return null to drop it. Running under the lock means
+        // PurgeAll and ApplyAnonymousDowngrade can't slip in mid-decision, so
+        // a Track that races a consent downgrade gets its userId stripped or
+        // the message dropped before it reaches the queue.
         internal void EnqueueChecked(
             Dictionary<string, object>? msg,
             Func<Dictionary<string, object>, Dictionary<string, object>?>? transform)

--- a/src/Packages/Audience/Runtime/Transport/EventQueue.cs
+++ b/src/Packages/Audience/Runtime/Transport/EventQueue.cs
@@ -64,16 +64,25 @@ namespace Immutable.Audience
                 _flushGate.Set();
         }
 
-        // Enqueues under _drainLock, re-checking stillAllowed inside the lock.
-        // Closes the window where a concurrent PurgeAll could complete between
-        // the caller's check and the enqueue, leaking the event past revocation.
-        internal void EnqueueChecked(Dictionary<string, object>? msg, Func<bool>? stillAllowed)
+        // Enqueues under _drainLock, giving the caller a transform callback
+        // that runs inside the lock. The transform returns the (possibly
+        // mutated) message or null to drop. Serialises the decision against
+        // PurgeAll / ApplyAnonymousDowngrade so consent-race leaks and stale
+        // userIds can be dropped or stripped atomically.
+        internal void EnqueueChecked(
+            Dictionary<string, object>? msg,
+            Func<Dictionary<string, object>, Dictionary<string, object>?>? transform)
         {
             if (_disposed || msg == null) return;
 
             lock (_drainLock)
             {
-                if (stillAllowed != null && !stillAllowed()) return;
+                if (transform != null)
+                {
+                    var transformed = transform(msg);
+                    if (transformed == null) return;
+                    msg = transformed;
+                }
                 _memory.Enqueue(msg);
             }
 

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -568,7 +568,7 @@ namespace Immutable.Audience.Tests
             // before SetConsent starts on a fast machine. This stress variant runs
             // the race many times with many concurrent Track threads so at least
             // some iterations are guaranteed to land the enqueue inside the
-            // _consent=None/PurgeAll window.
+            // _state=None/PurgeAll window.
             //
             // Without the EnqueueChecked re-check, this test leaks events
             // reproducibly. With the fix, zero leaks across all iterations.

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -749,6 +749,72 @@ namespace Immutable.Audience.Tests
         }
 
         [Test]
+        public void SetConsent_DowngradeToAnonymous_StressTest_NoUserIdLeak()
+        {
+            // Full → Anonymous race: Track reads _state with userId still set,
+            // then SetConsent flips _state to Anonymous and calls
+            // ApplyAnonymousDowngrade (one-shot rewrite). If Track's enqueue
+            // lands after the rewrite, the msg with userId is not stripped.
+            //
+            // With the ConsentState + EnqueueChecked transform in place, Track's
+            // transform runs under _drainLock and strips userId when current state
+            // is not Full. Zero leaks across all iterations.
+            //
+            // Sabotage: remove the `m.Remove(MessageFields.UserId)` in
+            // EnqueueTrack and this test leaks reproducibly.
+            const int iterations = 200;
+            const int trackersPerIteration = 4;
+            const string testUserId = "user_race_stress";
+
+            for (int iter = 0; iter < iterations; iter++)
+            {
+                ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
+                ImmutableAudience.Identify(testUserId, "steam");
+
+                // Clear Init events so only race events can leak.
+                ImmutableAudience.FlushQueueToDiskForTesting();
+                var queueDir = AudiencePaths.QueueDir(_testDir);
+                if (Directory.Exists(queueDir))
+                    foreach (var f in Directory.GetFiles(queueDir, "*.json")) File.Delete(f);
+
+                var barrier = new Barrier(trackersPerIteration + 1);
+                var trackers = new Task[trackersPerIteration];
+                for (int t = 0; t < trackersPerIteration; t++)
+                {
+                    trackers[t] = Task.Run(() =>
+                    {
+                        barrier.SignalAndWait();
+                        ImmutableAudience.Track("race_stress");
+                    });
+                }
+
+                barrier.SignalAndWait();
+                ImmutableAudience.SetConsent(ConsentLevel.Anonymous);
+                Task.WaitAll(trackers, TimeSpan.FromSeconds(5));
+
+                ImmutableAudience.FlushQueueToDiskForTesting();
+
+                int userIdLeaks = 0;
+                if (Directory.Exists(queueDir))
+                {
+                    userIdLeaks = Directory.GetFiles(queueDir, "*.json")
+                        .Select(File.ReadAllText)
+                        .Count(c => c.Contains($"\"{testUserId}\""));
+                }
+
+                if (userIdLeaks > 0)
+                {
+                    Assert.Fail(
+                        $"iteration {iter}: {userIdLeaks} track events retained userId past SetConsent(Anonymous)");
+                }
+
+                ImmutableAudience.ResetState();
+                if (Directory.Exists(AudiencePaths.AudienceDir(_testDir)))
+                    Directory.Delete(AudiencePaths.AudienceDir(_testDir), recursive: true);
+            }
+        }
+
+        [Test]
         public void ResetState_ClearsIdentityCache_AcrossInitWithDifferentPath()
         {
             // First init: mints and caches an anonymousId under _testDir.


### PR DESCRIPTION
## Summary
- Introduces `ConsentState` — an immutable record packing `(ConsentLevel, UserId)`. `_state` is a `volatile ConsentState`, so a single reference swap publishes both fields atomically and readers never observe `(Anonymous, oldUserId)`.
- Takes `_initLock` in `Identify`, `Reset`, and `SetConsent` around the state swap so the pair stays atomic against concurrent callers.
- Changes `EnqueueChecked` signature: replaces `Func<bool>? stillAllowed` with `Func<Dictionary<string, object>, Dictionary<string, object>?>? transform`. The transform runs under `_drainLock` and returns the (possibly mutated) msg, or `null` to drop.
- Re-reads `_state` inside `_drainLock` at enqueue time: `EnqueueTrack` strips `userId` when the current level is not Full; `EnqueueIdentity` drops when the current level is not Full. Closes the race where a `Track` racing `SetConsent(Full → Anonymous)` could land an old-userId msg on disk after `ApplyAnonymousDowngrade` had already rewritten the queue.
- Adds a 200-iteration × 4-thread stress test: concurrent `Track`s racing `SetConsent(Full → Anonymous)` after `Identify`, asserting zero userId leaks on disk.
- Polyfills `IsExternalInit` — `record { init; }` requires it and `netstandard2.1` (Unity) does not ship it.

Linear:
- [SDK-233](https://linear.app/imtbl/issue/SDK-233) — primary
- [SDK-143](https://linear.app/imtbl/issue/SDK-143) — contributes thread-safety: atomic `ConsentState` makes `SetConsent` callable from any thread

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consent/identity handling and concurrency around event queuing, where mistakes could cause userId leakage or dropped events. Changes are localized and backed by new stress coverage, but affect a privacy-sensitive path.
> 
> **Overview**
> Prevents privacy-related race conditions by replacing separate volatile `_consent`/`_userId` fields with a single `volatile` `ConsentState` record and updating `Identify`, `Reset`, `Shutdown`, `ResetState`, and `SetConsent` to swap this state under `_initLock`.
> 
> Hardens queuing against concurrent consent changes by changing `EventQueue.EnqueueChecked` to accept an under-`_drainLock` transform (mutate/drop message), and routing `Track`/`Identify`/`Alias` through new `EnqueueTrack`/`EnqueueIdentity` helpers that re-read current consent to drop events under `None` and strip `userId` when not `Full`. Adds a stress test covering the Full→Anonymous race and a Unity `IsExternalInit` polyfill to support the new record type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1ee63047c80815d701d5118f20e2d4e47746511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->