### PR TITLE
fix(audience): lowercase DistributionPlatform at Init (SDK-269)

### DIFF
--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -113,6 +113,13 @@ namespace Immutable.Audience
             if (string.IsNullOrEmpty(config.PersistentDataPath))
                 throw new ArgumentException("PersistentDataPath is required", nameof(config));
 
+            // Normalize casing so dashboards aggregate consistently. The
+            // DistributionPlatforms constants ship lowercase; a studio that
+            // passes "Steam" or "STEAM" would otherwise split rows from
+            // constant-using studios in the same project.
+            if (!string.IsNullOrEmpty(config.DistributionPlatform))
+                config.DistributionPlatform = config.DistributionPlatform.ToLowerInvariant();
+
             ConsentLevel consentAtInit;
             Session? sessionToStart;
             lock (_initLock)

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -1118,6 +1118,47 @@ namespace Immutable.Audience.Tests
         }
 
         [Test]
+        public void Init_LowercasesDistributionPlatform_WhenCallerPassesMixedCase()
+        {
+            var config = MakeConfig();
+            config.DistributionPlatform = "Steam";
+            ImmutableAudience.Init(config);
+
+            Assert.AreEqual("steam", config.DistributionPlatform,
+                "Init should lowercase mixed-case DistributionPlatform so dashboards aggregate consistently.");
+        }
+
+        [Test]
+        public void Init_LowercasesDistributionPlatform_WhenCallerPassesAllUpperCase()
+        {
+            var config = MakeConfig();
+            config.DistributionPlatform = "STEAM";
+            ImmutableAudience.Init(config);
+
+            Assert.AreEqual("steam", config.DistributionPlatform);
+        }
+
+        [Test]
+        public void Init_LeavesDistributionPlatformUnchanged_WhenAlreadyLowercase()
+        {
+            var config = MakeConfig();
+            config.DistributionPlatform = "steam";
+            ImmutableAudience.Init(config);
+
+            Assert.AreEqual("steam", config.DistributionPlatform);
+        }
+
+        [Test]
+        public void Init_LeavesDistributionPlatformNull_WhenNotSet()
+        {
+            var config = MakeConfig();
+            Assert.IsNull(config.DistributionPlatform);
+            ImmutableAudience.Init(config);
+
+            Assert.IsNull(config.DistributionPlatform);
+        }
+
+        [Test]
         public void Init_ConsentNone_DoesNotFireGameLaunch()
         {
             ImmutableAudience.Init(MakeConfig(ConsentLevel.None));


### PR DESCRIPTION
## Summary

- Init normalizes `config.DistributionPlatform` to lowercase once at the SDK boundary
- `DistributionPlatforms` constants ship lowercase; passing `"Steam"` or `"STEAM"` previously shipped that casing on the wire and split dashboard rows from constant-using studios
- Mutates the caller's `AudienceConfig` instance the same way Init already does for `PersistentDataPath`
- Adds 4 test cases covering mixed-case input, all-uppercase input, already-lowercase input, and unset (null) input
- Discovered during SDK-150 docs review (immutable/documentation#69)

Linear: [SDK-269](https://linear.app/imtbl/issue/SDK-269/audience-lowercase-distributionplatform-at-init)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small input-normalization change at SDK init that only affects the casing of `AudienceConfig.DistributionPlatform`, with targeted unit test coverage.
> 
> **Overview**
> `ImmutableAudience.Init` now normalizes `config.DistributionPlatform` to lowercase (when non-empty) so mixed/uppercase caller values don’t fragment analytics aggregation.
> 
> Adds unit tests covering mixed-case, uppercase, already-lowercase, and unset `DistributionPlatform` inputs to verify the normalization behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b86aa409444b628c4f91b68540adc3811aca9ef4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->