### PR TITLE
refactor(audience-sdk): centralise log message text in AudienceLogs (SDK-272)

### DIFF
--- a/src/Packages/Audience/Runtime/Core/Session.cs
+++ b/src/Packages/Audience/Runtime/Core/Session.cs
@@ -112,7 +112,7 @@ namespace Immutable.Audience
                 // when End fires while paused), over-crediting engagement.
                 if (_pausedAt.HasValue)
                 {
-                    Log.Debug("Session: Pause while already paused. Ignoring.");
+                    Log.Debug(AudienceLogs.SessionPauseAlreadyPaused);
                     return;
                 }
                 _pausedAt = _getUtcNow();
@@ -259,7 +259,7 @@ namespace Immutable.Audience
             }
             catch (Exception ex)
             {
-                Log.Warn($"Session: {eventName} track callback threw {ex.GetType().Name}. Event dropped.");
+                Log.Warn(AudienceLogs.SessionTrackCallbackThrew(eventName, ex));
             }
         }
 
@@ -277,8 +277,7 @@ namespace Immutable.Audience
 
             if (!TimerDisposal.DisposeAndWait(timer, TimeSpan.FromSeconds(1)))
             {
-                Log.Warn("Session: heartbeat callback did not complete within 1s on timer stop. " +
-                         "A trailing session_heartbeat may race with the next session lifecycle event.");
+                Log.Warn(AudienceLogs.SessionHeartbeatTimeout);
             }
         }
 

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -159,8 +159,7 @@ namespace Immutable.Audience
             {
                 if (_initialized)
                 {
-                    Log.Warn("Init called more than once. Ignoring; original config retained. " +
-                             "Call Shutdown() first if reconfiguring is intended.");
+                    Log.Warn(AudienceLogs.InitCalledTwice);
                     return;
                 }
 
@@ -237,7 +236,7 @@ namespace Immutable.Audience
             if (!_initialized || !state.Level.CanTrack()) return;
             if (evt == null)
             {
-                Log.Warn("Track(IEvent) called with null event. Dropping.");
+                Log.Warn(AudienceLogs.TrackIEventNull);
                 return;
             }
 
@@ -254,13 +253,13 @@ namespace Immutable.Audience
             }
             catch (Exception ex)
             {
-                Log.Warn($"Track(IEvent): {evt.GetType().Name}.ToProperties()/EventName threw {ex.GetType().Name}: {ex.Message}. Dropping.");
+                Log.Warn(AudienceLogs.TrackIEventThrew(evt.GetType().Name, ex));
                 return;
             }
 
             if (string.IsNullOrEmpty(eventName))
             {
-                Log.Warn($"Track(IEvent): {evt.GetType().Name}.EventName returned null or empty. Dropping.");
+                Log.Warn(AudienceLogs.TrackIEventEmptyName(evt.GetType().Name));
                 return;
             }
 
@@ -284,7 +283,7 @@ namespace Immutable.Audience
             if (!_initialized || !state.Level.CanTrack()) return;
             if (string.IsNullOrEmpty(eventName))
             {
-                Log.Warn("Track(string) called with null or empty event name. Dropping.");
+                Log.Warn(AudienceLogs.TrackStringEmptyName);
                 return;
             }
 
@@ -315,7 +314,7 @@ namespace Immutable.Audience
             // Validate inputs before consent so null-arg callers get the right warning.
             if (string.IsNullOrEmpty(userId))
             {
-                Log.Warn("Identify called with null or empty userId. Dropping.");
+                Log.Warn(AudienceLogs.IdentifyEmptyUserId);
                 return;
             }
 
@@ -330,7 +329,7 @@ namespace Immutable.Audience
                 level = current.Level;
                 if (!level.CanIdentify())
                 {
-                    Log.Warn($"Identify discarded. Requires Full consent, current is {level}.");
+                    Log.Warn(AudienceLogs.IdentifyDiscarded(level));
                     return;
                 }
                 config = _config;
@@ -357,13 +356,13 @@ namespace Immutable.Audience
 
             if (string.IsNullOrEmpty(fromId) || string.IsNullOrEmpty(toId))
             {
-                Log.Warn("Alias called with null or empty fromId/toId. Dropping.");
+                Log.Warn(AudienceLogs.AliasEmptyIds);
                 return;
             }
             var state = _state;
             if (!state.Level.CanIdentify())
             {
-                Log.Warn($"Alias discarded. Requires Full consent, current is {state.Level}.");
+                Log.Warn(AudienceLogs.AliasDiscarded(state.Level));
                 return;
             }
 
