### PR TITLE
fix(audience-http): HTTP transport and flush hardening (SDK-234)

### DIFF
--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -554,9 +554,25 @@ namespace Immutable.Audience
 
             queue.FlushSync();
 
-            while (!transport.IsInBackoffWindow &&
-                   await transport.SendBatchAsync().ConfigureAwait(false))
+            // Serialise SendBatchAsync via _sendInFlight. Without the gate,
+            // two concurrent FlushAsync callers both call ReadBatch with the
+            // same paths and double-POST. Poll cheaply while another caller
+            // (timer SendBatch or a racing FlushAsync) holds the gate.
+            while (Interlocked.CompareExchange(ref _sendInFlight, 1, 0) != 0)
             {
+                await Task.Yield();
+            }
+
+            try
+            {
+                while (!transport.IsInBackoffWindow &&
+                       await transport.SendBatchAsync().ConfigureAwait(false))
+                {
+                }
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _sendInFlight, 0);
             }
         }
 

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -555,10 +555,10 @@ namespace Immutable.Audience
 
             queue.FlushSync();
 
-            // Serialise SendBatchAsync via _sendInFlight. Without the gate,
-            // two concurrent FlushAsync callers both call ReadBatch with the
-            // same paths and double-POST. Poll cheaply while another caller
-            // (timer SendBatch or a racing FlushAsync) holds the gate.
+            // Only one send runs at a time. Without this, two FlushAsync
+            // callers would both read the same batch from disk and send it
+            // twice. Yield while another caller (the timer or another
+            // FlushAsync) holds the in-flight slot.
             while (Interlocked.CompareExchange(ref _sendInFlight, 1, 0) != 0)
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -543,8 +543,9 @@ namespace Immutable.Audience
         // Flush / Shutdown
         // -----------------------------------------------------------------
 
-        // Sends all pending events now.
-        public static async Task FlushAsync()
+        // Sends all pending events now. Respects cancellationToken for both
+        // the gate wait and the HTTP send.
+        public static async Task FlushAsync(CancellationToken cancellationToken = default)
         {
             if (!_initialized) return;
 
@@ -560,15 +561,21 @@ namespace Immutable.Audience
             // (timer SendBatch or a racing FlushAsync) holds the gate.
             while (Interlocked.CompareExchange(ref _sendInFlight, 1, 0) != 0)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 await Task.Yield();
             }
 
             try
             {
                 while (!transport.IsInBackoffWindow &&
-                       await transport.SendBatchAsync().ConfigureAwait(false))
+                       await transport.SendBatchAsync(cancellationToken).ConfigureAwait(false))
                 {
                 }
+            }
+            catch (ObjectDisposedException)
+            {
+                // Concurrent Shutdown disposed the transport. Exit silently —
+                // caller is tearing down.
             }
             finally
             {

--- a/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
+++ b/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
@@ -41,7 +41,11 @@ namespace Immutable.Audience
             _publishableKey = publishableKey ?? throw new ArgumentNullException(nameof(publishableKey));
             _url = Constants.MessagesUrl(publishableKey);
             _onError = onError;
-            _client = handler != null ? new HttpClient(handler) : new HttpClient();
+            // disposeHandler: false so the consumer can reuse their handler
+            // across Init/Shutdown cycles (matches _controlClient's policy).
+            _client = handler != null
+                ? new HttpClient(handler, disposeHandler: false)
+                : new HttpClient();
             _client.Timeout = TimeSpan.FromSeconds(30);
             _getUtcNow = getUtcNow ?? (() => DateTime.UtcNow);
         }

