### PR TITLE
ci(audience-sdk): stop running Unity tests on docs-only PRs (SDK-268)

### DIFF
--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -3,8 +3,14 @@ name: Audience SDK — PlayMode (IL2CPP + Mono)
 on:
   pull_request:
     paths:
-      - 'src/Packages/Audience/**'
-      - 'examples/audience/**'
+      - 'src/Packages/Audience/Runtime/**'
+      - 'src/Packages/Audience/Tests/**'
+      - 'src/Packages/Audience/package.json'
+      - 'src/Packages/Audience/Directory.Build.props'
+      - 'src/Packages/Audience/link.xml'
+      - 'examples/audience/Assets/**'
+      - 'examples/audience/Packages/**'
+      - 'examples/audience/ProjectSettings/**'
       - '.github/workflows/test-audience-sample-app.yml'
   workflow_dispatch:
 

--- a/.github/workflows/test-audience-sdk.yml
+++ b/.github/workflows/test-audience-sdk.yml
@@ -4,11 +4,19 @@ on:
   push:
     branches: [main]
     paths:
-      - 'src/Packages/Audience/**'
+      - 'src/Packages/Audience/Runtime/**'
+      - 'src/Packages/Audience/Tests/**'
+      - 'src/Packages/Audience/package.json'
+      - 'src/Packages/Audience/Directory.Build.props'
+      - 'src/Packages/Audience/link.xml'
       - '.github/workflows/test-audience-sdk.yml'
   pull_request:
     paths:
-      - 'src/Packages/Audience/**'
+      - 'src/Packages/Audience/Runtime/**'
+      - 'src/Packages/Audience/Tests/**'
+      - 'src/Packages/Audience/package.json'
+      - 'src/Packages/Audience/Directory.Build.props'
+      - 'src/Packages/Audience/link.xml'
       - '.github/workflows/test-audience-sdk.yml'
 
 jobs:


### PR DESCRIPTION
## Summary

- Doc-only changes (e.g. adding a `README.md` under `src/Packages/Audience/`) currently trigger the full Audience CI surface — `test-audience-sample-app.yml` runs all 12 self-hosted Unity PlayMode cells, and `test-audience-sdk.yml` runs the .NET unit-test job.
- Both workflows scope their `paths:` filter to the entire package and example directories (`src/Packages/Audience/**`, `examples/audience/**`), with no carve-out for documentation or repo metadata.
- This PR replaces those blanket matches with explicit allow-lists of source-affecting roots, so doc-only PRs no longer schedule the matrix.

`test-audience-sdk.yml` now triggers on:
- `src/Packages/Audience/Runtime/**`
- `src/Packages/Audience/Tests/**`
- `src/Packages/Audience/package.json`
- `src/Packages/Audience/Directory.Build.props`
- `src/Packages/Audience/link.xml`
- `.github/workflows/test-audience-sdk.yml`

`test-audience-sample-app.yml` triggers on the same paths, plus:
- `examples/audience/Assets/**`
- `examples/audience/Packages/**`
- `examples/audience/ProjectSettings/**`
- `.github/workflows/test-audience-sample-app.yml`

`paths` and `paths-ignore` are mutually exclusive in GitHub Actions, and `paths-ignore` only suppresses a workflow when every changed file matches the ignore list — so a mixed change (markdown + `package.json`) would still trigger. An explicit allow-list is the only filter shape that handles mixed PRs correctly.

`package.json`, `Directory.Build.props`, and `link.xml` stay in the trigger because version, dependency, build-config, and IL2CPP-stripping changes can each produce regressions the matrix exists to catch.

Linear: [SDK-268](https://linear.app/imtbl/issue/SDK-268/ci-stop-running-unity-tests-on-docs-only-prs-to-the-audience-sdk)