@@ -486,7 +485,7 @@ namespace Immutable.Audience
             }
             catch (Exception ex)
             {
-                Log.Warn($"onError threw {ex.GetType().Name}: {ex.Message}");
+                Log.Warn(AudienceLogs.OnErrorThrew(ex));
             }
         }
 
@@ -579,8 +578,7 @@ namespace Immutable.Audience
             }
             catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
             {
-                Log.Warn($"SetConsent: failed to persist consent level. {ex.GetType().Name}: {ex.Message}. " +
-                         "In-memory level is updated but will revert on next launch.");
+                Log.Warn(AudienceLogs.ConsentPersistFailed(ex));
                 NotifyErrorCallback(config.OnError, AudienceErrorCode.ConsentPersistFailed,
                     $"Consent persist failed: {ex.Message}");
             }
@@ -802,13 +800,12 @@ namespace Immutable.Audience
                     var send = transport.SendBatchAsync();
                     if (!send.Wait(timeoutMs))
                     {
-                        Log.Warn($"Shutdown flush exceeded {timeoutMs}ms. Abandoning. " +
-                                 "Queued events remain on disk and will retry on next startup.");
+                        Log.Warn(AudienceLogs.ShutdownFlushExceeded(timeoutMs));
                     }
                 }
                 catch (Exception ex)
                 {
-                    Log.Warn($"Shutdown flush threw: {ex.GetType().Name}: {ex.Message}");
+                    Log.Warn(AudienceLogs.ShutdownFlushThrew(ex));
                 }
             }
 
@@ -870,17 +867,11 @@ namespace Immutable.Audience
 
             if (isTestKey && trimmed == Constants.ProductionBaseUrl)
             {
-                Log.Warn(
-                    $"Publishable key has the test prefix ({Constants.TestKeyPrefix}) but BaseUrl points to production. " +
-                    "The backend will reject events with 401. Either remove the BaseUrl override (test keys " +
-                    "default to sandbox) or use a non-test publishable key.");
+                Log.Warn(AudienceLogs.TestKeyAgainstProduction);
             }
             else if (!isTestKey && trimmed == Constants.SandboxBaseUrl)
             {
-                Log.Warn(
-                    "Publishable key is not a test key but BaseUrl points to sandbox. " +
-                    "The backend will reject events with 401. Either remove the BaseUrl override (non-test " +
-                    $"keys default to production) or use a test publishable key ({Constants.TestKeyPrefix}).");
+                Log.Warn(AudienceLogs.NonTestKeyAgainstSandbox);
             }
         }
 
@@ -922,8 +913,7 @@ namespace Immutable.Audience
             }
             catch (Exception ex)
             {
-                Log.Warn($"ContextProvider threw {ex.GetType().Name}: {ex.Message}. " +
-                         "Event ships with base context only.");
+                Log.Warn(AudienceLogs.ContextProviderThrew(ex));
                 return;
             }
             if (extra == null) return;
@@ -959,7 +949,7 @@ namespace Immutable.Audience
                     catch (Exception ex)
                     {
                         // Timer-thread callback; no caller above to catch.
-                        Log.Warn($"SendBatch unexpected exception: {ex.GetType().Name}: {ex.Message}");
+                        Log.Warn(AudienceLogs.SendBatchUnexpected(ex));
                     }
                 }
 
@@ -1007,8 +997,7 @@ namespace Immutable.Audience
                 try { unityContext = provider(); }
                 catch (Exception ex)
                 {
-                    Log.Warn($"LaunchContextProvider threw {ex.GetType().Name}: {ex.Message}. " +
-                             "game_launch will ship without auto-detected Unity context.");
+                    Log.Warn(AudienceLogs.LaunchContextProviderThrew(ex));
                 }
 
                 if (unityContext != null)

--- a/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
+++ b/src/Packages/Audience/Runtime/Transport/HttpTransport.cs
@@ -288,7 +288,7 @@ namespace Immutable.Audience
             }
             catch (Exception ex)
             {
-                Log.Warn($"ParseRejectedCount threw {ex.GetType().Name}: {ex.Message}");
+                Log.Warn(AudienceLogs.ParseRejectedCountThrew(ex));
                 return 0;
             }
             if (string.IsNullOrEmpty(body)) return 0;
@@ -339,7 +339,7 @@ namespace Immutable.Audience
             }
             catch (Exception ex)
             {
-                Log.Warn($"_onError threw {ex.GetType().Name}: {ex.Message}");
+                Log.Warn(AudienceLogs.OnErrorThrew(ex));
             }
         }
     }

