### PR TITLE
feat(audience-sdk)!: drop Identify/Alias string-identityType overloads (SDK-271)

### DIFF
--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
@@ -189,7 +189,7 @@ namespace Immutable.Audience.Samples.SampleApp
         {
             var f = CaptureIdentifyForm();
             var traits = ParseTraits(f.RawTraits);
-            ImmutableAudience.Identify(f.Id, f.Type, traits);
+            ImmutableAudience.Identify(f.Id, ParseIdentityType(f.Type), traits);
             // SDK drops via Log.Warn when id is empty or consent < Full. Mirror
             // only when accepted — otherwise the panel would show stale state.
             var accepted = !string.IsNullOrEmpty(f.Id)
@@ -212,7 +212,7 @@ namespace Immutable.Audience.Samples.SampleApp
             if (string.IsNullOrEmpty(userId)) throw new InvalidOperationException("no active identity — call Identify first");
             var traits = ParseTraits(CaptureTraitsUpdate());
             if (traits == null || traits.Count == 0) throw new InvalidOperationException("traits required");
-            ImmutableAudience.Identify(userId, _mirrorIdentityType ?? IdentityType.Custom.ToLowercaseString(), traits);
+            ImmutableAudience.Identify(userId, ParseIdentityType(_mirrorIdentityType), traits);
             _mirrorTraits = traits;
             OnSdkStateChanged();
             return Json.Serialize(traits, 2);
@@ -221,7 +221,7 @@ namespace Immutable.Audience.Samples.SampleApp
         private void OnAlias() => RunAndLog("alias()", () =>
         {
             var f = CaptureAliasForm();
-            ImmutableAudience.Alias(f.FromId, f.FromType, f.ToId, f.ToType);
+            ImmutableAudience.Alias(f.FromId, ParseIdentityType(f.FromType), f.ToId, ParseIdentityType(f.ToType));
             // SDK drops via Log.Warn when fromId/toId is empty or consent < Full.
             // The IsAliasReady gate keeps empty endpoints unreachable from the
             // UI; this post-call check is defense-in-depth.
@@ -371,5 +371,20 @@ namespace Immutable.Audience.Samples.SampleApp
 
         private static Dictionary<string, object>? ParseTraits(string? raw) =>
             string.IsNullOrWhiteSpace(raw) ? null : JsonReader.DeserializeObject(raw!);
+
+        // Parses a wire-format identity string (e.g. "steam") back into the
+        // IdentityType enum the SDK now requires. Falls back to Custom for
+        // unknown or empty values.
+        private static IdentityType ParseIdentityType(string? value) => (value ?? "").ToLowerInvariant() switch
+        {
+            "passport" => IdentityType.Passport,
+            "steam"    => IdentityType.Steam,
+            "epic"     => IdentityType.Epic,
+            "google"   => IdentityType.Google,
+            "apple"    => IdentityType.Apple,
+            "discord"  => IdentityType.Discord,
+            "email"    => IdentityType.Email,
+            _          => IdentityType.Custom,
+        };
     }
 }

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -308,20 +308,7 @@ namespace Immutable.Audience
         /// <param name="userId">The player's identifier within the chosen provider.</param>
         /// <param name="identityType">The identity provider that issued <paramref name="userId"/>.</param>
         /// <param name="traits">Optional player attributes (email, name, etc.).</param>
-        public static void Identify(string userId, IdentityType identityType, Dictionary<string, object>? traits = null) =>
-            Identify(userId, identityType.ToLowercaseString(), traits);
-
-        /// <summary>
-        /// Attaches a known user ID to subsequent events. String overload
-        /// for providers outside the <see cref="IdentityType"/> enum.
-        /// </summary>
-        /// <param name="userId">The player's identifier within the chosen provider.</param>
-        /// <param name="identityType">
-        /// The identity provider name. Required. Data-deletion requests
-        /// match events by this namespace.
-        /// </param>
-        /// <param name="traits">Optional player attributes (email, name, etc.).</param>
-        public static void Identify(string userId, string identityType, Dictionary<string, object>? traits = null)
+        public static void Identify(string userId, IdentityType identityType, Dictionary<string, object>? traits = null)
         {
             if (!_initialized) return;
 
@@ -352,8 +339,8 @@ namespace Immutable.Audience
             }
 
             var anonymousId = Identity.GetOrCreate(config.PersistentDataPath!, level);
-            var msg = MessageBuilder.Identify(anonymousId, userId, identityType, config.PackageVersion,
-                SnapshotCallerDict(traits));
+            var msg = MessageBuilder.Identify(anonymousId, userId, identityType.ToLowercaseString(),
+                config.PackageVersion, SnapshotCallerDict(traits));
             EnqueueIdentity(msg);
         }
 
@@ -364,23 +351,7 @@ namespace Immutable.Audience
         /// <param name="fromType">Identity provider for <paramref name="fromId"/>.</param>
         /// <param name="toId">The new identifier.</param>
         /// <param name="toType">Identity provider for <paramref name="toId"/>.</param>