--- a/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
+++ b/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
@@ -99,9 +99,17 @@ namespace Immutable.Audience
 
                 if (statusCode >= 200 && statusCode < 300)
                 {
-                    // 2xx: server acked, drop the batch, healthy state.
+                    // 2xx: server acked. Parse {accepted, rejected} and surface
+                    // any partial rejections via onError — rejected events are
+                    // validation errors, won't succeed on retry.
+                    var rejected = await ParseRejectedCount(response).ConfigureAwait(false);
                     _store.Delete(batch);
                     ResetBackoff();
+                    if (rejected > 0)
+                    {
+                        NotifyError(AudienceErrorCode.ValidationRejected,
+                            $"Batch partially rejected: {rejected} of {batch.Count} events dropped");
+                    }
                 }
                 else if (statusCode >= 400 && statusCode < 500)
                 {
@@ -223,6 +231,39 @@ namespace Immutable.Audience
 
             sb.Append("]}");
             return sb.ToString();
+        }
+
+        // Reads the body and extracts "rejected". Returns 0 on any parse or
+        // read failure — the body is diagnostic, so a malformed one must not
+        // block the success path.
+        private static async Task<int> ParseRejectedCount(HttpResponseMessage response)
+        {
+            string body;
+            try
+            {
+                body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+                return 0;
+            }
+            if (string.IsNullOrEmpty(body)) return 0;
+
+            try
+            {
+                var parsed = JsonReader.DeserializeObject(body);
+                if (!parsed.TryGetValue("rejected", out var raw)) return 0;
+                return raw switch
+                {
+                    int i => i,
+                    long l => (int)l,
+                    _ => 0,
+                };
+            }
+            catch (FormatException)
+            {
+                return 0;
+            }
         }
 
         private void NotifyError(AudienceErrorCode code, string message)

--- a/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
+++ b/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
@@ -99,9 +99,10 @@ namespace Immutable.Audience
 
                 if (statusCode >= 200 && statusCode < 300)
                 {
-                    // 2xx: server acked. Parse {accepted, rejected} and surface
-                    // any partial rejections via onError — rejected events are
-                    // validation errors, won't succeed on retry.
+                    // Server accepted the batch. Count how many messages it
+                    // rejected; if any, tell the studio via onError. Rejected
+                    // messages are validation failures — retrying won't help,
+                    // so the batch is deleted either way.
                     var rejected = await ParseRejectedCount(response).ConfigureAwait(false);
                     _store.Delete(batch);
                     ResetBackoff();
@@ -233,9 +234,9 @@ namespace Immutable.Audience
             return sb.ToString();
         }
 
-        // Reads the body and extracts "rejected". Returns 0 on any parse or
-        // read failure — the body is diagnostic, so a malformed one must not
-        // block the success path.
+        // Reads the response body and pulls out the "rejected" count. Returns
+        // 0 if the body is missing or unreadable — the body is only for
+        // reporting, so failing to read it must not break the success path.
         private static async Task<int> ParseRejectedCount(HttpResponseMessage response)
         {
             string body;

--- a/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
+++ b/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
@@ -131,10 +131,15 @@ namespace Immutable.Audience
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
-                // Caller cancelled the token (e.g. on shutdown). Events stay on
-                // disk, no failure recorded. HttpClient timeouts throw the same
-                // exception but without ct.IsCancellationRequested set, so they
-                // fall through to the Exception branch below and trigger backoff.
+                // Caller cancelled the token (e.g. on shutdown). Events stay
+                // on disk, no failure recorded. Rethrow so the caller's send
+                // loop exits — swallowing here returns `true`, and the loop
+                // would re-enter on the same cancelled token and spin because
+                // the batch is still on disk. HttpClient timeouts throw the
+                // same exception but without ct.IsCancellationRequested set,
+                // so they fall through to the Exception branch below and
+                // trigger backoff.
+                throw;
             }
             catch (Exception ex)
             {

--- a/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
+++ b/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
@@ -22,6 +22,7 @@ namespace Immutable.Audience
         private readonly Action<AudienceError>? _onError;
         private readonly Func<DateTime> _getUtcNow;
 
+        private readonly object _backoffLock = new object();
         private int _consecutiveFailures;
         private DateTime? _nextAttemptAt;
 
@@ -131,7 +132,15 @@ namespace Immutable.Audience
             return true;
         }
 
