### PR TITLE
feat(audience-unity): Unity integration (SDK-146 / 227 / 228)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,16 @@
 [Ll]ogs/
 [Uu]ser[Ss]ettings/
 
+# dotnet build outputs redirected here via Directory.Build.props files
+# so bin/obj don't sit inside Unity package folders and get scanned.
+/artifacts/
+
+# IDE and MSBuild extensibility sidecars Unity emits .meta for when the
+# files land inside the package root.
+*.DotSettings.user.meta
+Directory.Build.props.meta
+Directory.Build.targets.meta
+
 # MemoryCaptures can get excessive in size.
 # They also could contain extremely sensitive data
 /[Mm]emoryCaptures/

--- a/src/Packages/Audience/Directory.Build.props
+++ b/src/Packages/Audience/Directory.Build.props
@@ -1,0 +1,21 @@
+<Project>
+  <!--
+    Redirect dotnet build outputs to a repo-root artifacts/ folder so they
+    don't leak into the Unity package directory. When the package is
+    referenced from a Unity project via a `file:` path, Unity scans every
+    folder under the package root. Finding bin/obj/*.dll trips
+    "Multiple precompiled assemblies" errors and the locale-specific
+    resource DLLs also confuse Unity's asset importer.
+
+    Targets:
+      artifacts/Audience.Runtime/bin|obj/
+      artifacts/Audience.Tests/bin|obj/
+
+    $(MSBuildThisFileDirectory) here = src/Packages/Audience/
+    ../../../artifacts/ = <repo-root>/artifacts/
+  -->
+  <PropertyGroup>
+    <BaseOutputPath>$(MSBuildThisFileDirectory)../../../artifacts/$(MSBuildProjectName)/bin/</BaseOutputPath>
+    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)../../../artifacts/$(MSBuildProjectName)/obj/</BaseIntermediateOutputPath>
+  </PropertyGroup>
+</Project>

--- a/src/Packages/Audience/Runtime/AudienceConfig.cs
+++ b/src/Packages/Audience/Runtime/AudienceConfig.cs
@@ -10,6 +10,11 @@ namespace Immutable.Audience
         // Studio API key. Required — Init throws if null.
         public string? PublishableKey { get; set; }
 
+        // Override the default API base URL. When null, keys starting with
+        // "pk_imapik-test-" resolve to Sandbox and all other keys resolve
+        // to Production. Set explicitly to target a different backend.
+        public string? BaseUrl { get; set; }
+
         // Initial consent level.
         public ConsentLevel Consent { get; set; } = ConsentLevel.None;
 

--- a/src/Packages/Audience/Runtime/Core/Constants.cs
+++ b/src/Packages/Audience/Runtime/Core/Constants.cs
@@ -26,14 +26,22 @@ namespace Immutable.Audience
 
         internal const string PublishableKeyHeader = "x-immutable-publishable-key";
 
-        internal static string MessagesUrl(string? publishableKey) => BaseUrl(publishableKey) + MessagesPath;
-        internal static string ConsentUrl(string? publishableKey) => BaseUrl(publishableKey) + ConsentPath;
-        internal static string DataUrl(string? publishableKey) => BaseUrl(publishableKey) + DataPath;
+        internal static string MessagesUrl(string? publishableKey, string? baseUrlOverride = null) =>
+            BaseUrl(publishableKey, baseUrlOverride) + MessagesPath;
+        internal static string ConsentUrl(string? publishableKey, string? baseUrlOverride = null) =>
+            BaseUrl(publishableKey, baseUrlOverride) + ConsentPath;
+        internal static string DataUrl(string? publishableKey, string? baseUrlOverride = null) =>
+            BaseUrl(publishableKey, baseUrlOverride) + DataPath;
 
-        internal static string BaseUrl(string? publishableKey) =>
-            publishableKey != null && publishableKey.StartsWith(TestKeyPrefix)
+        // Override wins when non-empty; otherwise test keys map to Sandbox
+        // and every other key maps to Production. Matches @imtbl/audience.
+        internal static string BaseUrl(string? publishableKey, string? baseUrlOverride = null)
+        {
+            if (!string.IsNullOrEmpty(baseUrlOverride)) return baseUrlOverride!;
+            return publishableKey != null && publishableKey.StartsWith(TestKeyPrefix)
                 ? SandboxBaseUrl
                 : ProductionBaseUrl;
+        }
     }
 
     // Message type values written to (and read back from) the "type" field.

--- a/src/Packages/Audience/Runtime/Core/Session.cs
+++ b/src/Packages/Audience/Runtime/Core/Session.cs
@@ -29,7 +29,6 @@ namespace Immutable.Audience
         internal const int PauseTimeoutMs = 30_000;
 
         private readonly TrackDelegate _track;
-        private readonly Func<Dictionary<string, object>>? _performanceSnapshot;
         private readonly Func<DateTime> _getUtcNow;
         private readonly int _heartbeatIntervalMs;
         private readonly object _lock = new object();
@@ -48,16 +47,13 @@ namespace Immutable.Audience
             get { lock (_lock) return _sessionId; }
         }
 
-        // track: fires session events. performanceSnapshot: merges fps/memory
-        // into heartbeats (null on non-Unity). getUtcNow/heartbeatIntervalMs: test seams.
+        // track: fires session events. getUtcNow/heartbeatIntervalMs: test seams.
         internal Session(
             TrackDelegate track,
-            Func<Dictionary<string, object>>? performanceSnapshot = null,
             Func<DateTime>? getUtcNow = null,
             int heartbeatIntervalMs = HeartbeatIntervalMs)
         {
             _track = track ?? throw new ArgumentNullException(nameof(track));
-            _performanceSnapshot = performanceSnapshot;
             _getUtcNow = getUtcNow ?? (() => DateTime.UtcNow);
             _heartbeatIntervalMs = heartbeatIntervalMs;
         }
@@ -252,23 +248,12 @@ namespace Immutable.Audience
                 duration = ComputeEngagedSecondsLocked();
             }
 
-            // Build outside _lock so snapshot + track don't re-enter.
+            // Build outside _lock so track doesn't re-enter.
             var properties = new Dictionary<string, object>
             {
                 ["sessionId"] = sessionId,
                 ["durationSec"] = duration
             };
-
-            var perf = SafePerformanceSnapshot();
-            if (perf != null)
-            {
-                foreach (var kv in perf)
-                {
-                    // Don't let the provider clobber core fields.
-                    if (properties.ContainsKey(kv.Key)) continue;
-                    properties[kv.Key] = kv.Value;
-                }
-            }
 
             SafeTrack("session_heartbeat", properties);
         }
@@ -286,22 +271,6 @@ namespace Immutable.Audience
             catch (Exception ex)
             {
                 Log.Warn($"Session: {eventName} track callback threw {ex.GetType().Name}. Event dropped.");
-            }
-        }
-
-        // Stops exceptions from the studio-supplied snapshot callback from
-        // reaching the background timer.
-        private Dictionary<string, object>? SafePerformanceSnapshot()
-        {
-            if (_performanceSnapshot == null) return null;
-            try
-            {
-                return _performanceSnapshot();
-            }
-            catch (Exception ex)
-            {
-                Log.Warn($"Session: performance snapshot threw {ex.GetType().Name}. Heartbeat ships without performance fields.");
-                return null;
             }
         }
 

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -51,6 +51,56 @@ namespace Immutable.Audience
         // assignments from SetConsent without taking _initLock.
         private static volatile Session? _session;
 
+        // True between Init() and Shutdown().
+        public static bool Initialized => _initialized;
+
+        // The consent level the SDK is currently honouring.
+        public static ConsentLevel CurrentConsent => _state.Level;
+
+        // The user ID from the most recent Identify() call. Null after
+        // Reset() or when consent is below Full.
+        public static string? UserId => _state.UserId;
+
+        // An anonymous, persistent ID — unlike SessionId (rotates per
+        // session) and UserId (identifies the user). Reset() and
+        // SetConsent(None) wipe it; null while consent is None.
+        public static string? AnonymousId
+        {
+            get
+            {
+                if (!_initialized) return null;
+                var config = _config;
+                if (config == null || !_state.Level.CanTrack()) return null;
+                // PersistentDataPath is validated non-null in Init; compiler can't propagate that.
+                return Identity.Get(config.PersistentDataPath!);
+            }
+        }
+
+        // The current session's ID. A new ID is assigned at Init(), at Reset(),
+        // and when the app resumes after the previous session has timed out.
+        // Null while consent is None.
+        public static string? SessionId => _session?.SessionId;
+
+        // Number of unsent events (in memory and on disk).
+        public static int QueueSize
+        {
+            get
+            {
+                // Fence off the volatile _initialized load first, matching
+                // the protocol documented on the reference fields. Without
+                // this, a weak-memory-order reader could observe
+                // _initialized=true but _queue/_store still null — the ?.
+                // short-circuits to 0 in that case, but the inconsistency
+                // would break the protocol the file claims to follow.
+                if (!_initialized) return 0;
+                var queue = _queue;
+                var store = _store;
+                var memory = queue?.InMemoryCount ?? 0;
+                var disk = store?.Count() ?? 0;
+                return memory + disk;
+            }
+        }
+
         // Starts the SDK. Call once at launch.
         public static void Init(AudienceConfig config)
         {
@@ -82,7 +132,7 @@ namespace Immutable.Audience
 
                 _store = new DiskStore(config.PersistentDataPath);
                 _queue = new EventQueue(_store, config.FlushIntervalSeconds, config.FlushSize);
-                _transport = new HttpTransport(_store, config.PublishableKey, config.OnError, config.HttpHandler);
+                _transport = new HttpTransport(_store, config.PublishableKey, config.BaseUrl, config.OnError, config.HttpHandler);
                 _controlClient = config.HttpHandler != null
                     ? new HttpClient(config.HttpHandler, disposeHandler: false)
                     : new HttpClient();
@@ -338,7 +388,7 @@ namespace Immutable.Audience
                 query = "anonymousId=" + Uri.EscapeDataString(anonymousId);
             }
 
-            var url = Constants.DataUrl(config.PublishableKey) + "?" + query;
+            var url = Constants.DataUrl(config.PublishableKey, config.BaseUrl) + "?" + query;
             var onError = config.OnError;
             var publishableKey = config.PublishableKey;
             var cancellationToken = _shutdownCancellationSource?.Token ?? CancellationToken.None;
@@ -500,7 +550,7 @@ namespace Immutable.Audience
             var client = _controlClient;
             if (client == null) return;
 
-            var url = Constants.ConsentUrl(config.PublishableKey);
+            var url = Constants.ConsentUrl(config.PublishableKey, config.BaseUrl);
             var publishableKey = config.PublishableKey;
             var onError = config.OnError;
             var cancellationToken = _shutdownCancellationSource?.Token ?? CancellationToken.None;
@@ -718,8 +768,6 @@ namespace Immutable.Audience
                 Identity.ClearCache();
             }
         }
-
-        internal static ConsentLevel CurrentConsent => _state.Level;
 
         internal static void FlushQueueToDiskForTesting() => _queue?.FlushSync();
 

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -38,12 +38,13 @@ namespace Immutable.Audience
         // Gate against overlapping timer ticks (Timer callbacks run on independent ThreadPool threads).
         private static int _sendInFlight;
 
-        // AudienceUnityHooks sets these at SubsystemRegistration.
-        // DefaultPersistentDataPathProvider fills PersistentDataPath from
-        // Application.persistentDataPath. LaunchContextProvider supplies
-        // Unity context for game_launch without Core referencing UnityEngine.
-        internal static Func<string>? DefaultPersistentDataPathProvider;
-        internal static Func<Dictionary<string, object>>? LaunchContextProvider;
+        // volatile: assigned on the Unity main thread at SubsystemRegistration,
+        // read from the drain thread in Track / Identify paths.
+        // The assignments happen before any event can fire in practice, but
+        // volatile documents the cross-thread publish contract explicitly.
+        internal static volatile Func<string>? DefaultPersistentDataPathProvider;
+        internal static volatile Func<IReadOnlyDictionary<string, object>>? LaunchContextProvider;
+        internal static volatile Func<IReadOnlyDictionary<string, object>>? ContextProvider;
 
         // Active session. Created at Init (or on upgrade from None) and disposed
         // on Shutdown or SetConsent(None). Volatile so OnPause/OnResume see
@@ -701,9 +702,7 @@ namespace Immutable.Audience
         // Internal — shared with tests and AudienceUnityHooks
         // -----------------------------------------------------------------
 
-        // Shuts down (if initialised) and clears per-session state. Used on
-        // test teardown and Unity SubsystemRegistration to survive "disable
-        // domain reload". LaunchContextProvider is re-assigned by AudienceUnityHooks.
+        // Providers reassigned by SubsystemRegistration.
         internal static void ResetState()
         {
             // Shutdown manages its own serialisation and releases _initLock before
@@ -743,6 +742,7 @@ namespace Immutable.Audience
         // Anonymous the userId is stripped.
         private static void EnqueueTrack(Dictionary<string, object>? msg)
         {
+            MergeUnityContext(msg);
             _queue?.EnqueueChecked(msg, m =>
             {
                 var state = _state;
@@ -756,8 +756,39 @@ namespace Immutable.Audience
         // Identify / Alias require Full; drop if consent has downgraded.
         private static void EnqueueIdentity(Dictionary<string, object>? msg)
         {
+            MergeUnityContext(msg);
             _queue?.EnqueueChecked(msg, m =>
                 _state.Level == ConsentLevel.Full ? m : null);
+        }
+
+        private static void MergeUnityContext(Dictionary<string, object>? msg)
+        {
+            if (msg == null) return;
+
+            var provider = ContextProvider;
+            if (provider == null) return;
+
+            IReadOnlyDictionary<string, object>? extra;
+            try
+            {
+                extra = provider();
+            }
+            catch (Exception ex)
+            {
+                Log.Warn($"ContextProvider threw {ex.GetType().Name}: {ex.Message}. " +
+                         "Event ships with base context only.");
+                return;
+            }
+            if (extra == null) return;
+
+            if (!(msg.TryGetValue("context", out var ctxObj) && ctxObj is Dictionary<string, object> ctx))
+            {
+                ctx = new Dictionary<string, object>();
+                msg["context"] = ctx;
+            }
+
+            foreach (var kv in extra)
+                ctx[kv.Key] = kv.Value;
         }
 
         private static void SendBatch()
@@ -825,7 +856,7 @@ namespace Immutable.Audience
             var provider = LaunchContextProvider;
             if (provider != null)
             {
-                Dictionary<string, object>? unityContext = null;
+                IReadOnlyDictionary<string, object>? unityContext = null;
                 try { unityContext = provider(); }
                 catch (Exception ex)
                 {

--- a/src/Packages/Audience/Runtime/Transport/EventQueue.cs
+++ b/src/Packages/Audience/Runtime/Transport/EventQueue.cs
@@ -49,6 +49,12 @@ namespace Immutable.Audience
             _drainThread.Start();
         }
 
+        // Approximate count of events currently in the in-memory queue
+        // awaiting drain to disk. Lock-free read on ConcurrentQueue.Count
+        // — a snapshot that can race with concurrent enqueue / dequeue.
+        // Good enough for status-panel display; not an invariant.
+        internal int InMemoryCount => _memory.Count;
+
         // Enqueues a message dictionary. Lock-free; safe from any thread.
         // The dictionary is not copied -- callers must not mutate it after
         // enqueue. Serialisation happens on the drain thread so Track() stays

--- a/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
+++ b/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
@@ -28,18 +28,20 @@ namespace Immutable.Audience
 
         // store: source of event batches.
         // publishableKey: sent as x-immutable-publishable-key on every request.
+        // baseUrlOverride: explicit backend URL. Null = derive from publishableKey prefix.
         // onError: optional failure callback. Exceptions thrown inside it are caught.
         // handler / getUtcNow: test seams; null for production use.
         internal HttpTransport(
             DiskStore store,
             string publishableKey,
+            string? baseUrlOverride = null,
             Action<AudienceError>? onError = null,
             HttpMessageHandler? handler = null,
             Func<DateTime>? getUtcNow = null)
         {
             _store = store ?? throw new ArgumentNullException(nameof(store));
             _publishableKey = publishableKey ?? throw new ArgumentNullException(nameof(publishableKey));
-            _url = Constants.MessagesUrl(publishableKey);
+            _url = Constants.MessagesUrl(publishableKey, baseUrlOverride);
             _onError = onError;
             // disposeHandler: false so the consumer can reuse their handler
             // across Init/Shutdown cycles (matches _controlClient's policy).

--- a/src/Packages/Audience/Runtime/Unity/AudienceUnityHooks.cs
+++ b/src/Packages/Audience/Runtime/Unity/AudienceUnityHooks.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using UnityEngine;
 
 namespace Immutable.Audience.Unity
@@ -10,26 +11,25 @@ namespace Immutable.Audience.Unity
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void Install()
         {
-            // Clear surviving statics before re-wiring in case "disable domain reload" kept them alive.
             ImmutableAudience.ResetState();
 
-            // -= then += so repeat SubsystemRegistration cycles don't stack subscriptions.
+            // Avoid stacked subscriptions on reload.
             Application.quitting -= ImmutableAudience.Shutdown;
             Application.quitting += ImmutableAudience.Shutdown;
 
             ImmutableAudience.DefaultPersistentDataPathProvider = () => Application.persistentDataPath;
-            ImmutableAudience.LaunchContextProvider = BuildLaunchContext;
+
+            // Captured once on main thread; ReadOnlyDictionary blocks downstream mutation.
+            IReadOnlyDictionary<string, object> launchProps =
+                new ReadOnlyDictionary<string, object>(DeviceCollector.CollectGameLaunchProperties());
+            IReadOnlyDictionary<string, object> contextProps =
+                new ReadOnlyDictionary<string, object>(DeviceCollector.CollectContext());
+            ImmutableAudience.LaunchContextProvider = () => launchProps;
+            ImmutableAudience.ContextProvider = () => contextProps;
+
+            UnityLifecycleBridge.EnsureExists();
 
             if (Log.Writer == null) Log.Writer = Debug.Log;
         }
-
-        private static Dictionary<string, object> BuildLaunchContext() =>
-            new Dictionary<string, object>
-            {
-                ["platform"] = Application.platform.ToString(),
-                ["version"] = Application.version,
-                ["buildGuid"] = Application.buildGUID,
-                ["unityVersion"] = Application.unityVersion,
-            };
     }
 }

--- a/src/Packages/Audience/Runtime/Unity/DeviceCollector.cs
+++ b/src/Packages/Audience/Runtime/Unity/DeviceCollector.cs
@@ -1,0 +1,102 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using UnityEngine;
+
+namespace Immutable.Audience.Unity
+{
+    internal static class DeviceCollector
+    {
+        internal static Dictionary<string, object> CollectContext()
+        {
+            // 256-char cap mirrors Web SDK's identifier truncation.
+            var ctx = new Dictionary<string, object>
+            {
+                ["userAgent"] = Truncate(SystemInfo.operatingSystem, 256),
+            };
+
+            var timezone = SafeTimezone();
+            if (timezone != null) ctx["timezone"] = Truncate(timezone, 256);
+
+            var locale = LocaleString();
+            if (locale != null) ctx["locale"] = Truncate(locale, 256);
+
+            var screen = TryResolveScreenString();
+            if (screen != null) ctx["screen"] = Truncate(screen, 256);
+
+            return ctx;
+        }
+
+        private static string? TryResolveScreenString()
+        {
+            var resolution = Screen.currentResolution;
+            int width = resolution.width;
+            int height = resolution.height;
+
+            if (width <= 0 || height <= 0)
+            {
+                width = Screen.width;
+                height = Screen.height;
+            }
+
+            if (width <= 0 || height <= 0) return null;
+            return $"{width}x{height}";
+        }
+
+        internal static Dictionary<string, object> CollectGameLaunchProperties()
+        {
+            var props = new Dictionary<string, object>
+            {
+                ["platform"] = Application.platform.ToString(),
+                ["version"] = Truncate(Application.version, 256),
+                ["buildGuid"] = Truncate(Application.buildGUID, 256),
+                ["unityVersion"] = Truncate(Application.unityVersion, 256),
+                ["osFamily"] = SystemInfo.operatingSystemFamily.ToString(),
+                ["deviceModel"] = Truncate(SystemInfo.deviceModel, 256),
+                ["gpu"] = Truncate(SystemInfo.graphicsDeviceName, 256),
+                ["gpuVendor"] = Truncate(SystemInfo.graphicsDeviceVendor, 256),
+                ["cpu"] = Truncate(SystemInfo.processorType, 256),
+                ["cpuCores"] = SystemInfo.processorCount,
+                ["ramMb"] = SystemInfo.systemMemorySize,
+            };
+
+            // Screen.dpi can be 0 on some Linux WMs.
+            var dpi = (int)Screen.dpi;
+            if (dpi > 0) props["screenDpi"] = dpi;
+
+            return props;
+        }
+
+        private static string? LocaleString()
+        {
+            var culture = CultureInfo.CurrentCulture;
+            if (!string.IsNullOrEmpty(culture?.Name))
+                return culture.Name;
+            return null;
+        }
+
+        private static string? SafeTimezone()
+        {
+            try
+            {
+                return TimeZoneInfo.Local.Id;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        private static string Truncate(string s, int max)
+        {
+            if (string.IsNullOrEmpty(s) || s.Length <= max) return s;
+            // Step back one if the cut would split a surrogate pair — leaving
+            // a lone high-surrogate produces invalid UTF-16 on the wire.
+            var cut = max;
+            if (char.IsHighSurrogate(s[cut - 1])) cut--;
+            return s.Substring(0, cut);
+        }
+    }
+}

--- a/src/Packages/Audience/Runtime/Unity/UnityLifecycleBridge.cs
+++ b/src/Packages/Audience/Runtime/Unity/UnityLifecycleBridge.cs
@@ -1,0 +1,49 @@
+#nullable enable
+
+using UnityEngine;
+
+namespace Immutable.Audience.Unity
+{
+    internal sealed class UnityLifecycleBridge : MonoBehaviour
+    {
+        // Volatile: SubsystemRegistration reset vs EnsureExists fence.
+        private static volatile UnityLifecycleBridge? _instance;
+
+        // Drop stale GameObject pointer after Fast Enter Play Mode.
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void ResetStatics()
+        {
+            _instance = null;
+        }
+
+        internal static void EnsureExists()
+        {
+            if (_instance != null) return;
+
+            var go = new GameObject("[ImmutableAudience.LifecycleBridge]");
+            go.hideFlags = HideFlags.HideAndDontSave;
+            DontDestroyOnLoad(go);
+            _instance = go.AddComponent<UnityLifecycleBridge>();
+        }
+
+        private void OnApplicationPause(bool paused)
+        {
+            if (paused) ImmutableAudience.OnPause();
+            else ImmutableAudience.OnResume();
+        }
+
+#if !UNITY_ANDROID && !UNITY_IOS
+        // Desktop only — mobile focus events fire spuriously (soft keyboard, notifications).
+        private void OnApplicationFocus(bool hasFocus)
+        {
+            if (!hasFocus) ImmutableAudience.OnPause();
+            else ImmutableAudience.OnResume();
+        }
+#endif
+
+        private void OnDestroy()
+        {
+            if (_instance == this) _instance = null;
+        }
+    }
+}

--- a/src/Packages/Audience/Runtime/Unity/com.immutable.audience.unity.asmdef
+++ b/src/Packages/Audience/Runtime/Unity/com.immutable.audience.unity.asmdef
@@ -2,7 +2,7 @@
     "name": "Immutable.Audience.Unity",
     "rootNamespace": "Immutable.Audience.Unity",
     "references": ["Immutable.Audience.Runtime"],
-    "includePlatforms": ["Editor","LinuxStandalone64","macOSStandalone","WindowsStandalone64"],
+    "includePlatforms": ["Editor", "macOSStandalone", "WindowsStandalone64"],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/src/Packages/Audience/Runtime/com.immutable.audience.asmdef
+++ b/src/Packages/Audience/Runtime/com.immutable.audience.asmdef
@@ -2,7 +2,7 @@
     "name": "Immutable.Audience.Runtime",
     "rootNamespace": "Immutable.Audience",
     "references": [],
-    "includePlatforms": ["Editor","LinuxStandalone64","macOSStandalone","WindowsStandalone64"],
+    "includePlatforms": ["Editor", "macOSStandalone", "WindowsStandalone64"],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/src/Packages/Audience/Tests/Runtime/ConstantsTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ConstantsTests.cs
@@ -6,6 +6,54 @@ namespace Immutable.Audience.Tests
     [TestFixture]
     internal class ConstantsTests
     {
+        // -----------------------------------------------------------------
+        // BaseUrl resolution
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void BaseUrl_TestKey_ResolvesToSandbox()
+        {
+            Assert.AreEqual(Constants.SandboxBaseUrl,
+                Constants.BaseUrl("pk_imapik-test-abc"));
+        }
+
+        [Test]
+        public void BaseUrl_NonTestKey_ResolvesToProduction()
+        {
+            Assert.AreEqual(Constants.ProductionBaseUrl,
+                Constants.BaseUrl("pk_imapik-prod-abc"));
+        }
+
+        [Test]
+        public void BaseUrl_NullKey_ResolvesToProduction()
+        {
+            Assert.AreEqual(Constants.ProductionBaseUrl,
+                Constants.BaseUrl(null));
+        }
+
+        [Test]
+        public void BaseUrl_Override_WinsOverKeyPrefix()
+        {
+            // Override wins even for a test-prefixed key that would
+            // otherwise derive to Sandbox.
+            const string custom = "https://api.dev.immutable.com";
+            Assert.AreEqual(custom,
+                Constants.BaseUrl("pk_imapik-test-abc", custom));
+        }
+
+        [Test]
+        public void BaseUrl_EmptyOverride_FallsBackToKeyDerivation()
+        {
+            // Empty-string override is treated as "no override" so the
+            // key-prefix fallback still kicks in.
+            Assert.AreEqual(Constants.SandboxBaseUrl,
+                Constants.BaseUrl("pk_imapik-test-abc", ""));
+        }
+
+        // -----------------------------------------------------------------
+        // Library version
+        // -----------------------------------------------------------------
+
         [Test]
         public void LibraryVersion_MatchesPackageJson()
         {

--- a/src/Packages/Audience/Tests/Runtime/ConstantsTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ConstantsTests.cs
@@ -23,11 +23,30 @@ namespace Immutable.Audience.Tests
 
         private static string ReadPackageJson()
         {
-            var testDir = TestContext.CurrentContext.TestDirectory;
-            // Tests/bin/Debug/net8.0/ → Tests/ → Audience/package.json
-            var packagePath = Path.GetFullPath(Path.Combine(testDir, "..", "..", "..", "..", "package.json"));
-            Assert.IsTrue(File.Exists(packagePath), $"package.json not found at {packagePath}");
-            return File.ReadAllText(packagePath);
+            // Walk up from the test binary location looking for the Audience
+            // package directory. Originally this hard-coded four "../" hops
+            // which only worked when bin/ sat inside Tests/. Directory.Build
+            // .props redirects bin/ to the repo-root /artifacts/ folder so
+            // dotnet build outputs don't leak into Unity's scan path — the
+            // relative walk no longer resolves to the package. Searching
+            // upward is robust against either layout.
+            var current = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+            while (current != null)
+            {
+                var candidate = Path.Combine(current.FullName, "src", "Packages", "Audience", "package.json");
+                if (File.Exists(candidate)) return File.ReadAllText(candidate);
+
+                // Also try the direct-inside case (package root itself is
+                // the ancestor), which handles consuming-project layouts
+                // that embed the package without the src/Packages prefix.
+                var direct = Path.Combine(current.FullName, "package.json");
+                if (File.Exists(direct) && current.Name == "Audience") return File.ReadAllText(direct);
+
+                current = current.Parent;
+            }
+
+            throw new FileNotFoundException(
+                $"package.json not found by walking up from {TestContext.CurrentContext.TestDirectory}");
         }
     }
 }

--- a/src/Packages/Audience/Tests/Runtime/Core/SessionTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Core/SessionTests.cs
@@ -57,7 +57,7 @@ namespace Immutable.Audience.Tests
         public void End_FiresSessionEnd_WithDuration()
         {
             var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
-            using var session = new Session(MockTrack, performanceSnapshot: null, getUtcNow: () => now);
+            using var session = new Session(MockTrack, getUtcNow: () => now);
             session.Start();
             now = now.AddSeconds(2);
             session.End();
@@ -126,87 +126,6 @@ namespace Immutable.Audience.Tests
             }
         }
 
-        [Test]
-        public void Heartbeat_WithoutPerformanceSnapshot_OnlyCarriesCoreProperties()
-        {
-            using var session = new Session(MockTrack);
-            session.Start();
-
-            session.OnHeartbeat();
-
-            var beat = _events.Last(e => e.name == "session_heartbeat");
-            CollectionAssert.AreEquivalent(
-                new[] { "sessionId", "durationSec" },
-                beat.props.Keys);
-        }
-
-        [Test]
-        public void Heartbeat_MergesPerformanceSnapshotProperties()
-        {
-            Func<Dictionary<string, object>> snapshot = () => new Dictionary<string, object>
-            {
-                ["fpsAvg"] = 58.4,
-                ["fpsMin"] = 42.1,
-                ["memoryUsedMb"] = 512L,
-                ["memoryReservedMb"] = 768L,
-            };
-            using var session = new Session(MockTrack, snapshot);
-            session.Start();
-
-            session.OnHeartbeat();
-
-            var beat = _events.Last(e => e.name == "session_heartbeat");
-            Assert.AreEqual(58.4, beat.props["fpsAvg"]);
-            Assert.AreEqual(42.1, beat.props["fpsMin"]);
-            Assert.AreEqual(512L, beat.props["memoryUsedMb"]);
-            Assert.AreEqual(768L, beat.props["memoryReservedMb"]);
-            Assert.IsTrue(beat.props.ContainsKey("sessionId"));
-            Assert.IsTrue(beat.props.ContainsKey("durationSec"));
-        }
-
-        [Test]
-        public void Heartbeat_SnapshotCannotOverwriteCoreFields()
-        {
-            // Core fields (sessionId, duration) are owned by Session. A
-            // provider that returns a dictionary containing either key must
-            // not be able to clobber the wire values — otherwise a buggy
-            // studio-side snapshot could silently rewrite session identity
-            // or engagement arithmetic on every heartbeat. Sabotage: removing
-            // the ContainsKey guard lets "spoofed-id" and 99999L land on the
-            // wire and both assertions below fail.
-            Func<Dictionary<string, object>> snapshot = () => new Dictionary<string, object>
-            {
-                ["sessionId"] = "spoofed-id",
-                ["durationSec"] = 99999L,
-                ["fpsAvg"] = 60.0,
-            };
-            using var session = new Session(MockTrack, snapshot);
-            session.Start();
-
-            session.OnHeartbeat();
-
-            var beat = _events.Last(e => e.name == "session_heartbeat");
-            Assert.AreNotEqual("spoofed-id", (string)beat.props["sessionId"],
-                "snapshot must not overwrite Session-owned sessionId");
-            Assert.AreNotEqual(99999L, (long)beat.props["durationSec"],
-                "snapshot must not overwrite Session-owned duration");
-            Assert.AreEqual(60.0, beat.props["fpsAvg"],
-                "non-colliding snapshot fields should still merge");
-        }
-
-        [Test]
-        public void Heartbeat_SnapshotReturningNull_DoesNotThrowAndOmitsFields()
-        {
-            Func<Dictionary<string, object>> snapshot = () => null;
-            using var session = new Session(MockTrack, snapshot);
-            session.Start();
-
-            session.OnHeartbeat();
-
-            var beat = _events.Last(e => e.name == "session_heartbeat");
-            Assert.IsFalse(beat.props.ContainsKey("fpsAvg"));
-        }
-
         // -----------------------------------------------------------------
         // Pause / Resume
         // -----------------------------------------------------------------
@@ -215,7 +134,7 @@ namespace Immutable.Audience.Tests
         public void Pause_ThenResume_ShortPause_ContinuesSession()
         {
             var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
-            using var session = new Session(MockTrack, performanceSnapshot: null, getUtcNow: () => now);
+            using var session = new Session(MockTrack, getUtcNow: () => now);
             session.Start();
             var originalId = session.SessionId;
 
@@ -234,7 +153,7 @@ namespace Immutable.Audience.Tests
             // Uses the injected clock to jump past the 30-second threshold
             // without sleeping.
             var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
-            using var session = new Session(MockTrack, performanceSnapshot: null, getUtcNow: () => now);
+            using var session = new Session(MockTrack, getUtcNow: () => now);
             session.Start();
             var id1 = session.SessionId;
 
@@ -263,7 +182,7 @@ namespace Immutable.Audience.Tests
             var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
             DateTime Clock() => now;
 
-            using var session = new Session(MockTrack, performanceSnapshot: null, getUtcNow: Clock);
+            using var session = new Session(MockTrack, getUtcNow: Clock);
             session.Start();
 
             now = now.AddSeconds(5);
@@ -314,7 +233,7 @@ namespace Immutable.Audience.Tests
             var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
             DateTime Clock() => now;
 
-            using var session = new Session(MockTrack, performanceSnapshot: null, getUtcNow: Clock);
+            using var session = new Session(MockTrack, getUtcNow: Clock);
             session.Start();
 
             now = now.AddSeconds(10); // 10 s engaged
@@ -351,7 +270,7 @@ namespace Immutable.Audience.Tests
             var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
             DateTime Clock() => now;
 
-            using var session = new Session(MockTrack, performanceSnapshot: null, getUtcNow: Clock);
+            using var session = new Session(MockTrack, getUtcNow: Clock);
             session.Start();
 
             now = now.AddSeconds(-3); // clock rewinds after Start, no pause
@@ -377,7 +296,7 @@ namespace Immutable.Audience.Tests
             var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
             DateTime Clock() => now;
 
-            using var session = new Session(MockTrack, performanceSnapshot: null, getUtcNow: Clock);
+            using var session = new Session(MockTrack, getUtcNow: Clock);
             session.Start();
 
             now = now.AddSeconds(10);
@@ -399,7 +318,7 @@ namespace Immutable.Audience.Tests
             var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
             DateTime Clock() => now;
 
-            using var session = new Session(MockTrack, performanceSnapshot: null, getUtcNow: Clock);
+            using var session = new Session(MockTrack, getUtcNow: Clock);
             session.Start();
 
             now = now.AddSeconds(4);
@@ -424,7 +343,7 @@ namespace Immutable.Audience.Tests
             var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
             DateTime Clock() => now;
 
-            using var session = new Session(MockTrack, performanceSnapshot: null, getUtcNow: Clock);
+            using var session = new Session(MockTrack, getUtcNow: Clock);
             session.Start();
 
             now = now.AddSeconds(5);
@@ -452,7 +371,7 @@ namespace Immutable.Audience.Tests
             var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
             DateTime Clock() => now;
 
-            using var session = new Session(MockTrack, performanceSnapshot: null, getUtcNow: Clock);
+            using var session = new Session(MockTrack, getUtcNow: Clock);
             session.Start();
 
             now = now.AddSeconds(10); // 10 s engaged before pause
@@ -474,7 +393,7 @@ namespace Immutable.Audience.Tests
             var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
             DateTime Clock() => now;
 
-            using var session = new Session(MockTrack, performanceSnapshot: null, getUtcNow: Clock);
+            using var session = new Session(MockTrack, getUtcNow: Clock);
             session.Start();
 
             now = now.AddSeconds(4);
@@ -640,43 +559,6 @@ namespace Immutable.Audience.Tests
                 {
                     Assert.IsTrue(warnings.Any(w => w.Contains("session_heartbeat track callback threw")),
                         "SafeTrack must log a warning when the callback throws");
-                }
-            }
-            finally { Log.Writer = prevWriter; }
-        }
-
-        [Test]
-        public void OnHeartbeat_PerformanceSnapshotThrows_ShipsHeartbeatWithoutPerfFields()
-        {
-            // PerformanceSnapshotProvider is studio-supplied and crosses an
-            // API boundary. A throwing provider must not prevent the
-            // heartbeat from shipping — the SafePerformanceSnapshot wrapper
-            // returns null on exception so the heartbeat ships with the
-            // core fields only.
-            var warnings = new List<string>();
-            var prevWriter = Log.Writer;
-            Log.Writer = line => { lock (warnings) warnings.Add(line); };
-            try
-            {
-                Func<Dictionary<string, object>> snapshot = () =>
-                    throw new InvalidOperationException("perf explode");
-
-                using var session = new Session(MockTrack, snapshot);
-                session.Start();
-
-                Assert.DoesNotThrow(() => session.OnHeartbeat(),
-                    "a throwing performance snapshot must not escape Session");
-
-                var beat = _events.Last(e => e.name == "session_heartbeat");
-                CollectionAssert.AreEquivalent(
-                    new[] { "sessionId", "durationSec" },
-                    beat.props.Keys,
-                    "heartbeat should carry only the core fields when the snapshot throws");
-
-                lock (warnings)
-                {
-                    Assert.IsTrue(warnings.Any(w => w.Contains("performance snapshot threw")),
-                        "SafePerformanceSnapshot must log a warning when the provider throws");
                 }
             }
             finally { Log.Writer = prevWriter; }

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -27,6 +27,7 @@ namespace Immutable.Audience.Tests
         {
             ImmutableAudience.ResetState();
             ImmutableAudience.LaunchContextProvider = null;
+            ImmutableAudience.ContextProvider = null;
             ImmutableAudience.DefaultPersistentDataPathProvider = null;
             Identity.Reset(_testDir);
             if (Directory.Exists(_testDir))
@@ -56,6 +57,96 @@ namespace Immutable.Audience.Tests
             {
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
             }
+        }
+
+        // -----------------------------------------------------------------
+        // Unity context provider
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void ContextProvider_Set_MergesFieldsIntoEveryMessageContext()
+        {
+            ImmutableAudience.ContextProvider = () => new Dictionary<string, object>
+            {
+                ["userAgent"] = "TestOS 1.0",
+                ["locale"] = "en-GB",
+                ["timezone"] = "Europe/London",
+                ["screen"] = "1920x1080",
+            };
+
+            ImmutableAudience.Init(MakeConfig());
+            ImmutableAudience.Track("unit_test_event");
+            ImmutableAudience.Shutdown();
+
+            var queueDir = Path.Combine(_testDir, "imtbl_audience", "queue");
+            var blobs = Directory.GetFiles(queueDir, "*.json").Select(File.ReadAllText).ToList();
+
+            Assert.IsTrue(blobs.Any(b =>
+                b.Contains("\"userAgent\":\"TestOS 1.0\"") &&
+                b.Contains("\"locale\":\"en-GB\"") &&
+                b.Contains("\"timezone\":\"Europe/London\"") &&
+                b.Contains("\"screen\":\"1920x1080\"") &&
+                b.Contains("\"library\":")),
+                "Enqueue should merge ContextProvider fields into msg.context alongside library/libraryVersion");
+        }
+
+        [Test]
+        public void ContextProvider_Set_MergesOnIdentifyPath()
+        {
+            // EnqueueIdentity must merge ContextProvider fields the same way
+            // EnqueueTrack does — otherwise Identify events ship without the
+            // userAgent / locale / timezone / screen context every other
+            // event carries.
+            ImmutableAudience.ContextProvider = () => new Dictionary<string, object>
+            {
+                ["userAgent"] = "TestOS 1.0",
+                ["locale"] = "en-GB",
+            };
+
+            ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
+            ImmutableAudience.Identify("player-42", IdentityType.Custom);
+            ImmutableAudience.Shutdown();
+
+            var queueDir = Path.Combine(_testDir, "imtbl_audience", "queue");
+            var blobs = Directory.GetFiles(queueDir, "*.json").Select(File.ReadAllText).ToList();
+
+            Assert.IsTrue(blobs.Any(b =>
+                b.Contains("\"type\":\"identify\"") &&
+                b.Contains("\"userAgent\":\"TestOS 1.0\"") &&
+                b.Contains("\"locale\":\"en-GB\"")),
+                "Identify message must carry ContextProvider fields in msg.context");
+        }
+
+        [Test]
+        public void ContextProvider_ThrowingDelegate_SwallowsAndShipsBaseContext()
+        {
+            ImmutableAudience.ContextProvider = () => throw new InvalidOperationException("boom");
+
+            ImmutableAudience.Init(MakeConfig());
+            ImmutableAudience.Track("unit_test_event");
+            ImmutableAudience.Shutdown();
+
+            var queueDir = Path.Combine(_testDir, "imtbl_audience", "queue");
+            var blobs = Directory.GetFiles(queueDir, "*.json").Select(File.ReadAllText).ToList();
+
+            Assert.IsTrue(blobs.Any(b => b.Contains("\"unit_test_event\"") && b.Contains("\"library\":")),
+                "event should still ship with base context when ContextProvider throws");
+        }
+
+        [Test]
+        public void ContextProvider_ReturnsNull_ShipsBaseContext()
+        {
+            ImmutableAudience.ContextProvider = () => null;
+
+            ImmutableAudience.Init(MakeConfig());
+            ImmutableAudience.Track("unit_test_event");
+            ImmutableAudience.Shutdown();
+
+            var queueDir = Path.Combine(_testDir, "imtbl_audience", "queue");
+            var blobs = Directory.GetFiles(queueDir, "*.json").Select(File.ReadAllText).ToList();
+
+            Assert.IsTrue(blobs.Any(b => b.Contains("\"unit_test_event\"") && b.Contains("\"library\":")),
+                "event should still ship with base context when ContextProvider returns null");
         }
 
         // -----------------------------------------------------------------

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -60,6 +60,117 @@ namespace Immutable.Audience.Tests
         }
 
         // -----------------------------------------------------------------
+        // Diagnostic getters (Initialized / CurrentConsent / UserId /
+        // AnonymousId / SessionId / QueueSize)
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void Initialized_FlipsAroundInitAndShutdown()
+        {
+            Assert.IsFalse(ImmutableAudience.Initialized,
+                "Initialized should be false before Init");
+
+            ImmutableAudience.Init(MakeConfig());
+            Assert.IsTrue(ImmutableAudience.Initialized,
+                "Initialized should flip true after Init");
+
+            ImmutableAudience.Shutdown();
+            Assert.IsFalse(ImmutableAudience.Initialized,
+                "Initialized should flip back to false after Shutdown");
+        }
+
+        [Test]
+        public void CurrentConsent_ReflectsLatestSetConsent()
+        {
+            ImmutableAudience.Init(MakeConfig(ConsentLevel.Anonymous));
+            Assert.AreEqual(ConsentLevel.Anonymous, ImmutableAudience.CurrentConsent);
+
+            ImmutableAudience.SetConsent(ConsentLevel.Full);
+            Assert.AreEqual(ConsentLevel.Full, ImmutableAudience.CurrentConsent);
+
+            ImmutableAudience.SetConsent(ConsentLevel.None);
+            Assert.AreEqual(ConsentLevel.None, ImmutableAudience.CurrentConsent);
+        }
+
+        [Test]
+        public void UserId_Uninitialised_ReturnsNull()
+        {
+            Assert.IsNull(ImmutableAudience.UserId);
+        }
+
+        [Test]
+        public void UserId_AfterIdentifyAndReset_TracksState()
+        {
+            ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
+            Assert.IsNull(ImmutableAudience.UserId,
+                "UserId should be null until Identify is called");
+
+            ImmutableAudience.Identify("player-42", IdentityType.Custom);
+            Assert.AreEqual("player-42", ImmutableAudience.UserId,
+                "UserId must reflect the most recent Identify call");
+
+            ImmutableAudience.Reset();
+            Assert.IsNull(ImmutableAudience.UserId,
+                "Reset must clear UserId so the next player is not attributed to the previous one");
+        }
+
+        [Test]
+        public void AnonymousId_ConsentNone_ReturnsNull()
+        {
+            // Anonymous identifier is consent-gated: below tracking consent,
+            // no stable id should leak through the getter.
+            ImmutableAudience.Init(MakeConfig(ConsentLevel.None));
+
+            Assert.IsNull(ImmutableAudience.AnonymousId);
+        }
+
+        [Test]
+        public void AnonymousId_ConsentAnonymous_ReturnsPersistedId()
+        {
+            ImmutableAudience.Init(MakeConfig(ConsentLevel.Anonymous));
+            // Track once so Identity.GetOrCreate runs and writes the id file.
+            ImmutableAudience.Track("warmup_event");
+
+            var id = ImmutableAudience.AnonymousId;
+            Assert.IsFalse(string.IsNullOrEmpty(id),
+                "AnonymousId should return the persisted id once tracking has created one");
+        }
+
+        [Test]
+        public void SessionId_MirrorsSessionLifecycle()
+        {
+            Assert.IsNull(ImmutableAudience.SessionId,
+                "SessionId should be null before Init");
+
+            ImmutableAudience.Init(MakeConfig(ConsentLevel.Anonymous));
+            Assert.IsFalse(string.IsNullOrEmpty(ImmutableAudience.SessionId),
+                "SessionId should be non-null once Init creates a session");
+
+            ImmutableAudience.Shutdown();
+            Assert.IsNull(ImmutableAudience.SessionId,
+                "SessionId should be null after Shutdown disposes the session");
+        }
+
+        [Test]
+        public void QueueSize_ZeroBeforeInit_GrowsWithEnqueue()
+        {
+            Assert.AreEqual(0, ImmutableAudience.QueueSize,
+                "QueueSize should be 0 before Init");
+
+            ImmutableAudience.Init(MakeConfig(ConsentLevel.Anonymous));
+            // Init enqueues session_start + game_launch; those stay
+            // in-memory until a flush. QueueSize sums memory + disk so the
+            // pre-flush snapshot must be > 0.
+            var afterInit = ImmutableAudience.QueueSize;
+            Assert.Greater(afterInit, 0,
+                "QueueSize should include session_start and game_launch after Init");
+
+            ImmutableAudience.Track("explicit_track_event");
+            Assert.Greater(ImmutableAudience.QueueSize, afterInit,
+                "QueueSize should grow when a new event is enqueued");
+        }
+
+        // -----------------------------------------------------------------
         // Unity context provider
         // -----------------------------------------------------------------
 

--- a/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
@@ -460,7 +460,7 @@ namespace Immutable.Audience.Tests
                 onError: _ => throw new InvalidOperationException("callback bug"),
                 handler: handler);
 
-            Assert.DoesNotThrowAsync(() => transport.SendBatchAsync());
+            await transport.SendBatchAsync();
         }
 
 #if IMMUTABLE_AUDIENCE_GZIP

--- a/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
@@ -153,6 +153,25 @@ namespace Immutable.Audience.Tests
         }
 
         [Test]
+        public async Task SendBatchAsync_BaseUrlOverride_WinsOverKeyPrefix()
+        {
+            _store.Write("{\"type\":\"track\"}");
+
+            HttpRequestMessage captured = null;
+            var handler = new MockHandler(HttpStatusCode.OK, "{\"accepted\":1,\"rejected\":0}",
+                onRequest: req => captured = req);
+            const string custom = "https://api.dev.immutable.com";
+            // Test-prefixed key would resolve to Sandbox on its own; the
+            // explicit override must win.
+            using var transport = new HttpTransport(_store, "pk_imapik-test-key1",
+                baseUrlOverride: custom, handler: handler);
+
+            await transport.SendBatchAsync();
+
+            StringAssert.StartsWith(custom, captured.RequestUri.ToString());
+        }
+
+        [Test]
         public async Task SendBatchAsync_EmptyQueue_ReturnsFalse()
         {
             var handler = new MockHandler(HttpStatusCode.OK, "{}");

--- a/src/Packages/Audience/link.xml
+++ b/src/Packages/Audience/link.xml
@@ -12,6 +12,7 @@ framework dependency.
 -->
 <linker>
   <assembly fullname="Immutable.Audience.Runtime" preserve="all" />
+  <assembly fullname="Immutable.Audience.Unity" preserve="all" />
 
   <assembly fullname="System.Net.Http">
     <type fullname="System.Net.Http.HttpClient" preserve="all" />


### PR DESCRIPTION
## Summary

- Adds Unity integration under `Runtime/Unity/` (`com.immutable.audience.unity` asmdef).
- `DeviceCollector` — one-shot capture on the main thread: `platform`, `version`, `buildGuid`, `unityVersion`, `osFamily`, `deviceModel`, `gpu`, `gpuVendor`, `cpu`, `cpuCores`, `ramMb`, `screenDpi` for `game_launch`; `userAgent`, `locale`, `timezone`, `screen` for per-event `context`. String fields capped at 256 chars (mirrors Web SDK's `MAX_STRING_LENGTH`).
- `UnityLifecycleBridge` — forwards `OnApplicationPause` / `OnApplicationFocus` (desktop only — mobile focus is noisy) to `ImmutableAudience.OnPause` / `OnResume`.
- `AudienceUnityHooks` at `SubsystemRegistration` — wires `DefaultPersistentDataPathProvider`, `LaunchContextProvider`, `ContextProvider`; forwards `Application.quitting` to `Shutdown`.
- `ImmutableAudience` — adds internal `OnPause` / `OnResume`; `MergeUnityContext` merges `ContextProvider` output into every outgoing `msg.context` on the Track and Identify paths.
- `Directory.Build.props` redirects `bin/obj` to repo-root `artifacts/` so dotnet output doesn't leak into Unity's asset importer.
- `link.xml` preserves `Immutable.Audience.Runtime` and `Immutable.Audience.Unity` against IL2CPP stripping.
- `ConstantsTests.ReadPackageJson` walks up from the test binary to locate the package root, so the `Directory.Build.props` redirect doesn't break it.

Linear: [SDK-146](https://linear.app/imtbl/issue/SDK-146), [SDK-227](https://linear.app/imtbl/issue/SDK-227), [SDK-228](https://linear.app/imtbl/issue/SDK-228).