### PR TITLE
ci(audience): add Unity 2022.3.62f2 cells to PlayMode matrix (SDK-256)

### DIFF
--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -329,6 +329,40 @@ jobs:
         run: |
           git config --global --add safe.directory $env:GITHUB_WORKSPACE.Replace('\','/')
 
+      - name: Capture player log (macOS)
+        if: always() && runner.os == 'macOS'
+        shell: bash
+        run: |
+          # The test-runner builds + launches a player binary that writes its own
+          # log separately from Unity's editor log. When the editor reports
+          # "Test execution timed out. No activity received from the player ..."
+          # the editor unity.log alone cannot tell us whether the player crashed,
+          # hung, or never started. Copy whatever Player.log files Unity wrote
+          # into artifacts/ so the upload-artifact step preserves them.
+          mkdir -p artifacts
+          src="$HOME/Library/Logs"
+          if [ -d "$src" ]; then
+            find "$src" -name "Player.log" 2>/dev/null | while IFS= read -r f; do
+              cp "$f" "artifacts/Player-$(basename "$(dirname "$f")").log" 2>/dev/null || true
+            done
+          fi
+
+      - name: Capture player log (Windows)
+        if: always() && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          # See macOS counterpart for rationale. Windows player log location:
+          # %USERPROFILE%\AppData\LocalLow\<CompanyName>\<ProductName>\Player.log
+          New-Item -ItemType Directory -Force -Path artifacts | Out-Null
+          $src = "$env:USERPROFILE\AppData\LocalLow"
+          if (Test-Path $src) {
+            Get-ChildItem -Path $src -Recurse -Filter "Player.log" -ErrorAction SilentlyContinue |
+              ForEach-Object {
+                $name = $_.Directory.Name
+                Copy-Item -Path $_.FullName -Destination "artifacts/Player-$name.log" -ErrorAction SilentlyContinue
+              }
+          }
+
       - name: Surface Unity compile errors as annotations (macOS)
         if: always() && runner.os == 'macOS'
         shell: bash
@@ -390,4 +424,5 @@ jobs:
           path: |
             artifacts/test-results.xml
             artifacts/unity.log
+            artifacts/Player-*.log
             examples/audience/Logs/**

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -60,6 +60,26 @@ jobs:
             unity: 6000.4.0f1
             changeset: 8cf496087c8f
             runner: [self-hosted, macOS, ARM64]
+          - target: StandaloneWindows64
+            backend: IL2CPP
+            unity: 2022.3.62f2
+            changeset: 7670c08855a9
+            runner: [self-hosted, Windows, X64]
+          - target: StandaloneWindows64
+            backend: Mono2x
+            unity: 2022.3.62f2
+            changeset: 7670c08855a9
+            runner: [self-hosted, Windows, X64]
+          - target: StandaloneOSX
+            backend: IL2CPP
+            unity: 2022.3.62f2
+            changeset: 7670c08855a9
+            runner: [self-hosted, macOS, ARM64]
+          - target: StandaloneOSX
+            backend: Mono2x
+            unity: 2022.3.62f2
+            changeset: 7670c08855a9
+            runner: [self-hosted, macOS, ARM64]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
 

--- a/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
@@ -89,7 +89,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
             yield return SceneManager.LoadSceneAsync(SampleAppUi.SceneName, LoadSceneMode.Single);
             yield return null;  // one extra frame for Awake/InitializeUi
 
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_2022_2_OR_NEWER
             var sample = UnityEngine.Object.FindFirstObjectByType<AudienceSample>(FindObjectsInactive.Include);
 #else
             var sample = UnityEngine.Object.FindObjectOfType<AudienceSample>(includeInactive: true);

--- a/examples/audience/Packages/manifest.json
+++ b/examples/audience/Packages/manifest.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "com.immutable.audience": "file:../../../src/Packages/Audience",
-    "com.unity.collab-proxy": "2.5.2",
     "com.unity.test-framework": "1.4.5",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.6.5",


### PR DESCRIPTION
## Summary

- Adds 4 Unity 2022.3.62f2 cells (Win+Mac × IL2CPP+Mono2x) to the audience PlayMode matrix.
- Broadens the `FindFirstObjectByType<T>(FindObjectsInactive)` cutoff in `SampleAppLiveFireTests` from `#if UNITY_2023_1_OR_NEWER` to `#if UNITY_2022_2_OR_NEWER`.
- Removes `com.unity.collab-proxy` from the sample manifest.
- Captures the Unity player log (`~/Library/Logs/<Co>/<Prod>/Player.log` on macOS, `%USERPROFILE%\AppData\LocalLow\<Co>\<Prod>\Player.log` on Windows) into `artifacts/Player-*.log` and adds it to the upload-artifact `path:` block.

Linear: [SDK-256](https://linear.app/imtbl/issue/SDK-256)