-        internal int BackoffMs => _consecutiveFailures switch
+        internal int BackoffMs
+        {
+            get
+            {
+                lock (_backoffLock) return BackoffMsLocked();
+            }
+        }
+
+        private int BackoffMsLocked() => _consecutiveFailures switch
         {
             <= 0 => 0,
             1 => 5_000,
@@ -143,10 +152,16 @@ namespace Immutable.Audience
 
         // Earliest UTC time at which the next attempt may run.
         // Null when no backoff is active.
-        internal DateTime? NextAttemptAt => _nextAttemptAt;
+        internal DateTime? NextAttemptAt
+        {
+            get { lock (_backoffLock) return _nextAttemptAt; }
+        }
 
         // True while UtcNow < NextAttemptAt. Flips false as the clock advances.
-        internal bool IsInBackoffWindow => _getUtcNow() < _nextAttemptAt;
+        internal bool IsInBackoffWindow
+        {
+            get { lock (_backoffLock) return _getUtcNow() < _nextAttemptAt; }
+        }
 
         public void Dispose()
         {
@@ -155,17 +170,22 @@ namespace Immutable.Audience
 
         private void RecordFailure()
         {
-            var now = _getUtcNow();
-            if (now < _nextAttemptAt) return;  // inside prior window — don't compound backoff
-
-            _consecutiveFailures++;
-            _nextAttemptAt = now.AddMilliseconds(BackoffMs);
+            lock (_backoffLock)
+            {
+                var now = _getUtcNow();
+                if (now < _nextAttemptAt) return;  // inside prior window — don't compound backoff
+                _consecutiveFailures++;
+                _nextAttemptAt = now.AddMilliseconds(BackoffMsLocked());
+            }
         }
 
         private void ResetBackoff()
         {
-            _consecutiveFailures = 0;
-            _nextAttemptAt = null;
+            lock (_backoffLock)
+            {
+                _consecutiveFailures = 0;
+                _nextAttemptAt = null;
+            }
         }
 
         // Reads each path and wraps the concatenated JSON bodies in

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -1145,6 +1145,39 @@ namespace Immutable.Audience.Tests
                 "overlapping tick must not issue a second HTTP request");
         }
 
+        [Test]
+        public void FlushAsync_ConcurrentCallers_OnlyOneReachesTransport()
+        {
+            // Two parallel FlushAsync calls must serialise on _sendInFlight so
+            // ReadBatch/POST pairs do not double-send. Sabotage: remove the
+            // gate in FlushAsync and this test sees RequestCount > 1.
+            var handler = new BlockingHandler();
+            var config = MakeConfig();
+            config.HttpHandler = handler;
+
+            ImmutableAudience.Init(config);
+            ImmutableAudience.Track("event_to_send");
+            ImmutableAudience.FlushQueueToDiskForTesting();
+
+            // First caller enters SendAsync and blocks on handler.Release.
+            var flush1 = Task.Run(() => ImmutableAudience.FlushAsync());
+            Assert.IsTrue(handler.EnteredSendAsync.Wait(TimeSpan.FromSeconds(2)),
+                "first FlushAsync should reach the HTTP handler");
+
+            // Second caller starts while the first holds the gate — it must
+            // wait, not issue a second request.
+            var flush2 = Task.Run(() => ImmutableAudience.FlushAsync());
+
+            // Give the second caller a moment to try (and back off).
+            Thread.Sleep(200);
+            Assert.AreEqual(1, handler.RequestCount,
+                "second FlushAsync must not issue a second HTTP request while the first is in-flight");
+
+            handler.Release.Set();
+            Assert.IsTrue(Task.WaitAll(new[] { flush1, flush2 }, TimeSpan.FromSeconds(10)),
+                "both FlushAsync calls should complete after release");
+        }
+
         private class BlockingHandler : HttpMessageHandler
         {
             public readonly ManualResetEventSlim EnteredSendAsync = new ManualResetEventSlim(false);

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -1178,6 +1178,63 @@ namespace Immutable.Audience.Tests
                 "both FlushAsync calls should complete after release");
         }
 