--- a/src/Packages/Audience/Runtime/Utility/Log.cs
+++ b/src/Packages/Audience/Runtime/Utility/Log.cs
@@ -42,4 +42,99 @@ namespace Immutable.Audience
             }
         }
     }
+
+    internal static class AudienceLogs
+    {
+        // ---- Init / config validation ----
+
+        internal const string InitCalledTwice =
+            "Init called more than once. Ignoring; original config retained. " +
+            "Call Shutdown() first if reconfiguring is intended.";
+
+        internal static readonly string TestKeyAgainstProduction =
+            $"Publishable key has the test prefix ({Constants.TestKeyPrefix}) but BaseUrl points to production. " +
+            "The backend will reject events with 401. Either remove the BaseUrl override (test keys " +
+            "default to sandbox) or use a non-test publishable key.";
+
+        internal static readonly string NonTestKeyAgainstSandbox =
+            "Publishable key is not a test key but BaseUrl points to sandbox. " +
+            "The backend will reject events with 401. Either remove the BaseUrl override (non-test " +
+            $"keys default to production) or use a test publishable key ({Constants.TestKeyPrefix}).";
+
+        // ---- Track ----
+
+        internal const string TrackIEventNull =
+            "Track(IEvent) called with null event. Dropping.";
+
+        internal const string TrackStringEmptyName =
+            "Track(string) called with null or empty event name. Dropping.";
+
+        internal static string TrackIEventThrew(string evtTypeName, Exception ex) =>
+            $"Track(IEvent): {evtTypeName}.ToProperties()/EventName threw {ex.GetType().Name}: {ex.Message}. Dropping.";
+
+        internal static string TrackIEventEmptyName(string evtTypeName) =>
+            $"Track(IEvent): {evtTypeName}.EventName returned null or empty. Dropping.";
+
+        // ---- Identify / Alias ----
+
+        internal const string IdentifyEmptyUserId =
+            "Identify called with null or empty userId. Dropping.";
+
+        internal const string AliasEmptyIds =
+            "Alias called with null or empty fromId/toId. Dropping.";
+
+        internal static string IdentifyDiscarded(ConsentLevel current) =>
+            $"Identify discarded. Requires Full consent, current is {current}.";
+
+        internal static string AliasDiscarded(ConsentLevel current) =>
+            $"Alias discarded. Requires Full consent, current is {current}.";
+
+        // ---- Consent / Shutdown ----
+
+        internal static string ConsentPersistFailed(Exception ex) =>
+            $"SetConsent: failed to persist consent level. {ex.GetType().Name}: {ex.Message}. " +
+            "In-memory level is updated but will revert on next launch.";
+
+        internal static string ShutdownFlushExceeded(int timeoutMs) =>
+            $"Shutdown flush exceeded {timeoutMs}ms. Abandoning. " +
+            "Queued events remain on disk and will retry on next startup.";
+
+        internal static string ShutdownFlushThrew(Exception ex) =>
+            $"Shutdown flush threw: {ex.GetType().Name}: {ex.Message}";
+
+        // ---- onError handler swallow ----
+
+        internal static string OnErrorThrew(Exception ex) =>
+            $"onError threw {ex.GetType().Name}: {ex.Message}";
+
+        // ---- Send loop ----
+
+        internal static string SendBatchUnexpected(Exception ex) =>
+            $"SendBatch unexpected exception: {ex.GetType().Name}: {ex.Message}";
+
+        internal static string ParseRejectedCountThrew(Exception ex) =>
+            $"ParseRejectedCount threw {ex.GetType().Name}: {ex.Message}";
+
+        // ---- Session ----
+
+        internal const string SessionPauseAlreadyPaused =
+            "Session: Pause while already paused. Ignoring.";
+
+        internal const string SessionHeartbeatTimeout =
+            "Session: heartbeat callback did not complete within 1s on timer stop. " +
+            "A trailing session_heartbeat may race with the next session lifecycle event.";
+
+        internal static string SessionTrackCallbackThrew(string eventName, Exception ex) =>
+            $"Session: {eventName} track callback threw {ex.GetType().Name}. Event dropped.";
+
+        // ---- Context providers ----
+
+        internal static string ContextProviderThrew(Exception ex) =>
+            $"ContextProvider threw {ex.GetType().Name}: {ex.Message}. " +
+            "Event ships with base context only.";
+
+        internal static string LaunchContextProviderThrew(Exception ex) =>
+            $"LaunchContextProvider threw {ex.GetType().Name}: {ex.Message}. " +
+            "game_launch will ship without auto-detected Unity context.";
+    }
 }