-        public static void Alias(string fromId, IdentityType fromType, string toId, IdentityType toType) =>
-            Alias(fromId, fromType.ToLowercaseString(), toId, toType.ToLowercaseString());
-
-        /// <summary>
-        /// Links two user IDs for the same player. String overload for
-        /// providers outside the <see cref="IdentityType"/> enum.
-        /// </summary>
-        /// <param name="fromId">The previously-known identifier.</param>
-        /// <param name="fromType">
-        /// Identity provider for <paramref name="fromId"/>. Required.
-        /// Data-deletion requests match events by this namespace.
-        /// </param>
-        /// <param name="toId">The new identifier.</param>
-        /// <param name="toType">
-        /// Identity provider for <paramref name="toId"/>. Required.
-        /// </param>
-        public static void Alias(string fromId, string fromType, string toId, string toType)
+        public static void Alias(string fromId, IdentityType fromType, string toId, IdentityType toType)
         {
             if (!_initialized) return;
 
@@ -399,7 +370,8 @@ namespace Immutable.Audience
             var config = _config;
             if (config == null) return;
 
-            var msg = MessageBuilder.Alias(fromId, fromType, toId, toType, config.PackageVersion);
+            var msg = MessageBuilder.Alias(fromId, fromType.ToLowercaseString(), toId, toType.ToLowercaseString(),
+                config.PackageVersion);
             EnqueueIdentity(msg);
         }
 

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -618,7 +618,7 @@ namespace Immutable.Audience.Tests
         {
             ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
 
-            ImmutableAudience.Identify("76561198012345", "steam");
+            ImmutableAudience.Identify("76561198012345", IdentityType.Steam);
             ImmutableAudience.Shutdown();
 
             var queueDir = AudiencePaths.QueueDir(_testDir);
@@ -633,7 +633,7 @@ namespace Immutable.Audience.Tests
         {
             ImmutableAudience.Init(MakeConfig(ConsentLevel.Anonymous));
 
-            ImmutableAudience.Identify("user1", "steam");
+            ImmutableAudience.Identify("user1", IdentityType.Steam);
             ImmutableAudience.Shutdown();
 
             var queueDir = AudiencePaths.QueueDir(_testDir);
@@ -648,7 +648,7 @@ namespace Immutable.Audience.Tests
         {
             ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
 
-            ImmutableAudience.Alias("steam123", "steam", "user_456", "passport");
+            ImmutableAudience.Alias("steam123", IdentityType.Steam, "user_456", IdentityType.Passport);
             ImmutableAudience.Shutdown();
 
             var queueDir = AudiencePaths.QueueDir(_testDir);
@@ -971,7 +971,7 @@ namespace Immutable.Audience.Tests
             for (int iter = 0; iter < iterations; iter++)
             {
                 ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
-                ImmutableAudience.Identify(testUserId, "steam");
+                ImmutableAudience.Identify(testUserId, IdentityType.Steam);
 
                 // Clear Init events so only race events can leak.
                 ImmutableAudience.FlushQueueToDiskForTesting();


### PR DESCRIPTION
## Summary

Removes the two `Identify` and `Alias` overloads on `ImmutableAudience` that take an identity type as a plain string. Studios now have only the overloads that take the typed `IdentityType` enum.

**Before**
```csharp
ImmutableAudience.Identify("76561198012345", "steam");
ImmutableAudience.Alias("steam-id", "steam", "passport-id", "passport");
```

**After**
```csharp
ImmutableAudience.Identify("76561198012345", IdentityType.Steam);
ImmutableAudience.Alias("steam-id", IdentityType.Steam, "passport-id", IdentityType.Passport);
```

Studios with a custom identity provider that isn't in the enum should use `IdentityType.Custom`.

**Why**

The Audience backend's `IdentityType` is a closed enum. Anything outside the enum is rejected with a 4xx at validation. The string overloads looked like an extensibility point but produced `AudienceErrorCode.ValidationRejected` for any value not already in the enum. The TypeScript Audience SDK never exposed these overloads. This change brings Unity in line and removes a way for studios to accidentally ship events the backend will reject.

**Implementation**
- `ImmutableAudience.Identify(string, IdentityType, Dictionary?)` and `ImmutableAudience.Alias(string, IdentityType, string, IdentityType)` now contain the validation, lock, and enqueue logic directly. The wire-format conversion (`.ToLowercaseString()`) happens inline at the `MessageBuilder` boundary.
- 4 test call sites in `ImmutableAudienceTests.cs` migrated to the enum form.

**Breaking change**
- Public API removal flagged with the `feat!:` conventional-commit prefix. Studios calling the string overloads must migrate per the table above.

**PR stack**
- Stacked on #722 (SDK-216 XML doc rollout). Once #722 lands, this PR's base will rebase to `main` automatically.

`dotnet test` passes (274 / 274; 1 pre-existing skip).

Linear: [SDK-271](https://linear.app/imtbl/issue/SDK-271/drop-identifyalias-string-identitytype-overloads-unity-audience-sdk)