### PR TITLE
fix(audience-transport): surface 4xx body + messages envelope

### DIFF
--- a/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
+++ b/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
@@ -119,10 +119,22 @@ namespace Immutable.Audience
                 {
                     // 4xx: server rejected the payload. Drop it (retry won't help) and
                     // reset backoff — server is healthy, our data was the problem.
+                    // Pull the response body so the studio has something actionable:
+                    // the status code alone just says "something is wrong"; the body
+                    // names which field or event broke validation. Truncated to keep
+                    // logs sane if the backend ever returns a long diagnostic.
+                    string? body = null;
+                    try { body = await response.Content.ReadAsStringAsync().ConfigureAwait(false); }
+                    catch { /* Content read failed (disposed, network) — fall through with body=null. */ }
+
                     _store.Delete(batch);
                     ResetBackoff();
-                    NotifyError(AudienceErrorCode.ValidationRejected,
-                        $"Batch rejected with {statusCode}");
+
+                    const int maxBodyLen = 500;
+                    var message = string.IsNullOrEmpty(body)
+                        ? $"Batch rejected with {statusCode}"
+                        : $"Batch rejected with {statusCode}: {(body.Length > maxBodyLen ? body.Substring(0, maxBodyLen) + "…" : body)}";
+                    NotifyError(AudienceErrorCode.ValidationRejected, message);
                 }
                 else
                 {
@@ -210,11 +222,11 @@ namespace Immutable.Audience
         }
 
         // Reads each path and wraps the concatenated JSON bodies in
-        // {"batch":[msg1,msg2,...]}. Returns null if every path was
+        // {"messages":[msg1,msg2,...]}. Returns null if every path was
         // unreadable; the caller treats null as "nothing to send".
         private static string? BuildPayload(IReadOnlyList<string> paths)
         {
-            var sb = new StringBuilder("{\"batch\":[");
+            var sb = new StringBuilder("{\"messages\":[");
             var count = 0;
 
             for (var i = 0; i < paths.Count; i++)

--- a/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
@@ -87,7 +87,7 @@ namespace Immutable.Audience.Tests
             Assert.AreEqual("gzip", capturedContentEncoding);
 
             var decompressed = DecompressGzip(capturedBody);
-            StringAssert.StartsWith("{\"batch\":[", decompressed);
+            StringAssert.StartsWith("{\"messages\":[", decompressed);
             StringAssert.EndsWith("]}", decompressed);
             StringAssert.Contains("\"eventName\":\"test\"", decompressed);
         }
@@ -116,7 +116,7 @@ namespace Immutable.Audience.Tests
             Assert.AreEqual("pk_imapik-test-key1", capturedKey);
             Assert.AreEqual("application/json", capturedContentType);
             Assert.AreEqual(0, capturedContentEncodingCount, "no Content-Encoding header is permitted in v1");
-            StringAssert.StartsWith("{\"batch\":[", capturedBody);
+            StringAssert.StartsWith("{\"messages\":[", capturedBody);
             StringAssert.EndsWith("]}", capturedBody);
             StringAssert.Contains("\"eventName\":\"test\"", capturedBody);
         }
@@ -186,7 +186,8 @@ namespace Immutable.Audience.Tests
         {
             _store.Write("{\"type\":\"track\"}");
 
-            var handler = new MockHandler(HttpStatusCode.BadRequest, "");
+            var handler = new MockHandler(HttpStatusCode.BadRequest,
+                "{\"error\":\"invalid eventName format at /batch/0/eventName\"}");
             AudienceError reportedError = null;
             using var transport = new HttpTransport(_store, "pk_imapik-test-key1",
                 onError: e => reportedError = e, handler: handler);
@@ -197,6 +198,9 @@ namespace Immutable.Audience.Tests
             Assert.IsFalse(transport.IsInBackoffWindow);
             Assert.IsNotNull(reportedError);
             Assert.AreEqual(AudienceErrorCode.ValidationRejected, reportedError.Code);
+            // Backend-supplied diagnostic must reach the studio, otherwise a 400
+            // collapses to "something broke, good luck" with no actionable signal.
+            StringAssert.Contains("invalid eventName format", reportedError.Message);
         }
 
         [Test]

--- a/src/Packages/Audience/Tests/Runtime/Utility/GzipTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Utility/GzipTests.cs
@@ -29,7 +29,7 @@ namespace Immutable.Audience.Tests
         public void Compress_OutputIsSmallerThanInput_ForRealisticPayload()
         {
             // Repeated field names compress well in JSON batches.
-            var sb = new StringBuilder("{\"batch\":[");
+            var sb = new StringBuilder("{\"messages\":[");
             for (var i = 0; i < 20; i++)
             {
                 if (i > 0) sb.Append(',');


### PR DESCRIPTION
## Summary

- `HttpTransport.SendBatchAsync` — 4xx branch reads `response.Content` (truncated to 500 chars) and includes it in the `onError` message. Previously only the status code reached the callback, masking the backend's validation diagnostic (e.g. `"invalid eventName format at /batch/0/eventName"`).
- `HttpTransport.BuildPayload` — emits `{"messages":[...]}` instead of `{"batch":[...]}` to match the backend's `MessagesRequest` schema; every send was 400'ing before the fix.
- `HttpTransportTests` — renames the URL-routing tests to env-explicit names (`_DefaultEnvironment_HitsSandbox`, `_ExplicitDev_HitsDev`, `_ExplicitProduction_HitsProduction`); asserts the 400 body reaches the `onError` callback.
- `HttpTransportTests` and `GzipTests` fixtures updated to the `{"messages":[...]}` envelope.

Linear: [SDK-245](https://linear.app/imtbl/issue/SDK-245). Follow-up to [SDK-234](https://linear.app/imtbl/issue/SDK-234).