### PR TITLE
fix(audience): Init does not mutate caller's AudienceConfig (SDK-235)

### DIFF
--- a/src/Packages/Audience/Runtime/AudienceConfig.cs
+++ b/src/Packages/Audience/Runtime/AudienceConfig.cs
@@ -41,9 +41,10 @@ namespace Immutable.Audience
         // Test seam for HttpTransport; not part of the public API.
         internal System.Net.Http.HttpMessageHandler? HttpHandler { get; set; }
 
-        // Shallow copy so Init can populate PersistentDataPath without mutating
-        // the caller's object. Reference-typed properties (OnError, HttpHandler)
-        // are intentionally shared — cloning delegates/handlers is wrong.
+        // Makes a shallow copy so Init can fill in PersistentDataPath without
+        // modifying the caller's object. Delegates and handlers (OnError,
+        // HttpHandler) are deliberately kept as the same instance — cloning
+        // them would break their behaviour.
         internal AudienceConfig Clone() => (AudienceConfig)MemberwiseClone();
     }
 }

--- a/src/Packages/Audience/Runtime/AudienceConfig.cs
+++ b/src/Packages/Audience/Runtime/AudienceConfig.cs
@@ -40,5 +40,10 @@ namespace Immutable.Audience
 
         // Test seam for HttpTransport; not part of the public API.
         internal System.Net.Http.HttpMessageHandler? HttpHandler { get; set; }
+
+        // Shallow copy so Init can populate PersistentDataPath without mutating
+        // the caller's object. Reference-typed properties (OnError, HttpHandler)
+        // are intentionally shared — cloning delegates/handlers is wrong.
+        internal AudienceConfig Clone() => (AudienceConfig)MemberwiseClone();
     }
 }

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -50,6 +50,8 @@ namespace Immutable.Audience
             if (string.IsNullOrEmpty(config.PublishableKey))
                 throw new ArgumentException("PublishableKey is required", nameof(config));
 
+            // Clone so Init's PersistentDataPath fill-in does not mutate the caller's object.
+            config = config.Clone();
             if (string.IsNullOrEmpty(config.PersistentDataPath))
                 config.PersistentDataPath = DefaultPersistentDataPathProvider?.Invoke();
             if (string.IsNullOrEmpty(config.PersistentDataPath))

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -47,12 +47,14 @@ namespace Immutable.Audience
         public static void Init(AudienceConfig config)
         {
             if (config == null) throw new ArgumentNullException(nameof(config));
-            if (string.IsNullOrEmpty(config.PublishableKey))
-                throw new ArgumentException("PublishableKey is required", nameof(config));
 
             // Copy the caller's config so filling in PersistentDataPath below
-            // doesn't change the object they passed in.
+            // doesn't change the object they passed in. Validating after the
+            // clone keeps the compiler's null-flow analysis for PublishableKey
+            // alive through the HttpTransport constructor below.
             config = config.Clone();
+            if (string.IsNullOrEmpty(config.PublishableKey))
+                throw new ArgumentException("PublishableKey is required", nameof(config));
             if (string.IsNullOrEmpty(config.PersistentDataPath))
                 config.PersistentDataPath = DefaultPersistentDataPathProvider?.Invoke();
             if (string.IsNullOrEmpty(config.PersistentDataPath))

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -50,7 +50,8 @@ namespace Immutable.Audience
             if (string.IsNullOrEmpty(config.PublishableKey))
                 throw new ArgumentException("PublishableKey is required", nameof(config));
 
-            // Clone so Init's PersistentDataPath fill-in does not mutate the caller's object.
+            // Copy the caller's config so filling in PersistentDataPath below
+            // doesn't change the object they passed in.
             config = config.Clone();
             if (string.IsNullOrEmpty(config.PersistentDataPath))
                 config.PersistentDataPath = DefaultPersistentDataPathProvider?.Invoke();


### PR DESCRIPTION
## Summary
- Adds internal `AudienceConfig.Clone()` backed by `MemberwiseClone`. Reference-typed properties (`OnError`, `HttpHandler`) remain shared — cloning delegates or handlers would break them.
- Clones the caller's config inside `Init` before writing the resolved `PersistentDataPath`, so callers who reuse a config (tests, retry flows, domain-reload scenarios) no longer observe a mutated field.

Linear: [SDK-235](https://linear.app/imtbl/issue/SDK-235)