--- a/src/Packages/Audience/Tests/Runtime/Core/SessionTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Core/SessionTests.cs
@@ -499,7 +499,7 @@ namespace Immutable.Audience.Tests
 
                 lock (warnings)
                 {
-                    Assert.IsTrue(warnings.Any(w => w.Contains("heartbeat callback did not complete")),
+                    Assert.IsTrue(warnings.Any(w => w.Contains(AudienceLogs.SessionHeartbeatTimeout)),
                         "End must log the drain-timeout warning when an in-flight heartbeat exceeds 1 s");
                 }
             }
@@ -557,7 +557,8 @@ namespace Immutable.Audience.Tests
 
                 lock (warnings)
                 {
-                    Assert.IsTrue(warnings.Any(w => w.Contains("session_heartbeat track callback threw")),
+                    var expected = AudienceLogs.SessionTrackCallbackThrew("session_heartbeat", new InvalidOperationException());
+                    Assert.IsTrue(warnings.Any(w => w.Contains(expected)),
                         "SafeTrack must log a warning when the callback throws");
                 }
             }
@@ -590,7 +591,8 @@ namespace Immutable.Audience.Tests
 
                 lock (warnings)
                 {
-                    Assert.IsTrue(warnings.Any(w => w.Contains("session_start track callback threw")),
+                    var expected = AudienceLogs.SessionTrackCallbackThrew("session_start", new InvalidOperationException());
+                    Assert.IsTrue(warnings.Any(w => w.Contains(expected)),
                         "SafeTrack must log a warning when the Start callback throws");
                 }
             }
@@ -625,7 +627,8 @@ namespace Immutable.Audience.Tests
 
                 lock (warnings)
                 {
-                    Assert.IsTrue(warnings.Any(w => w.Contains("session_end track callback threw")),
+                    var expected = AudienceLogs.SessionTrackCallbackThrew("session_end", new InvalidOperationException());
+                    Assert.IsTrue(warnings.Any(w => w.Contains(expected)),
                         "SafeTrack must log a warning when the End callback throws");
                 }
             }

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -303,7 +303,7 @@ namespace Immutable.Audience.Tests
             try
             {
                 Assert.DoesNotThrow(() => ImmutableAudience.Track((IEvent)null));
-                Assert.That(lines, Has.Some.Contains("null event"));
+                Assert.That(lines, Has.Some.Contains(AudienceLogs.TrackIEventNull));
             }
             finally { Log.Writer = null; }
         }
@@ -320,7 +320,9 @@ namespace Immutable.Audience.Tests
                 // Purchase with no Value set: ToProperties throws; Track must
                 // catch, warn, and drop rather than ship an incomplete event.
                 Assert.DoesNotThrow(() => ImmutableAudience.Track(new Purchase { Currency = "USD" }));
-                Assert.That(lines, Has.Some.Contains("Purchase"));
+                // Assert the stable parts (event-type name and trailing "Dropping")
+                // so the test survives any change to the exception type or message.
+                Assert.That(lines, Has.Some.Contains(nameof(Purchase)));
                 Assert.That(lines, Has.Some.Contains("Dropping"));
             }
             finally { Log.Writer = null; }
@@ -430,7 +432,7 @@ namespace Immutable.Audience.Tests
                 ImmutableAudience.Init(MakeConfig());
                 ImmutableAudience.Init(MakeConfig());
 
-                Assert.That(lines, Has.Some.Contains("Init called more than once"),
+                Assert.That(lines, Has.Some.Contains(AudienceLogs.InitCalledTwice),
                     "second Init must surface a warning so a developer notices the silent no-op");
             }
             finally
@@ -467,7 +469,7 @@ namespace Immutable.Audience.Tests
 
                 foreach (var t in threads) t.Join(TimeSpan.FromSeconds(5));
 
-                var warningCount = lines.Count(l => l.Contains("Init called more than once"));
+                var warningCount = lines.Count(l => l.Contains(AudienceLogs.InitCalledTwice));
                 Assert.AreEqual(threadCount - 1, warningCount,
                     "exactly one thread should initialise; the other (threadCount - 1) should hit the duplicate-call warning branch");
             }