+        [Test]
+        public async Task FlushAsync_CancelledToken_Terminates_DoesNotHotLoop()
+        {
+            // Regression for PR #701 review (@nattb8): if SendBatchAsync
+            // silently swallowed caller cancellation, the inner while-loop
+            // here would re-enter on the same cancelled token and spin
+            // because the batch is never deleted on that code path. The
+            // task below would never complete. After the fix, cancellation
+            // propagates and the task faults quickly.
+            var handler = new CancellingHandler();
+            var config = MakeConfig();
+            config.HttpHandler = handler;
+
+            ImmutableAudience.Init(config);
+            ImmutableAudience.Track("event_to_send");
+            ImmutableAudience.FlushQueueToDiskForTesting();
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var flush = ImmutableAudience.FlushAsync(cts.Token);
+            var finishedFirst = await Task.WhenAny(flush, Task.Delay(TimeSpan.FromSeconds(2)));
+
+            Assert.AreSame(flush, finishedFirst,
+                "FlushAsync must terminate (not hot-loop) when the token is cancelled");
+            Assert.IsTrue(flush.IsCanceled || flush.IsFaulted,
+                "FlushAsync must propagate the cancellation, not return normally");
+            Assert.LessOrEqual(handler.CallCount, 1,
+                "a cancelled token must not drive repeated SendAsync attempts");
+
+            // Gate must be released by the finally block — a follow-up flush
+            // on an uncancelled token should proceed, proving _sendInFlight
+            // is not stranded at 1.
+            handler.AcceptNextAsSuccess = true;
+            var followUp = ImmutableAudience.FlushAsync();
+            Assert.IsTrue(followUp.Wait(TimeSpan.FromSeconds(2)),
+                "_sendInFlight must be released after a cancelled flush");
+        }
+
+        private class CancellingHandler : HttpMessageHandler
+        {
+            public int CallCount;
+            public bool AcceptNextAsSuccess;
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            {
+                Interlocked.Increment(ref CallCount);
+                ct.ThrowIfCancellationRequested();
+                var status = AcceptNextAsSuccess ? HttpStatusCode.OK : HttpStatusCode.ServiceUnavailable;
+                var body = AcceptNextAsSuccess ? "{\"accepted\":1,\"rejected\":0}" : "";
+                return Task.FromResult(new HttpResponseMessage(status)
+                {
+                    Content = new StringContent(body)
+                });
+            }
+        }
+
         private class BlockingHandler : HttpMessageHandler
         {
             public readonly ManualResetEventSlim EnteredSendAsync = new ManualResetEventSlim(false);

--- a/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
@@ -397,6 +397,33 @@ namespace Immutable.Audience.Tests
         }
 
         [Test]
