### PR TITLE
refactor(audience-sdk): drop response-body cap on OnError messages

### DIFF
--- a/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
+++ b/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
@@ -282,11 +282,6 @@ namespace Immutable.Audience
             }
         }
 
-        // Cap the response-body excerpt the caller sees. Backends sometimes
-        // return verbose stack traces or HTML error pages; trimming keeps
-        // OnError consumers (loggers, UI) from being flooded.
-        private const int MaxErrorBodyChars = 500;
-
         // Best-effort body extraction; null on read failure.
         // Catches narrowed so OOM, OperationCanceledException, and ThreadAbortException
         // propagate — body extraction must not mask process-level faults.
@@ -295,11 +290,7 @@ namespace Immutable.Audience
             try
             {
                 var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                if (string.IsNullOrWhiteSpace(body)) return null;
-                body = body.Trim();
-                return body.Length > MaxErrorBodyChars
-                    ? body.Substring(0, MaxErrorBodyChars) + "…"
-                    : body;
+                return string.IsNullOrWhiteSpace(body) ? null : body.Trim();
             }
             catch (HttpRequestException) { return null; }
             catch (IOException) { return null; }


### PR DESCRIPTION
## Summary

Removes the 500-char `MaxErrorBodyChars` cap and the trim ternary inside `ReadBodyForErrorAsync` in `HttpTransport`. The cap was defensive against verbose backend responses (stack traces, HTML error pages) but the audience backend returns short structured JSON for both 4xx and 5xx, making the cap dead code. Consumers now see the full response body verbatim in `OnError` messages.

Stacked on top of [#711](https://github.com/immutable/unity-immutable-sdk/pull/711). Base = `feat/audience-sample-app`. Once 711 merges, this PR's base will auto-rebase to `main`.

Linear: [SDK-152](https://linear.app/imtbl/issue/SDK-152/create-audience-sample-app-in-examples)