--- a/src/Packages/Audience/Tests/Runtime/PublishableKeyPrefixTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/PublishableKeyPrefixTests.cs
@@ -74,7 +74,7 @@ namespace Immutable.Audience.Tests
             {
                 ImmutableAudience.Init(MakeConfig(TestPrefixKey, ProductionUrl));
 
-                Assert.That(lines, Has.Some.Contains("test prefix").And.Contains("production"),
+                Assert.That(lines, Has.Some.Contains(AudienceLogs.TestKeyAgainstProduction),
                     "Init must warn when a test-prefix key is paired with the production BaseUrl");
             }
             finally { Log.Writer = null; }
@@ -89,7 +89,7 @@ namespace Immutable.Audience.Tests
             {
                 ImmutableAudience.Init(MakeConfig(NonTestKey, SandboxUrl));
 
-                Assert.That(lines, Has.Some.Contains("not a test key").And.Contains("sandbox"),
+                Assert.That(lines, Has.Some.Contains(AudienceLogs.NonTestKeyAgainstSandbox),
                     "Init must warn when a non-test key is paired with the sandbox BaseUrl");
             }
             finally { Log.Writer = null; }
@@ -104,7 +104,11 @@ namespace Immutable.Audience.Tests
             {
                 ImmutableAudience.Init(MakeConfig(TestPrefixKey, SandboxUrl));
 
-                Assert.That(lines.Where(l => l.Contains("BaseUrl")), Is.Empty,
+                Assert.That(
+                    lines.Where(l =>
+                        l.Contains(AudienceLogs.TestKeyAgainstProduction) ||
+                        l.Contains(AudienceLogs.NonTestKeyAgainstSandbox)),
+                    Is.Empty,
                     "test-key + sandbox-URL is the canonical pairing; no warning expected");
             }
             finally { Log.Writer = null; }
@@ -120,7 +124,11 @@ namespace Immutable.Audience.Tests
                 // Fake fixture URL on purpose.
                 ImmutableAudience.Init(MakeConfig(TestPrefixKey, "https://api.dev.example.com"));
 
-                Assert.That(lines.Where(l => l.Contains("BaseUrl")), Is.Empty,
+                Assert.That(
+                    lines.Where(l =>
+                        l.Contains(AudienceLogs.TestKeyAgainstProduction) ||
+                        l.Contains(AudienceLogs.NonTestKeyAgainstSandbox)),
+                    Is.Empty,
                     "custom BaseUrl must not be flagged as a mismatch");
             }
             finally { Log.Writer = null; }
@@ -135,7 +143,11 @@ namespace Immutable.Audience.Tests
             {
                 ImmutableAudience.Init(MakeConfig(TestPrefixKey, baseUrl: null));
 
-                Assert.That(lines.Where(l => l.Contains("BaseUrl")), Is.Empty,
+                Assert.That(
+                    lines.Where(l =>
+                        l.Contains(AudienceLogs.TestKeyAgainstProduction) ||
+                        l.Contains(AudienceLogs.NonTestKeyAgainstSandbox)),
+                    Is.Empty,
                     "no override means no mismatch; no warning expected");
             }
             finally { Log.Writer = null; }
@@ -150,7 +162,7 @@ namespace Immutable.Audience.Tests
             {
                 ImmutableAudience.Init(MakeConfig(TestPrefixKey, ProductionUrl + "/"));
 
-                Assert.That(lines, Has.Some.Contains("test prefix").And.Contains("production"),
+                Assert.That(lines, Has.Some.Contains(AudienceLogs.TestKeyAgainstProduction),
                     "trailing slash on the production URL must not bypass the mismatch check");
             }
             finally { Log.Writer = null; }


### PR DESCRIPTION
## Summary

- Adds `Runtime/Utility/AudienceLogs.cs` as the single source of truth for runtime log message strings.
- Migrates every `Log.Warn` / `Log.Debug` call site in `ImmutableAudience.cs`, `Session.cs`, and `HttpTransport.cs` from inline literals to references against `AudienceLogs`.
- Static messages use `internal const string`; messages that compose from another `const` use `internal static readonly string`; parameterised messages use `internal static string Method(...)` returning a formatted string.
- Migrates the test assertions that previously matched on inline log-line substrings to reference `AudienceLogs` constants. Negative-path tests in `PublishableKeyPrefixTests` previously used `Contains("BaseUrl")` as a sentinel for "no key-mismatch warning fired"; switched to assert against the actual mismatch constants so an unrelated future log line cannot trip them.
- Unifies `HttpTransport.NotifyError` and `ImmutableAudience.NotifyErrorCallback` onto a single `OnErrorThrew(ex)` template; `HttpTransport`'s prior wording carried an incidental underscore (`_onError threw ...`) from the field name and is dropped during the migration.
- No code behaviour changes. Wire format and the consumer-facing `OnError` callback contract are untouched. The only user-visible log-text change is the dropped underscore noted above.
- `dotnet test` passes.

Linear: [SDK-272](https://linear.app/imtbl/issue/SDK-272)