+        public void SendBatchAsync_CallerCancelled_Throws_DoesNotDeleteOrRecordFailure()
+        {
+            // Regression guard for PR #701 review: caller cancellation must
+            // propagate. If the `when (ct.IsCancellationRequested)` branch
+            // swallowed the exception, SendBatchAsync would return `true`
+            // with the batch still on disk, and a FlushAsync loop watching
+            // that return value would re-enter on the same cancelled token
+            // forever — nothing ever drains, nothing ever throws.
+            _store.Write("{\"type\":\"track\"}");
+
+            var handler = new MockHandler(() => throw new OperationCanceledException("simulated"));
+            AudienceError reportedError = null;
+            using var transport = new HttpTransport(_store, "pk_imapik-test-key1",
+                onError: e => reportedError = e, handler: handler);
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await transport.SendBatchAsync(cts.Token));
+
+            Assert.AreEqual(1, _store.Count(), "cancelled send must not delete the batch");
+            Assert.IsFalse(transport.IsInBackoffWindow, "cancel is not a failure — no backoff engaged");
+            Assert.IsNull(reportedError, "cancel is caller-initiated — no onError fires");
+        }
+
+        [Test]
         public async Task IsInBackoffWindow_ClearsAfterNextAttemptAtElapses()
         {
             _store.Write("{\"type\":\"track\"}");

--- a/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
@@ -415,7 +415,10 @@ namespace Immutable.Audience.Tests
             using var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            Assert.ThrowsAsync<OperationCanceledException>(
+            // CatchAsync (not ThrowsAsync) because HttpClient re-wraps our mock's
+            // OperationCanceledException as TaskCanceledException before rethrowing.
+            // We want to assert the cancellation *family*, not a specific subclass.
+            Assert.CatchAsync<OperationCanceledException>(
                 async () => await transport.SendBatchAsync(cts.Token));
 
             Assert.AreEqual(1, _store.Count(), "cancelled send must not delete the batch");

--- a/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
@@ -183,6 +183,61 @@ namespace Immutable.Audience.Tests
         }
 
         [Test]
+        public async Task SendBatchAsync_200_WithRejected_DeletesFilesAndSurfacesValidationRejected()
+        {
+            // Per Unity Implementation Plan §4.6, a 200 with rejected>0 means
+            // per-message validation errors. The batch is deleted (retries
+            // would not help) and the count is surfaced via onError so
+            // studios can observe silently dropped events.
+            _store.Write("{\"type\":\"track\",\"eventName\":\"a\"}");
+            _store.Write("{\"type\":\"track\",\"eventName\":\"b\"}");
+
+            var handler = new MockHandler(HttpStatusCode.OK, "{\"accepted\":1,\"rejected\":1}");
+            AudienceError reportedError = null;
+            using var transport = new HttpTransport(_store, "pk_imapik-test-key1",
+                onError: e => reportedError = e, handler: handler);
+
+            await transport.SendBatchAsync();
+
+            Assert.AreEqual(0, _store.Count(), "200 with rejected>0 should still delete the batch");
+            Assert.IsNotNull(reportedError, "partial rejection must surface via onError");
+            Assert.AreEqual(AudienceErrorCode.ValidationRejected, reportedError.Code);
+            StringAssert.Contains("1", reportedError.Message, "message should include the rejected count");
+        }
+
+        [Test]
+        public async Task SendBatchAsync_200_ZeroRejected_DoesNotFireOnError()
+        {
+            _store.Write("{\"type\":\"track\",\"eventName\":\"a\"}");
+
+            var handler = new MockHandler(HttpStatusCode.OK, "{\"accepted\":1,\"rejected\":0}");
+            AudienceError reportedError = null;
+            using var transport = new HttpTransport(_store, "pk_imapik-test-key1",
+                onError: e => reportedError = e, handler: handler);
+
+            await transport.SendBatchAsync();
+
+            Assert.IsNull(reportedError, "zero rejected must not fire onError");
+        }
+
+        [Test]
+        public async Task SendBatchAsync_200_MalformedBody_TreatsAsZeroRejected()
+        {
+            // Malformed diagnostic body must not block the success path.
+            _store.Write("{\"type\":\"track\",\"eventName\":\"a\"}");
+
+            var handler = new MockHandler(HttpStatusCode.OK, "not-json");
+            AudienceError reportedError = null;
+            using var transport = new HttpTransport(_store, "pk_imapik-test-key1",
+                onError: e => reportedError = e, handler: handler);
+
+            await transport.SendBatchAsync();
+
+            Assert.AreEqual(0, _store.Count(), "files should still be deleted on 200");
+            Assert.IsNull(reportedError, "malformed body must not surface an error");
+        }
+
+        [Test]
         public async Task SendBatchAsync_5xx_KeepsFilesAndIncreasesBackoff()
         {
             _store.Write("{\"type\":\"track\"}");


### PR DESCRIPTION
## Summary
- Locks `HttpTransport` backoff state behind `_backoffLock`. Readers (`IsInBackoffWindow`, `NextAttemptAt`, `BackoffMs`, `RescheduleSendTimer`) and writers (`RecordFailure`, `ResetBackoff`) all go through it.
- Stops `HttpTransport.HttpClient` from disposing a consumer-supplied handler (`disposeHandler: false`). Matches the existing `_controlClient` convention.
- Surfaces partial rejection: `SendBatchAsync` parses `{accepted, rejected}` from the 2xx body and fires `OnError(ValidationRejected, ...)` with the count when `rejected > 0`. Malformed body falls through as zero-rejected so a diagnostic parse error never blocks the success path.
- Gates `FlushAsync` on the existing `_sendInFlight` flag (the same gate the timer tick uses). Two parallel callers no longer double-POST the same batch; the second polls via `Task.Yield` until the first releases.
- Adds optional `CancellationToken cancellationToken = default` to `FlushAsync` (no behaviour change for existing callers) and catches `ObjectDisposedException` thrown when a concurrent `Shutdown` disposes the transport mid-flush.
- Adds 4 tests — concurrent-flush serialisation, partial-rejection warning on 200 with `rejected > 0`, zero-rejected silence, malformed-body fall-through.

Linear: [SDK-234](https://linear.app/imtbl/issue/SDK-234)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the SDK’s event flushing/network send path, adding new concurrency and cancellation behavior plus backoff locking; regressions could affect delivery, retries, or shutdown behavior under load.
> 
> **Overview**
> **Hardens event flushing and HTTP transport behavior** to avoid duplicate sends and improve observability.
> 
> `ImmutableAudience.FlushAsync` now accepts an optional `CancellationToken`, serializes concurrent flushes using the existing `_sendInFlight` gate (preventing double-POST of the same on-disk batch), and exits cleanly if a concurrent `Shutdown` disposes the transport.
> 
> `HttpTransport` now (1) locks all backoff state reads/writes, (2) avoids disposing a consumer-provided `HttpMessageHandler`, (3) surfaces *partial* 2xx acceptance by parsing `rejected` from the response body and firing `OnError(ValidationRejected, ...)`, and (4) rethrows caller-initiated cancellation so flush loops don’t hot-spin. Tests were added to cover concurrent flush serialization, cancellation propagation, and the new 200-with-rejected response handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b588bdf10ec43a569dda993dccc81697a67b6d07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->