### PR TITLE
docs(audience): add UPM-visible README for the Audience package (SDK-150)

### DIFF
--- a/src/Packages/Audience/README.md
+++ b/src/Packages/Audience/README.md
@@ -1,0 +1,52 @@
+# Immutable Audience
+
+Typed C# tracking SDK for Unity games. Captures `game_launch`, `session_start` / `session_heartbeat` / `session_end` automatically; predefined events (`Progression`, `Resource`, `Purchase`, `MilestoneReached`) and custom events on demand.
+
+> **Status:** alpha. APIs and behavior may change between releases.
+
+## Install
+
+In Unity, open **Window → Package Manager**, click **+ → Add package from git URL...**, and paste:
+
+```
+https://github.com/immutable/unity-immutable-sdk.git?path=src/Packages/Audience#main
+```
+
+For reproducible builds, replace `#main` with a release tag or a specific commit SHA.
+
+Requires Unity 2021.3 or later. Works under Mono and IL2CPP.
+
+## First event
+
+```csharp
+using Immutable.Audience;
+using UnityEngine;
+
+public static class Analytics
+{
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    private static void Init()
+    {
+        ImmutableAudience.Init(new AudienceConfig
+        {
+            PublishableKey = "YOUR_PUBLISHABLE_KEY",
+            Consent = ConsentLevel.Anonymous,
+            DistributionPlatform = DistributionPlatforms.Steam,
+            Debug = true,
+        });
+
+        ImmutableAudience.Track(new Purchase { Currency = "USD", Value = 9.99m });
+    }
+}
+```
+
+Press Play; `ImmutableAudience.Initialized` returns `true` and `AnonymousId` becomes a non-null GUID. The SDK warns to the Unity Console with prefix `[ImmutableAudience]` only on errors.
+
+## Documentation
+
+- Integration guide and API reference: <https://docs.immutable.com/docs/products/audience/unity-sdk>
+- Sample Unity project: [`examples/audience`](https://github.com/immutable/unity-immutable-sdk/tree/main/examples/audience)
+
+## License
+
+See the repository [LICENSE](https://github.com/immutable/unity-immutable-sdk/blob/main/LICENSE.md).

--- a/src/Packages/Audience/package.json
+++ b/src/Packages/Audience/package.json
@@ -5,5 +5,7 @@
   "displayName": "Immutable Audience",
   "author": {"name": "Immutable", "url": "https://immutable.com"},
   "keywords": ["unity", "immutable", "audience", "analytics"],
-  "unity": "2021.3"
+  "unity": "2021.3",
+  "documentationUrl": "https://docs.immutable.com/docs/products/audience/unity-sdk",
+  "licensesUrl": "https://github.com/immutable/unity-immutable-sdk/blob/main/LICENSE.md"
 }


### PR DESCRIPTION
## Summary

- Adds `src/Packages/Audience/README.md` — UPM-visible README for the Audience package
- Sets `documentationUrl` and `licensesUrl` on `src/Packages/Audience/package.json` so Unity Package Manager surfaces "View documentation" and "View licenses" buttons
- README links to both the integration guide on docs.immutable.com and the sample Unity project at `examples/audience`

Linear: [SDK-150](https://linear.app/imtbl/issue/SDK-150/write-documentation-and-integration-guide-under-30-min-from-fresh)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus package metadata fields; no runtime behavior or API surface is modified.
> 
> **Overview**
> Adds a new `src/Packages/Audience/README.md` so the Audience Unity package shows an install/quick-start guide directly in UPM.
> 
> Updates `src/Packages/Audience/package.json` to include `documentationUrl` and `licensesUrl`, enabling Unity Package Manager to surface “View documentation” and “View licenses” links for the package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9368cfc6c803a62d1e388dfa9eb442ce1e2ad5cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->