### PR TITLE
chore(audience-sdk): track .meta files for runtime + tests

### DIFF
--- a/src/Packages/Audience/Runtime/AssemblyInfo.cs.meta
+++ b/src/Packages/Audience/Runtime/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f7655c5746e0b47f399f3b9e84e2161f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Core/AudiencePaths.cs.meta
+++ b/src/Packages/Audience/Runtime/Core/AudiencePaths.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc24434c2cd1a4a9da384dfd93e4a37f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Core/ConsentState.cs.meta
+++ b/src/Packages/Audience/Runtime/Core/ConsentState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ddb07627c6d5d45589a7c7ddcbc15ff6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Core/ConsentStore.cs.meta
+++ b/src/Packages/Audience/Runtime/Core/ConsentStore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88ecb69f8c55b4e9d818185e82461b3c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Core/Identity.cs.meta
+++ b/src/Packages/Audience/Runtime/Core/Identity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a8cbd1fd045246e28e9c74af359ed0e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Events.meta
+++ b/src/Packages/Audience/Runtime/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4e4e8b198a5c84e09b5674920faf1f11
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Events/IEvent.cs.meta
+++ b/src/Packages/Audience/Runtime/Events/IEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f3780e732b24478499fa6be4afbdb12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Events/MessageBuilder.cs.meta
+++ b/src/Packages/Audience/Runtime/Events/MessageBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7b3e751e4afd648d69a60e6a77948c9c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Events/TypedEvents.cs.meta
+++ b/src/Packages/Audience/Runtime/Events/TypedEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7883987e3a3f145bfbb9f264d346007c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/IdentityType.cs.meta
+++ b/src/Packages/Audience/Runtime/IdentityType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30214b6efcc08484c8aa4c6df90df326
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Transport/HttpTransport.cs.meta
+++ b/src/Packages/Audience/Runtime/Transport/HttpTransport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d5eb2bdbb9d9d47559fc08264b5f556b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Unity.meta
+++ b/src/Packages/Audience/Runtime/Unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 73df1e09855af46059367bdd6aa224f3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Unity/AudienceUnityHooks.cs.meta
+++ b/src/Packages/Audience/Runtime/Unity/AudienceUnityHooks.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e4b07001384a4a1585ec28b25910d67
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Unity/DeviceCollector.cs.meta
+++ b/src/Packages/Audience/Runtime/Unity/DeviceCollector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 330e8d32df87b417881003a84a847bf5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Unity/UnityLifecycleBridge.cs.meta
+++ b/src/Packages/Audience/Runtime/Unity/UnityLifecycleBridge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: abc70aebc630643a0974153999b138f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Unity/com.immutable.audience.unity.asmdef.meta
+++ b/src/Packages/Audience/Runtime/Unity/com.immutable.audience.unity.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 34cf9537910ef435491852a0b126a85a
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Utility.meta
+++ b/src/Packages/Audience/Runtime/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 47b5d617fa4534a22b8b7a4f0a24e1f3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Utility/Gzip.cs.meta
+++ b/src/Packages/Audience/Runtime/Utility/Gzip.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47a71d9dab27340138a5cc14127bc3fb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Utility/Json.cs.meta
+++ b/src/Packages/Audience/Runtime/Utility/Json.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 80c4f42d839cd44e490e79c16dd4acd5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Utility/JsonReader.cs.meta
+++ b/src/Packages/Audience/Runtime/Utility/JsonReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7cb1f34fd677048e8b18c0cbd6919f16
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Utility/Log.cs.meta
+++ b/src/Packages/Audience/Runtime/Utility/Log.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f6959e7ee48d841bb95c62bc2988462c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/ConsentLevelTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/ConsentLevelTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 24ac7a6de77db47b4b6d5152c1db2afa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/ConsentSyncTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/ConsentSyncTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f502ade033b04decacaeb16d7f36450
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/ConstantsTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/ConstantsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d2aff89d81956408f8c83c5452f6eeba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/Core.meta
+++ b/src/Packages/Audience/Tests/Runtime/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c2c07134c7228450d9a0ac1b5ea539b0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/Core/ConsentStoreTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/Core/ConsentStoreTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c2431d094af3f4f9ebb20183fc9f7ad4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/Core/IdentityTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/Core/IdentityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bfd2b3ff88ec148a8918b7e710487dad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/DeleteDataTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/DeleteDataTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 35e76d7540e6f474bbfba9b1a9589e40
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/Events.meta
+++ b/src/Packages/Audience/Tests/Runtime/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0abddb8e276cc45e784f80b81b48da4e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/Events/MessageBuilderTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/Events/MessageBuilderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b173a8b53c544fb4929360c997a642f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/Events/TypedEventTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/Events/TypedEventTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec344bbb768e64fa49167e7d8e09c2cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/IdentityTypeTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/IdentityTypeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f62f412c46c44e42a3fb694ead160dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4f7650bc2a664fada12c791b9c9140a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/Transport.meta
+++ b/src/Packages/Audience/Tests/Runtime/Transport.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 27923b8260bad4475bad934bc27ba9f9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27002c55446d44a0e9bdbcf0d6b0da07
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/Utility.meta
+++ b/src/Packages/Audience/Tests/Runtime/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b325dba9d799b427fae2207304346042
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/Utility/GzipTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/Utility/GzipTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7ecb705416524a829f788464a701030
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/Utility/JsonReaderTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/Utility/JsonReaderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 40fbba79d4fbe41b98669696a25c80bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/Utility/JsonTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/Utility/JsonTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8a253e73bc3f40b4805a58fb3a5e2ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/Utility/LogTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/Utility/LogTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c010e51aa90c4f4cb4612ba9b1f8286
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

Adds 40 Unity `.meta` files for pre-existing source files under `src/Packages/Audience/Runtime/` and `src/Packages/Audience/Tests/`. The source files were tracked but their `.meta` companions were not, which means cloning the repo into a Unity project causes Unity to regenerate fresh GUIDs and break any inter-asset references.

No code changes — `.meta`-only.

This PR is stacked on top of [#711](https://github.com/immutable/unity-immutable-sdk/pull/711) (the audience sample app). Merge order: 711 first, this second. Once 711 merges, this PR's base will auto-rebase to `main`.

Linear: [SDK-152](https://linear.app/imtbl/issue/SDK-152/create-audience-sample-app-in-examples)