### PR TITLE
feat(audience): Json.Serialize pretty-print overload + Samples.SampleApp IVT (SDK-231)

### DIFF
--- a/src/Packages/Audience/Runtime/AssemblyInfo.cs
+++ b/src/Packages/Audience/Runtime/AssemblyInfo.cs
@@ -2,3 +2,8 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Immutable.Audience.Runtime.Tests")]
 [assembly: InternalsVisibleTo("Immutable.Audience.Unity")]
+
+// First-party SampleApp reaches Json.Serialize and
+// JsonReader.DeserializeObject; both stay internal so their
+// signatures aren't frozen into the public API.
+[assembly: InternalsVisibleTo("Immutable.Audience.Samples.SampleApp")]

--- a/src/Packages/Audience/Runtime/Utility/Json.cs
+++ b/src/Packages/Audience/Runtime/Utility/Json.cs
@@ -10,11 +10,23 @@ namespace Immutable.Audience
         internal static string Serialize(Dictionary<string, object> data)
         {
             var sb = new StringBuilder();
-            WriteObject(sb, data);
+            WriteObject(sb, data, indent: 0, depth: 0);
             return sb.ToString();
         }
 
-        private static void WriteValue(StringBuilder sb, object value)
+        // Pretty-prints `data` with `indent` spaces per nesting level.
+        // Round-trips through Deserialize identically. Indent ≤ 0 returns
+        // the compact form. Use for human-readable output; wire payloads
+        // use the compact overload.
+        internal static string Serialize(Dictionary<string, object> data, int indent)
+        {
+            if (indent <= 0) return Serialize(data);
+            var sb = new StringBuilder();
+            WriteObject(sb, data, indent, depth: 0);
+            return sb.ToString();
+        }
+
+        private static void WriteValue(StringBuilder sb, object value, int indent, int depth)
         {
             if (value == null)
             {
@@ -56,11 +68,11 @@ namespace Immutable.Audience
             }
             else if (value is Dictionary<string, object> dict)
             {
-                WriteObject(sb, dict);
+                WriteObject(sb, dict, indent, depth);
             }
             else if (value is IList list)
             {
-                WriteArray(sb, list);
+                WriteArray(sb, list, indent, depth);
             }
             else
             {
@@ -68,32 +80,46 @@ namespace Immutable.Audience
             }
         }
 
-        private static void WriteObject(StringBuilder sb, Dictionary<string, object> dict)
+        private static void WriteObject(StringBuilder sb, Dictionary<string, object> dict, int indent, int depth)
         {
             sb.Append('{');
+            if (dict.Count == 0) { sb.Append('}'); return; }
+
+            var pretty = indent > 0;
             var first = true;
             foreach (var kvp in dict)
             {
-                if (!first)
-                    sb.Append(',');
+                if (!first) sb.Append(',');
                 first = false;
+                if (pretty) AppendNewline(sb, indent, depth + 1);
                 WriteString(sb, kvp.Key);
-                sb.Append(':');
-                WriteValue(sb, kvp.Value);
+                sb.Append(pretty ? ": " : ":");
+                WriteValue(sb, kvp.Value, indent, depth + 1);
             }
+            if (pretty) AppendNewline(sb, indent, depth);
             sb.Append('}');
         }
 
-        private static void WriteArray(StringBuilder sb, IList list)
+        private static void WriteArray(StringBuilder sb, IList list, int indent, int depth)
         {
             sb.Append('[');
+            if (list.Count == 0) { sb.Append(']'); return; }
+
+            var pretty = indent > 0;
             for (var i = 0; i < list.Count; i++)
             {
-                if (i > 0)
-                    sb.Append(',');
-                WriteValue(sb, list[i]);
+                if (i > 0) sb.Append(',');
+                if (pretty) AppendNewline(sb, indent, depth + 1);
+                WriteValue(sb, list[i], indent, depth + 1);
             }
+            if (pretty) AppendNewline(sb, indent, depth);
             sb.Append(']');
+        }
+
+        private static void AppendNewline(StringBuilder sb, int indent, int depth)
+        {
+            sb.Append('\n');
+            sb.Append(' ', indent * depth);
         }
 
         private static void WriteString(StringBuilder sb, string s)

--- a/src/Packages/Audience/Tests/Audience.Tests.csproj
+++ b/src/Packages/Audience/Tests/Audience.Tests.csproj
@@ -15,4 +15,12 @@
   <ItemGroup>
     <ProjectReference Include="../Runtime/Audience.Runtime.csproj" />
   </ItemGroup>
+  <!--
+    Exclude Tests/Editor/ from the headless dotnet build. Those tests reference
+    Unity-only types (MonoBehaviour, VisualElement, SampleApp MonoBehaviour)
+    and run inside the Unity Test Framework in-editor.
+  -->
+  <ItemGroup>
+    <Compile Remove="Editor/**/*.cs" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- `Json.Serialize(dict, indent)` pretty-print overload — `indent ≤ 0` routes to the compact `Serialize`, so every wire-payload caller is unaffected.
- `InternalsVisibleTo("Immutable.Audience.Samples.SampleApp")` so the in-repo sample reaches `Json.Serialize` / `JsonReader.DeserializeObject` without widening the public API.
- `Audience.Tests.csproj` excludes `Editor/**/*.cs` from the headless dotnet build — no-op today, prereq for the sample-app PR whose editor-only tests reference Unity types.

Closes [SDK-231](https://linear.app/imtbl/issue/SDK-231). Prereq for [SDK-230](https://linear.app/imtbl/issue/SDK-230) (Unity Audience SampleApp) landing next.

## Test plan
- [ ] `dotnet test src/Packages/Audience/Tests/Audience.Tests.csproj` passes.
- [ ] Unity Test Runner (2022 LTS+): existing `JsonTests` fixture still passes; pretty-print round-trips through `Deserialize` identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core JSON serialization used for event storage/network payloads; while the default compact path is intended to be unchanged, regressions could affect message formatting/round-tripping. Build changes also alter which tests compile in headless CI, potentially hiding Unity-only failures outside the Unity runner.
> 
> **Overview**
> Adds a new `Json.Serialize(dict, indent)` overload to optionally pretty-print JSON with indentation, while keeping the existing `Serialize(dict)` as the compact default for wire/disk payloads.
> 
> Refactors the JSON writer to thread `indent`/`depth` through object/array/value writing and insert newlines/spaces only when pretty-printing. Also grants `InternalsVisibleTo` for `Immutable.Audience.Samples.SampleApp` and excludes `Editor/**/*.cs` from the headless `Audience.Tests` build to avoid Unity-only compile dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73d3e467ea7d3ac1cb787bc69e94afefd94a7957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->