### PR TITLE
refactor(audience-sample-app): drop log row count cap

### DIFF
--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.UI.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.UI.cs
@@ -28,7 +28,6 @@ namespace Immutable.Audience.Samples.SampleApp
 
         private static readonly string[] StateClasses = { "state-ok", "state-warn", "state-err", "dim" };
 
-        private const int LogCapacity = 200;
         private const int CollapseThreshold = 240;
         private const int StatusPollIntervalMs = 500;
         private const float NarrowBreakpointPx = 1024f;
@@ -697,9 +696,6 @@ namespace Immutable.Audience.Samples.SampleApp
                 _mainSyncContext.Post(_ => AppendLog(label, body, level, source), null);
                 return;
             }
-
-            if (_logView.contentContainer.childCount >= LogCapacity)
-                _logView.contentContainer.RemoveAt(0);
 
             // Snapshot "was at bottom?" before adding — stateless per-row check.
             var s = _logView.verticalScroller;


### PR DESCRIPTION
## Summary

Removes the `LogCapacity` const (200) and the eviction check inside `AppendLog` in `AudienceSample.UI.cs`. Log rows now accumulate until the user clicks Clear or the session ends. The cap was preventive (defending against unbounded UI growth in long sessions) rather than corrective — sample-app demo sessions are short and the visual tree handles thousands of rows comfortably.

Stacked on top of [#711](https://github.com/immutable/unity-immutable-sdk/pull/711). Base = `feat/audience-sample-app`. Once 711 merges, this PR's base will auto-rebase to `main`.

Linear: [SDK-152](https://linear.app/imtbl/issue/SDK-152/create-audience-sample-app-in-examples)