### PR TITLE
refactor(audience): SDK test pinning and sample-app custom events (SDK-277)

### DIFF
--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.Events.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.Events.cs
@@ -55,15 +55,15 @@ namespace Immutable.Audience.Samples.SampleApp
 
         internal static readonly EventSpec[] Catalogue =
         {
-            new EventSpec(SampleAppCustomEvents.SignUp,        new[] { EventField.Text("method", optional: true) }),
-            new EventSpec(SampleAppCustomEvents.SignIn,        new[] { EventField.Text("method", optional: true) }),
-            new EventSpec(SampleAppCustomEvents.EmailAcquired, new[] { EventField.Text("source", optional: true) }),
+            new EventSpec(SampleAppCustomEvents.SignUp,        new[] { EventField.Text(SampleAppCustomEventPropertyKeys.Method, optional: true) }),
+            new EventSpec(SampleAppCustomEvents.SignIn,        new[] { EventField.Text(SampleAppCustomEventPropertyKeys.Method, optional: true) }),
+            new EventSpec(SampleAppCustomEvents.EmailAcquired, new[] { EventField.Text(SampleAppCustomEventPropertyKeys.Source, optional: true) }),
             new EventSpec(SampleAppCustomEvents.WishlistAdd,   new[] {
-                EventField.Text("gameId"),
-                EventField.Text("source",   optional: true),
-                EventField.Text("platform", optional: true),
+                EventField.Text(SampleAppCustomEventPropertyKeys.GameId),
+                EventField.Text(SampleAppCustomEventPropertyKeys.Source,   optional: true),
+                EventField.Text(SampleAppCustomEventPropertyKeys.Platform, optional: true),
             }),
-            new EventSpec(SampleAppCustomEvents.WishlistRemove, new[] { EventField.Text("gameId") }),
+            new EventSpec(SampleAppCustomEvents.WishlistRemove, new[] { EventField.Text(SampleAppCustomEventPropertyKeys.GameId) }),
             new EventSpec(EventNames.Purchase, new[] {
                 EventField.Text(EventPropertyKeys.Currency),
                 EventField.Number(EventPropertyKeys.Value),
@@ -92,15 +92,15 @@ namespace Immutable.Audience.Samples.SampleApp
             }),
             new EventSpec(EventNames.MilestoneReached, new[] { EventField.Text(EventPropertyKeys.Name) }),
             new EventSpec(SampleAppCustomEvents.GamePageViewed,  new[] {
-                EventField.Text("gameId"),
-                EventField.Text("gameName", optional: true),
-                EventField.Text("slug",     optional: true),
+                EventField.Text(SampleAppCustomEventPropertyKeys.GameId),
+                EventField.Text(SampleAppCustomEventPropertyKeys.GameName, optional: true),
+                EventField.Text(SampleAppCustomEventPropertyKeys.Slug,     optional: true),
             }),
             new EventSpec(SampleAppCustomEvents.LinkClicked, new[] {
-                EventField.Text("url"),
-                EventField.Text("label",  optional: true),
-                EventField.Text("source", optional: true),
-                EventField.Text("gameId", optional: true),
+                EventField.Text(SampleAppCustomEventPropertyKeys.Url),
+                EventField.Text(SampleAppCustomEventPropertyKeys.Label,  optional: true),
+                EventField.Text(SampleAppCustomEventPropertyKeys.Source, optional: true),
+                EventField.Text(SampleAppCustomEventPropertyKeys.GameId, optional: true),
             }),
         };
 

--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.Events.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.Events.cs
@@ -55,15 +55,15 @@ namespace Immutable.Audience.Samples.SampleApp
 
         internal static readonly EventSpec[] Catalogue =
         {
-            new EventSpec("sign_up",        new[] { EventField.Text("method", optional: true) }),
-            new EventSpec("sign_in",        new[] { EventField.Text("method", optional: true) }),
-            new EventSpec("email_acquired", new[] { EventField.Text("source", optional: true) }),
-            new EventSpec("wishlist_add",   new[] {
+            new EventSpec(SampleAppCustomEvents.SignUp,        new[] { EventField.Text("method", optional: true) }),
+            new EventSpec(SampleAppCustomEvents.SignIn,        new[] { EventField.Text("method", optional: true) }),
+            new EventSpec(SampleAppCustomEvents.EmailAcquired, new[] { EventField.Text("source", optional: true) }),
+            new EventSpec(SampleAppCustomEvents.WishlistAdd,   new[] {
                 EventField.Text("gameId"),
                 EventField.Text("source",   optional: true),
                 EventField.Text("platform", optional: true),
             }),
-            new EventSpec("wishlist_remove", new[] { EventField.Text("gameId") }),
+            new EventSpec(SampleAppCustomEvents.WishlistRemove, new[] { EventField.Text("gameId") }),
             new EventSpec(EventNames.Purchase, new[] {
                 EventField.Text(EventPropertyKeys.Currency),
                 EventField.Number(EventPropertyKeys.Value),
@@ -91,12 +91,12 @@ namespace Immutable.Audience.Samples.SampleApp
                 EventField.Text(EventPropertyKeys.ItemId,   optional: true),
             }),
             new EventSpec(EventNames.MilestoneReached, new[] { EventField.Text(EventPropertyKeys.Name) }),
-            new EventSpec("game_page_viewed",  new[] {
+            new EventSpec(SampleAppCustomEvents.GamePageViewed,  new[] {
                 EventField.Text("gameId"),
                 EventField.Text("gameName", optional: true),
                 EventField.Text("slug",     optional: true),
             }),
-            new EventSpec("link_clicked", new[] {
+            new EventSpec(SampleAppCustomEvents.LinkClicked, new[] {
                 EventField.Text("url"),
                 EventField.Text("label",  optional: true),
                 EventField.Text("source", optional: true),

--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.UI.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.UI.cs
@@ -365,7 +365,7 @@ namespace Immutable.Audience.Samples.SampleApp
                     if (label.ClassListContains(SampleAppUi.Css.Copied)) return;
                     if (string.IsNullOrEmpty(label.text) || label.text == SampleAppUi.StatusBar.EmptyText) return;
                     GUIUtility.systemCopyBuffer = label.text;
-                    label.text = "Copied!";
+                    label.text = SampleAppUi.ButtonText.CopiedFlash;
                     FlashCopied(label);
                 });
         }

--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.UI.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.UI.cs
@@ -533,17 +533,17 @@ namespace Immutable.Audience.Samples.SampleApp
             string? derivedFromKey = keyEmpty ? null : (isTest ? Constants.SandboxBaseUrl : Constants.ProductionBaseUrl);
             string? endpoint = hasOverride ? overrideUrl : derivedFromKey;
             bool warnState = hasOverride || (!keyEmpty && !isTest);
-            SetStatusCell(_statusEndpoint, endpoint, warnState ? "state-warn" : "state-ok");
+            SetStatusCell(_statusEndpoint, endpoint, warnState ? SampleAppUi.Css.StateWarn : SampleAppUi.Css.StateOk);
             _prodWarning.EnableInClassList(SampleAppUi.HiddenClass, hasOverride || keyEmpty || isTest);
 
             var consent = _initialised ? ImmutableAudience.CurrentConsent : ConsentOrder[Mathf.Clamp(_initialConsent?.index ?? 0, 0, ConsentOrder.Length - 1)];
             int cIdx = Array.IndexOf(ConsentOrder, consent);
-            SetStatusCell(_statusConsent, consent.ToLowercaseString(), cIdx >= 0 ? ConsentStateClass[cIdx] : "dim");
+            SetStatusCell(_statusConsent, consent.ToLowercaseString(), cIdx >= 0 ? ConsentStateClass[cIdx] : SampleAppUi.Css.Dim);
 
-            SetStatusCell(_statusAnon,    _initialised ? ImmutableAudience.AnonymousId : null, "dim");
-            SetStatusCell(_statusUser,    _initialised ? ImmutableAudience.UserId      : null, "dim");
-            SetStatusCell(_statusSession, _initialised ? ImmutableAudience.SessionId   : null, "dim");
-            SetStatusCell(_statusQueue,   _initialised ? ImmutableAudience.QueueSize.ToString(CultureInfo.InvariantCulture) : null, "dim");
+            SetStatusCell(_statusAnon,    _initialised ? ImmutableAudience.AnonymousId : null, SampleAppUi.Css.Dim);
+            SetStatusCell(_statusUser,    _initialised ? ImmutableAudience.UserId      : null, SampleAppUi.Css.Dim);
+            SetStatusCell(_statusSession, _initialised ? ImmutableAudience.SessionId   : null, SampleAppUi.Css.Dim);
+            SetStatusCell(_statusQueue,   _initialised ? ImmutableAudience.QueueSize.ToString(CultureInfo.InvariantCulture) : null, SampleAppUi.Css.Dim);
         }
 
         private void RefreshConsentPills()

--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
@@ -130,8 +130,8 @@ namespace Immutable.Audience.Samples.SampleApp
                     ImmutableAudience.Track(typed);
                     return Json.Serialize(new Dictionary<string, object>
                     {
-                        ["event"] = spec.Name,
-                        ["overload"] = "typed",
+                        [SampleAppUi.LogPayloadKeys.Event] = spec.Name,
+                        [SampleAppUi.LogPayloadKeys.Overload] = SampleAppUi.LogPayloadKeys.OverloadValues.Typed,
                         [MessageFields.Properties] = typed.ToProperties(),
                     }, 2);
                 }
@@ -139,8 +139,8 @@ namespace Immutable.Audience.Samples.SampleApp
                 ImmutableAudience.Track(spec.Name, props.Count > 0 ? props : null);
                 return Json.Serialize(new Dictionary<string, object>
                 {
-                    ["event"] = spec.Name,
-                    ["overload"] = "string",
+                    [SampleAppUi.LogPayloadKeys.Event] = spec.Name,
+                    [SampleAppUi.LogPayloadKeys.Overload] = SampleAppUi.LogPayloadKeys.OverloadValues.String,
                     [MessageFields.Properties] = props,
                 }, 2);
             });
@@ -154,7 +154,7 @@ namespace Immutable.Audience.Samples.SampleApp
             var f = CaptureCustomEventForm();
             var props = string.IsNullOrEmpty(f.RawProps) ? null : JsonReader.DeserializeObject(f.RawProps);
             ImmutableAudience.Track(f.Name, props);
-            var echo = new Dictionary<string, object> { ["event"] = f.Name };
+            var echo = new Dictionary<string, object> { [SampleAppUi.LogPayloadKeys.Event] = f.Name };
             if (props != null) echo[MessageFields.Properties] = props;
             return Json.Serialize(echo, 2);
         });
@@ -171,14 +171,14 @@ namespace Immutable.Audience.Samples.SampleApp
             if (!level.CanIdentify()) ResetIdentityMirror();
             var payload = new Dictionary<string, object>
             {
-                ["from"] = previous.ToLowercaseString(),
-                ["to"] = level.ToLowercaseString(),
+                [SampleAppUi.LogPayloadKeys.From] = previous.ToLowercaseString(),
+                [SampleAppUi.LogPayloadKeys.To] = level.ToLowercaseString(),
             };
             var effects = new List<string>();
             if (previous == ConsentLevel.None && level != ConsentLevel.None) effects.Add(SampleAppUi.Messages.QueueStartedSessionCreated);
             if (level == ConsentLevel.None) effects.Add(SampleAppUi.Messages.QueuePurgedAnonymousIdCleared);
             if (!level.CanIdentify() && previous.CanIdentify()) effects.Add(SampleAppUi.Messages.UserIdCleared);
-            if (effects.Count > 0) payload["effects"] = effects;
+            if (effects.Count > 0) payload[SampleAppUi.LogPayloadKeys.Effects] = effects;
             OnSdkStateChanged();
             return Json.Serialize(payload, 2);
         });
@@ -198,9 +198,9 @@ namespace Immutable.Audience.Samples.SampleApp
             OnSdkStateChanged();
             var payload = new Dictionary<string, object>
             {
-                ["id"]                       = f.Id,
-                [MessageFields.IdentityType] = f.Type,
-                ["accepted"]                 = accepted,
+                [SampleAppUi.LogPayloadKeys.Id]       = f.Id,
+                [MessageFields.IdentityType]          = f.Type,
+                [SampleAppUi.LogPayloadKeys.Accepted] = accepted,
             };
             if (traits != null) payload[MessageFields.Traits] = traits;
             return Json.Serialize(payload, 2);
@@ -233,9 +233,9 @@ namespace Immutable.Audience.Samples.SampleApp
             }
             return Json.Serialize(new Dictionary<string, object>
             {
-                ["from"]     = new Dictionary<string, object> { ["id"] = f.FromId, [MessageFields.IdentityType] = f.FromType },
-                ["to"]       = new Dictionary<string, object> { ["id"] = f.ToId,   [MessageFields.IdentityType] = f.ToType },
-                ["accepted"] = accepted,
+                [SampleAppUi.LogPayloadKeys.From]     = new Dictionary<string, object> { [SampleAppUi.LogPayloadKeys.Id] = f.FromId, [MessageFields.IdentityType] = f.FromType },
+                [SampleAppUi.LogPayloadKeys.To]       = new Dictionary<string, object> { [SampleAppUi.LogPayloadKeys.Id] = f.ToId,   [MessageFields.IdentityType] = f.ToType },
+                [SampleAppUi.LogPayloadKeys.Accepted] = accepted,
             }, 2);
         });
 
@@ -246,8 +246,8 @@ namespace Immutable.Audience.Samples.SampleApp
         private void OnSdkError(AudienceError err) =>
             AppendLog(SampleAppUi.LogLabels.OnError, Json.Serialize(new Dictionary<string, object>
             {
-                ["code"] = err.Code.ToString(),
-                ["message"] = err.Message,
+                [SampleAppUi.LogPayloadKeys.Code] = err.Code.ToString(),
+                [SampleAppUi.LogPayloadKeys.Message] = err.Message,
             }, 2), LogLevel.Err, LogSource.Sdk);
 
         // SDK Log.Writer adapter. May fire from any thread; AppendLog handles
@@ -334,17 +334,17 @@ namespace Immutable.Audience.Samples.SampleApp
         {
             var echo = new Dictionary<string, object>
             {
-                ["consent"]                = config.Consent.ToString(),
-                ["debug"]                  = config.Debug,
-                ["flushIntervalSeconds"]   = config.FlushIntervalSeconds,
-                ["flushSize"]              = config.FlushSize,
-                ["packageVersion"]         = config.PackageVersion,
-                ["shutdownFlushTimeoutMs"] = config.ShutdownFlushTimeoutMs,
+                [SampleAppUi.LogPayloadKeys.Consent]                = config.Consent.ToString(),
+                [SampleAppUi.LogPayloadKeys.Debug]                  = config.Debug,
+                [SampleAppUi.LogPayloadKeys.FlushIntervalSeconds]   = config.FlushIntervalSeconds,
+                [SampleAppUi.LogPayloadKeys.FlushSize]              = config.FlushSize,
+                [SampleAppUi.LogPayloadKeys.PackageVersion]         = config.PackageVersion,
+                [SampleAppUi.LogPayloadKeys.ShutdownFlushTimeoutMs] = config.ShutdownFlushTimeoutMs,
             };
             if (!string.IsNullOrEmpty(config.PublishableKey))
-                echo["publishableKey"] = RedactPublishableKey(config.PublishableKey);
+                echo[SampleAppUi.LogPayloadKeys.PublishableKey] = RedactPublishableKey(config.PublishableKey);
             if (!string.IsNullOrEmpty(config.PersistentDataPath))
-                echo["persistentDataPath"] = config.PersistentDataPath;
+                echo[SampleAppUi.LogPayloadKeys.PersistentDataPath] = config.PersistentDataPath;
             return echo;
         }
 

--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
@@ -111,7 +111,7 @@ namespace Immutable.Audience.Samples.SampleApp
             GuardConsentForTrack();
             var screen = SceneManager.GetActiveScene().name;
             var props = new Dictionary<string, object> { ["path"] = screen };
-            ImmutableAudience.Track("screen_viewed", props);
+            ImmutableAudience.Track(SampleAppCustomEvents.ScreenViewed, props);
             return Json.Serialize(props, 2);
         });
 

--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
@@ -71,7 +71,7 @@ namespace Immutable.Audience.Samples.SampleApp
             _initialised = false;
             ResetIdentityMirror();
             OnSdkStateChanged();
-            return "SDK stopped";
+            return SampleAppUi.Messages.SdkStopped;
         });
 
         private void OnReset() => RunAndLog(SampleAppUi.LogLabels.Reset, () =>
@@ -79,22 +79,22 @@ namespace Immutable.Audience.Samples.SampleApp
             ImmutableAudience.Reset();
             ResetIdentityMirror();
             OnSdkStateChanged();
-            return "anonymous ID regenerated, queue cleared";
+            return SampleAppUi.Messages.AnonymousIdRegeneratedQueueCleared;
         });
 
         private async Task OnFlushAsync()
         {
-            try { await ImmutableAudience.FlushAsync(); AppendLog(SampleAppUi.LogLabels.Flush, "queue flushed", LogLevel.Ok, LogSource.App); OnSdkStateChanged(); }
+            try { await ImmutableAudience.FlushAsync(); AppendLog(SampleAppUi.LogLabels.Flush, SampleAppUi.Messages.QueueFlushed, LogLevel.Ok, LogSource.App); OnSdkStateChanged(); }
             catch (Exception ex) { AppendLog(SampleAppUi.LogLabels.Flush, ex.Message, LogLevel.Err, LogSource.App); }
         }
 
         private async Task OnDeleteDataAsync()
         {
-            AppendLog(SampleAppUi.LogLabels.DeleteData, "erasure request dispatched", LogLevel.Info, LogSource.App);
+            AppendLog(SampleAppUi.LogLabels.DeleteData, SampleAppUi.Messages.ErasureRequestDispatched, LogLevel.Info, LogSource.App);
             try
             {
                 await ImmutableAudience.DeleteData();
-                AppendLog(SampleAppUi.LogLabels.DeleteData, "backend acknowledged", LogLevel.Ok, LogSource.App);
+                AppendLog(SampleAppUi.LogLabels.DeleteData, SampleAppUi.Messages.BackendAcknowledged, LogLevel.Ok, LogSource.App);
             }
             catch (Exception ex)
             {
@@ -288,7 +288,7 @@ namespace Immutable.Audience.Samples.SampleApp
             var consent = ImmutableAudience.CurrentConsent;
             if (!consent.CanTrack())
                 throw new InvalidOperationException(
-                    $"track dropped — consent is {consent.ToLowercaseString()}; raise to anonymous or full to queue events");
+                    string.Format(SampleAppUi.Messages.TrackDroppedConsentFmt, consent.ToLowercaseString()));
         }
 
         // Refresh* are idempotent reads, so calling all four every time is
@@ -320,7 +320,7 @@ namespace Immutable.Audience.Samples.SampleApp
             if (form.FlushIntervalMs is int flushMs && flushMs > 0)
             {
                 if (flushMs < 1000)
-                    AppendLog(SampleAppUi.LogLabels.Init, $"flushInterval {flushMs}ms below 1s — clamped", LogLevel.Warn, LogSource.App);
+                    AppendLog(SampleAppUi.LogLabels.Init, string.Format(SampleAppUi.Messages.FlushIntervalBelowOneSecondClampedFmt, flushMs), LogLevel.Warn, LogSource.App);
                 config.FlushIntervalSeconds = Math.Max(1, flushMs / 1000);
             }
             if (form.FlushSize is int flushSize && flushSize > 0)

--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
@@ -110,7 +110,7 @@ namespace Immutable.Audience.Samples.SampleApp
         {
             GuardConsentForTrack();
             var screen = SceneManager.GetActiveScene().name;
-            var props = new Dictionary<string, object> { ["path"] = screen };
+            var props = new Dictionary<string, object> { [SampleAppCustomEventPropertyKeys.Path] = screen };
             ImmutableAudience.Track(SampleAppCustomEvents.ScreenViewed, props);
             return Json.Serialize(props, 2);
         });

--- a/examples/audience/Assets/SampleApp/Scripts/SampleAppCustomEvents.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/SampleAppCustomEvents.cs
@@ -12,4 +12,18 @@ namespace Immutable.Audience.Samples.SampleApp
         internal const string LinkClicked = "link_clicked";
         internal const string ScreenViewed = "screen_viewed";
     }
+
+    // Property keys for the sample-app demo events.
+    internal static class SampleAppCustomEventPropertyKeys
+    {
+        internal const string Method = "method";
+        internal const string Source = "source";
+        internal const string GameId = "gameId";
+        internal const string Platform = "platform";
+        internal const string GameName = "gameName";
+        internal const string Slug = "slug";
+        internal const string Url = "url";
+        internal const string Label = "label";
+        internal const string Path = "path";
+    }
 }

--- a/examples/audience/Assets/SampleApp/Scripts/SampleAppCustomEvents.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/SampleAppCustomEvents.cs
@@ -1,0 +1,15 @@
+namespace Immutable.Audience.Samples.SampleApp
+{
+    // Sample-only event names that demonstrate the custom Track pattern.
+    internal static class SampleAppCustomEvents
+    {
+        internal const string SignUp = "sign_up";
+        internal const string SignIn = "sign_in";
+        internal const string EmailAcquired = "email_acquired";
+        internal const string WishlistAdd = "wishlist_add";
+        internal const string WishlistRemove = "wishlist_remove";
+        internal const string GamePageViewed = "game_page_viewed";
+        internal const string LinkClicked = "link_clicked";
+        internal const string ScreenViewed = "screen_viewed";
+    }
+}

--- a/examples/audience/Assets/SampleApp/Scripts/SampleAppCustomEvents.cs.meta
+++ b/examples/audience/Assets/SampleApp/Scripts/SampleAppCustomEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6dec0a319b2b488a9c964a046bb410b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/examples/audience/Assets/SampleApp/Scripts/SampleAppUi.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/SampleAppUi.cs
@@ -160,6 +160,10 @@ namespace Immutable.Audience.Samples.SampleApp
             internal const string Send = "Send";
             internal const string Copy = "Copy";
             internal const string Copied = "Copied";
+
+            // Click-to-copy flash on status cells (transient label override).
+            // Distinct from Copied which is the post-click button label.
+            internal const string CopiedFlash = "Copied!";
         }
 
         // ---- Resources paths ----

--- a/examples/audience/Assets/SampleApp/Scripts/SampleAppUi.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/SampleAppUi.cs
@@ -182,9 +182,22 @@ namespace Immutable.Audience.Samples.SampleApp
             internal const string QueueStartedSessionCreated = "queue started, session created";
             internal const string QueuePurgedAnonymousIdCleared = "queue purged, anonymous ID cleared";
             internal const string UserIdCleared = "userId cleared";
-            internal const string NoActiveIdentity = "no active identity — call Identify first";
+            internal const string NoActiveIdentity = "no active identity, call Identify first";
             internal const string TraitsRequired = "traits required";
             internal const string Ready = "Sample app loaded. Paste a publishable key and click Init.";
+
+            // Status messages emitted by AudienceSample's RunAndLog handlers.
+            internal const string SdkStopped = "SDK stopped";
+            internal const string AnonymousIdRegeneratedQueueCleared = "anonymous ID regenerated, queue cleared";
+            internal const string QueueFlushed = "queue flushed";
+            internal const string ErasureRequestDispatched = "erasure request dispatched";
+            internal const string BackendAcknowledged = "backend acknowledged";
+
+            // Formatted variants for use with string.Format or interpolation.
+            internal const string TrackDroppedConsentFmt =
+                "track dropped, consent is {0}; raise to anonymous or full to queue events";
+            internal const string FlushIntervalBelowOneSecondClampedFmt =
+                "flushInterval {0}ms below 1s, clamped";
         }
 
         // Mirrors AudienceSample.UI.cs PopulateTypedEventAccordions naming:

--- a/examples/audience/Assets/SampleApp/Scripts/SampleAppUi.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/SampleAppUi.cs
@@ -301,5 +301,42 @@ namespace Immutable.Audience.Samples.SampleApp
             internal const string Anonymous = "anonymous";
             internal const string Full = "full";
         }
+
+        // Log payload JSON keys used by RunAndLog "Ok" row dictionaries.
+
+        internal static class LogPayloadKeys
+        {
+            // Track outcomes
+            internal const string Event = "event";
+            internal const string Overload = "overload";
+            internal const string Effects = "effects";
+
+            // Identify / Alias outcomes
+            internal const string Id = "id";
+            internal const string Accepted = "accepted";
+            internal const string From = "from";
+            internal const string To = "to";
+
+            // OnError row payload
+            internal const string Code = "code";
+            internal const string Message = "message";
+
+            // Init config echo
+            internal const string Consent = "consent";
+            internal const string Debug = "debug";
+            internal const string FlushIntervalSeconds = "flushIntervalSeconds";
+            internal const string FlushSize = "flushSize";
+            internal const string PackageVersion = "packageVersion";
+            internal const string ShutdownFlushTimeoutMs = "shutdownFlushTimeoutMs";
+            internal const string PublishableKey = "publishableKey";
+            internal const string PersistentDataPath = "persistentDataPath";
+
+            // Track overload values.
+            internal static class OverloadValues
+            {
+                internal const string Typed = "typed";
+                internal const string String = "string";
+            }
+        }
     }
 }

--- a/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireFixtures.cs
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireFixtures.cs
@@ -1,0 +1,10 @@
+namespace Immutable.Audience.Samples.SampleApp.Tests
+{
+    // Values used by SampleAppLiveFireTests when filling the demo input fields.
+    internal static class SampleAppLiveFireFixtures
+    {
+        internal const string MilestoneSmokeName = "il2cpp_smoke";
+        internal const string GameId = "il2cpp_game_1";
+        internal const string LinkUrl = "https://example.com/il2cpp";
+    }
+}

--- a/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireFixtures.cs.meta
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireFixtures.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e230edd97bb4848af6b5988e961d01c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
@@ -172,7 +172,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         {
             yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(EventNames.MilestoneReached), root =>
             {
-                root.Q<TextField>(SampleAppUi.TypedEventField(EventNames.MilestoneReached, EventPropertyKeys.Name)).value = "il2cpp_smoke";
+                root.Q<TextField>(SampleAppUi.TypedEventField(EventNames.MilestoneReached, EventPropertyKeys.Name)).value = SampleAppLiveFireFixtures.MilestoneSmokeName;
             });
         }
 
@@ -262,7 +262,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
 
             // Custom event name + JSON props (the sample app parses props as JSON
             // and forwards them as Dictionary<string, object> to ImmutableAudience.Track).
-            _root!.Q<TextField>(SampleAppUi.CustomEvent.Name).value = "il2cpp_smoke";
+            _root!.Q<TextField>(SampleAppUi.CustomEvent.Name).value = SampleAppLiveFireFixtures.MilestoneSmokeName;
             _root.Q<TextField>(SampleAppUi.CustomEvent.Props).value =
                 "{\"int_field\":42,\"str_field\":\"hello\",\"bool_field\":true,\"nested\":{\"a\":1}}";
             _root.Q<Button>(SampleAppUi.Buttons.CustomEvent).Click();
@@ -423,7 +423,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         {
             yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(SampleAppCustomEvents.WishlistAdd), root =>
             {
-                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.WishlistAdd, SampleAppCustomEventPropertyKeys.GameId)).value = "il2cpp_game_1";
+                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.WishlistAdd, SampleAppCustomEventPropertyKeys.GameId)).value = SampleAppLiveFireFixtures.GameId;
             });
         }
 
@@ -432,7 +432,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         {
             yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(SampleAppCustomEvents.WishlistRemove), root =>
             {
-                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.WishlistRemove, SampleAppCustomEventPropertyKeys.GameId)).value = "il2cpp_game_1";
+                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.WishlistRemove, SampleAppCustomEventPropertyKeys.GameId)).value = SampleAppLiveFireFixtures.GameId;
             });
         }
 
@@ -441,7 +441,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         {
             yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(SampleAppCustomEvents.GamePageViewed), root =>
             {
-                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.GamePageViewed, SampleAppCustomEventPropertyKeys.GameId)).value = "il2cpp_game_1";
+                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.GamePageViewed, SampleAppCustomEventPropertyKeys.GameId)).value = SampleAppLiveFireFixtures.GameId;
             });
         }
 
@@ -450,7 +450,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         {
             yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(SampleAppCustomEvents.LinkClicked), root =>
             {
-                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.LinkClicked, SampleAppCustomEventPropertyKeys.Url)).value = "https://example.com/il2cpp";
+                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.LinkClicked, SampleAppCustomEventPropertyKeys.Url)).value = SampleAppLiveFireFixtures.LinkUrl;
             });
         }
 

--- a/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
@@ -152,8 +152,8 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         {
             yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(EventNames.Resource), root =>
             {
-                root.Q<TextField>(SampleAppUi.TypedEventField(EventNames.Resource, "currency")).value = "GOLD";
-                root.Q<TextField>(SampleAppUi.TypedEventField(EventNames.Resource, "amount")).value = "100";
+                root.Q<TextField>(SampleAppUi.TypedEventField(EventNames.Resource, EventPropertyKeys.Currency)).value = "GOLD";
+                root.Q<TextField>(SampleAppUi.TypedEventField(EventNames.Resource, EventPropertyKeys.Amount)).value = "100";
             });
         }
 
@@ -162,8 +162,8 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         {
             yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(EventNames.Purchase), root =>
             {
-                root.Q<TextField>(SampleAppUi.TypedEventField(EventNames.Purchase, "currency")).value = "USD";
-                root.Q<TextField>(SampleAppUi.TypedEventField(EventNames.Purchase, "value")).value = "9.99";
+                root.Q<TextField>(SampleAppUi.TypedEventField(EventNames.Purchase, EventPropertyKeys.Currency)).value = "USD";
+                root.Q<TextField>(SampleAppUi.TypedEventField(EventNames.Purchase, EventPropertyKeys.Value)).value = "9.99";
             });
         }
 
@@ -172,7 +172,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         {
             yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(EventNames.MilestoneReached), root =>
             {
-                root.Q<TextField>(SampleAppUi.TypedEventField(EventNames.MilestoneReached, "name")).value = "il2cpp_smoke";
+                root.Q<TextField>(SampleAppUi.TypedEventField(EventNames.MilestoneReached, EventPropertyKeys.Name)).value = "il2cpp_smoke";
             });
         }
 

--- a/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
@@ -403,54 +403,54 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         [UnityTest]
         public IEnumerator TypedEvent_SignUp_FlushReportsOk()
         {
-            yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent("sign_up"));
+            yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(SampleAppCustomEvents.SignUp));
         }
 
         [UnityTest]
         public IEnumerator TypedEvent_SignIn_FlushReportsOk()
         {
-            yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent("sign_in"));
+            yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(SampleAppCustomEvents.SignIn));
         }
 
         [UnityTest]
         public IEnumerator TypedEvent_EmailAcquired_FlushReportsOk()
         {
-            yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent("email_acquired"));
+            yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(SampleAppCustomEvents.EmailAcquired));
         }
 
         [UnityTest]
         public IEnumerator TypedEvent_WishlistAdd_FlushReportsOk()
         {
-            yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent("wishlist_add"), root =>
+            yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(SampleAppCustomEvents.WishlistAdd), root =>
             {
-                root.Q<TextField>(SampleAppUi.TypedEventField("wishlist_add", "gameId")).value = "il2cpp_game_1";
+                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.WishlistAdd, "gameId")).value = "il2cpp_game_1";
             });
         }
 
         [UnityTest]
         public IEnumerator TypedEvent_WishlistRemove_FlushReportsOk()
         {
-            yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent("wishlist_remove"), root =>
+            yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(SampleAppCustomEvents.WishlistRemove), root =>
             {
-                root.Q<TextField>(SampleAppUi.TypedEventField("wishlist_remove", "gameId")).value = "il2cpp_game_1";
+                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.WishlistRemove, "gameId")).value = "il2cpp_game_1";
             });
         }
 
         [UnityTest]
         public IEnumerator TypedEvent_GamePageViewed_FlushReportsOk()
         {
-            yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent("game_page_viewed"), root =>
+            yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(SampleAppCustomEvents.GamePageViewed), root =>
             {
-                root.Q<TextField>(SampleAppUi.TypedEventField("game_page_viewed", "gameId")).value = "il2cpp_game_1";
+                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.GamePageViewed, "gameId")).value = "il2cpp_game_1";
             });
         }
 
         [UnityTest]
         public IEnumerator TypedEvent_LinkClicked_FlushReportsOk()
         {
-            yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent("link_clicked"), root =>
+            yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(SampleAppCustomEvents.LinkClicked), root =>
             {
-                root.Q<TextField>(SampleAppUi.TypedEventField("link_clicked", "url")).value = "https://example.com/il2cpp";
+                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.LinkClicked, "url")).value = "https://example.com/il2cpp";
             });
         }
 

--- a/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
@@ -423,7 +423,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         {
             yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(SampleAppCustomEvents.WishlistAdd), root =>
             {
-                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.WishlistAdd, "gameId")).value = "il2cpp_game_1";
+                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.WishlistAdd, SampleAppCustomEventPropertyKeys.GameId)).value = "il2cpp_game_1";
             });
         }
 
@@ -432,7 +432,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         {
             yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(SampleAppCustomEvents.WishlistRemove), root =>
             {
-                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.WishlistRemove, "gameId")).value = "il2cpp_game_1";
+                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.WishlistRemove, SampleAppCustomEventPropertyKeys.GameId)).value = "il2cpp_game_1";
             });
         }
 
@@ -441,7 +441,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         {
             yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(SampleAppCustomEvents.GamePageViewed), root =>
             {
-                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.GamePageViewed, "gameId")).value = "il2cpp_game_1";
+                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.GamePageViewed, SampleAppCustomEventPropertyKeys.GameId)).value = "il2cpp_game_1";
             });
         }
 
@@ -450,7 +450,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         {
             yield return DriveTypedEventAndFlush(SampleAppUi.Buttons.TypedEvent(SampleAppCustomEvents.LinkClicked), root =>
             {
-                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.LinkClicked, "url")).value = "https://example.com/il2cpp";
+                root.Q<TextField>(SampleAppUi.TypedEventField(SampleAppCustomEvents.LinkClicked, SampleAppCustomEventPropertyKeys.Url)).value = "https://example.com/il2cpp";
             });
         }
 

--- a/src/Packages/Audience/Runtime/AssemblyInfo.cs
+++ b/src/Packages/Audience/Runtime/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Immutable.Audience.Runtime.Tests")]
+[assembly: InternalsVisibleTo("Immutable.Audience.Editor.Tests")]
 [assembly: InternalsVisibleTo("Immutable.Audience.Unity")]
 
 // First-party SampleApp reaches Json.Serialize and

--- a/src/Packages/Audience/Runtime/Unity/AssemblyInfo.cs
+++ b/src/Packages/Audience/Runtime/Unity/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+// Editor-only test fixture for DeviceCollector reads internals of this assembly.
+[assembly: InternalsVisibleTo("Immutable.Audience.Editor.Tests")]

--- a/src/Packages/Audience/Runtime/Unity/AssemblyInfo.cs.meta
+++ b/src/Packages/Audience/Runtime/Unity/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 42c73f606a344d9d8fcda6cd3cf6fa5c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Tests/Editor/DeviceCollectorTests.cs
+++ b/src/Packages/Audience/Tests/Editor/DeviceCollectorTests.cs
@@ -1,0 +1,113 @@
+#nullable enable
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using Immutable.Audience.Unity;
+
+namespace Immutable.Audience.Tests.Editor
+{
+    // Editor-only (DeviceCollector needs a Unity domain; skipped by the headless dotnet build).
+    // Pins emitted payload keys against GameLaunchPropertyKeys and ContextKeys.
+    [TestFixture]
+    internal class DeviceCollectorTests
+    {
+        [Test]
+        public void CollectGameLaunchProperties_EmitsTheExpectedKeySet()
+        {
+            var props = DeviceCollector.CollectGameLaunchProperties();
+
+            // Always-present keys. ScreenDpi is conditional (0 on some Linux WMs).
+            CollectionAssert.Contains(props.Keys, GameLaunchPropertyKeys.Platform);
+            CollectionAssert.Contains(props.Keys, GameLaunchPropertyKeys.Version);
+            CollectionAssert.Contains(props.Keys, GameLaunchPropertyKeys.BuildGuid);
+            CollectionAssert.Contains(props.Keys, GameLaunchPropertyKeys.UnityVersion);
+            CollectionAssert.Contains(props.Keys, GameLaunchPropertyKeys.OsFamily);
+            CollectionAssert.Contains(props.Keys, GameLaunchPropertyKeys.DeviceModel);
+            CollectionAssert.Contains(props.Keys, GameLaunchPropertyKeys.Gpu);
+            CollectionAssert.Contains(props.Keys, GameLaunchPropertyKeys.GpuVendor);
+            CollectionAssert.Contains(props.Keys, GameLaunchPropertyKeys.Cpu);
+            CollectionAssert.Contains(props.Keys, GameLaunchPropertyKeys.CpuCores);
+            CollectionAssert.Contains(props.Keys, GameLaunchPropertyKeys.RamMb);
+        }
+
+        [Test]
+        public void CollectGameLaunchProperties_EmitsNoUnknownKeys()
+        {
+            // Confirms the payload only carries known GameLaunchPropertyKeys entries.
+            var allowed = new HashSet<string>
+            {
+                GameLaunchPropertyKeys.Platform,
+                GameLaunchPropertyKeys.Version,
+                GameLaunchPropertyKeys.BuildGuid,
+                GameLaunchPropertyKeys.UnityVersion,
+                GameLaunchPropertyKeys.OsFamily,
+                GameLaunchPropertyKeys.DeviceModel,
+                GameLaunchPropertyKeys.Gpu,
+                GameLaunchPropertyKeys.GpuVendor,
+                GameLaunchPropertyKeys.Cpu,
+                GameLaunchPropertyKeys.CpuCores,
+                GameLaunchPropertyKeys.RamMb,
+                GameLaunchPropertyKeys.ScreenDpi,
+            };
+
+            var props = DeviceCollector.CollectGameLaunchProperties();
+            foreach (var key in props.Keys)
+                Assert.IsTrue(allowed.Contains(key),
+                    $"DeviceCollector.CollectGameLaunchProperties emitted unknown key '{key}' "
+                    + "with no matching GameLaunchPropertyKeys constant");
+        }
+
+        [Test]
+        public void CollectGameLaunchProperties_TruncatesStringValuesToMaxFieldLength()
+        {
+            // Every string value respects MaxFieldLength; an untruncated .ToString() would fail here.
+            var props = DeviceCollector.CollectGameLaunchProperties();
+            foreach (var kv in props)
+            {
+                if (kv.Value is string s)
+                    Assert.LessOrEqual(s.Length, Constants.MaxFieldLength,
+                        $"GameLaunchPropertyKeys.{kv.Key} value exceeds Constants.MaxFieldLength");
+            }
+        }
+
+        [Test]
+        public void CollectContext_EmitsTheExpectedKeySet()
+        {
+            var ctx = DeviceCollector.CollectContext();
+
+            // UserAgent is unconditional. Timezone / Locale / Screen are
+            // best-effort and may be absent under unusual hosts.
+            CollectionAssert.Contains(ctx.Keys, ContextKeys.UserAgent);
+        }
+
+        [Test]
+        public void CollectContext_EmitsNoUnknownKeys()
+        {
+            var allowed = new HashSet<string>
+            {
+                ContextKeys.UserAgent,
+                ContextKeys.Timezone,
+                ContextKeys.Locale,
+                ContextKeys.Screen,
+            };
+
+            var ctx = DeviceCollector.CollectContext();
+            foreach (var key in ctx.Keys)
+                Assert.IsTrue(allowed.Contains(key),
+                    $"DeviceCollector.CollectContext emitted unknown key '{key}' "
+                    + "with no matching ContextKeys constant");
+        }
+
+        [Test]
+        public void CollectContext_TruncatesStringValuesToMaxFieldLength()
+        {
+            var ctx = DeviceCollector.CollectContext();
+            foreach (var kv in ctx)
+            {
+                if (kv.Value is string s)
+                    Assert.LessOrEqual(s.Length, Constants.MaxFieldLength,
+                        $"ContextKeys.{kv.Key} value exceeds Constants.MaxFieldLength");
+            }
+        }
+    }
+}

--- a/src/Packages/Audience/Tests/Editor/com.immutable.audience.tests.editor.asmdef
+++ b/src/Packages/Audience/Tests/Editor/com.immutable.audience.tests.editor.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "Immutable.Audience.Editor.Tests",
+    "rootNamespace": "Immutable.Audience.Tests.Editor",
+    "references": [
+        "Immutable.Audience.Runtime",
+        "Immutable.Audience.Unity",
+        "UnityEditor.TestRunner",
+        "UnityEngine.TestRunner"
+    ],
+    "includePlatforms": ["Editor"],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": ["nunit.framework.dll"],
+    "autoReferenced": false,
+    "defineConstraints": ["UNITY_INCLUDE_TESTS"],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/src/Packages/Audience/Tests/Editor/com.immutable.audience.tests.editor.asmdef.meta
+++ b/src/Packages/Audience/Tests/Editor/com.immutable.audience.tests.editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a0de2d71dd564e69b03eb055285e697d
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Tests/Runtime/ConstantsTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ConstantsTests.cs
@@ -69,6 +69,20 @@ namespace Immutable.Audience.Tests
                 "Constants.LibraryVersion must match package.json version");
         }
 
+        [Test]
+        public void LibraryName_MatchesPackageJson()
+        {
+            // Same idea as LibraryVersion: fails the build if
+            // Constants.LibraryName drifts from package.json "name".
+            var packageJson = ReadPackageJson();
+            var parsed = JsonReader.DeserializeObject(packageJson);
+
+            Assert.IsTrue(parsed.TryGetValue("name", out var nameObj),
+                "package.json is missing a \"name\" field");
+            Assert.AreEqual(Constants.LibraryName, nameObj,
+                "Constants.LibraryName must match package.json name");
+        }
+
         private static string ReadPackageJson()
         {
             // Walk up from the test binary location looking for the Audience

--- a/src/Packages/Audience/Tests/Runtime/ConstantsTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ConstantsTests.cs
@@ -6,6 +6,19 @@ namespace Immutable.Audience.Tests
     [TestFixture]
     internal class ConstantsTests
     {
+        // Publishable key fixtures used by the BaseUrl resolution tests.
+        private const string TestPrefixKeyFixture = "pk_imapik-test-abc";
+        private const string ProdPrefixKeyFixture = "pk_imapik-prod-abc";
+        private const string CustomBaseUrlOverride = "https://api.dev.immutable.com";
+
+        // package.json upward-walk components and the JSON fields parsed back.
+        private const string SrcDirectoryName = "src";
+        private const string PackagesDirectoryName = "Packages";
+        private const string AudiencePackageDirectoryName = "Audience";
+        private const string PackageJsonFileName = "package.json";
+        private const string PackageJsonVersionField = "version";
+        private const string PackageJsonNameField = "name";
+
         // -----------------------------------------------------------------
         // BaseUrl resolution
         // -----------------------------------------------------------------
@@ -14,14 +27,14 @@ namespace Immutable.Audience.Tests
         public void BaseUrl_TestKey_ResolvesToSandbox()
         {
             Assert.AreEqual(Constants.SandboxBaseUrl,
-                Constants.BaseUrl("pk_imapik-test-abc"));
+                Constants.BaseUrl(TestPrefixKeyFixture));
         }
 
         [Test]
         public void BaseUrl_NonTestKey_ResolvesToProduction()
         {
             Assert.AreEqual(Constants.ProductionBaseUrl,
-                Constants.BaseUrl("pk_imapik-prod-abc"));
+                Constants.BaseUrl(ProdPrefixKeyFixture));
         }
 
         [Test]
@@ -36,9 +49,8 @@ namespace Immutable.Audience.Tests
         {
             // Override wins even for a test-prefixed key that would
             // otherwise derive to Sandbox.
-            const string custom = "https://api.dev.immutable.com";
-            Assert.AreEqual(custom,
-                Constants.BaseUrl("pk_imapik-test-abc", custom));
+            Assert.AreEqual(CustomBaseUrlOverride,
+                Constants.BaseUrl(TestPrefixKeyFixture, CustomBaseUrlOverride));
         }
 
         [Test]
@@ -47,7 +59,7 @@ namespace Immutable.Audience.Tests
             // Empty-string override is treated as "no override" so the
             // key-prefix fallback still kicks in.
             Assert.AreEqual(Constants.SandboxBaseUrl,
-                Constants.BaseUrl("pk_imapik-test-abc", ""));
+                Constants.BaseUrl(TestPrefixKeyFixture, ""));
         }
 
         // -----------------------------------------------------------------
@@ -63,7 +75,7 @@ namespace Immutable.Audience.Tests
             var packageJson = ReadPackageJson();
             var parsed = JsonReader.DeserializeObject(packageJson);
 
-            Assert.IsTrue(parsed.TryGetValue("version", out var versionObj),
+            Assert.IsTrue(parsed.TryGetValue(PackageJsonVersionField, out var versionObj),
                 "package.json is missing a \"version\" field");
             Assert.AreEqual(Constants.LibraryVersion, versionObj,
                 "Constants.LibraryVersion must match package.json version");
@@ -77,7 +89,7 @@ namespace Immutable.Audience.Tests
             var packageJson = ReadPackageJson();
             var parsed = JsonReader.DeserializeObject(packageJson);
 
-            Assert.IsTrue(parsed.TryGetValue("name", out var nameObj),
+            Assert.IsTrue(parsed.TryGetValue(PackageJsonNameField, out var nameObj),
                 "package.json is missing a \"name\" field");
             Assert.AreEqual(Constants.LibraryName, nameObj,
                 "Constants.LibraryName must match package.json name");
@@ -95,14 +107,14 @@ namespace Immutable.Audience.Tests
             var current = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
             while (current != null)
             {
-                var candidate = Path.Combine(current.FullName, "src", "Packages", "Audience", "package.json");
+                var candidate = Path.Combine(current.FullName, SrcDirectoryName, PackagesDirectoryName, AudiencePackageDirectoryName, PackageJsonFileName);
                 if (File.Exists(candidate)) return File.ReadAllText(candidate);
 
                 // Also try the direct-inside case (package root itself is
                 // the ancestor), which handles consuming-project layouts
                 // that embed the package without the src/Packages prefix.
-                var direct = Path.Combine(current.FullName, "package.json");
-                if (File.Exists(direct) && current.Name == "Audience") return File.ReadAllText(direct);
+                var direct = Path.Combine(current.FullName, PackageJsonFileName);
+                if (File.Exists(direct) && current.Name == AudiencePackageDirectoryName) return File.ReadAllText(direct);
 
                 current = current.Parent;
             }

--- a/src/Packages/Audience/Tests/Runtime/Core/ConsentStoreTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Core/ConsentStoreTests.cs
@@ -50,7 +50,7 @@ namespace Immutable.Audience.Tests
             // A garbage value that isn't a valid enum int.
             var dir = AudiencePaths.AudienceDir(_testDir);
             Directory.CreateDirectory(dir);
-            File.WriteAllText(AudiencePaths.ConsentFile(_testDir), "not-an-int");
+            File.WriteAllText(AudiencePaths.ConsentFile(_testDir), TestFixtures.NotAnInt);
 
             Assert.IsNull(ConsentStore.Load(_testDir));
         }

--- a/src/Packages/Audience/Tests/Runtime/Core/IdentityTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Core/IdentityTests.cs
@@ -39,7 +39,7 @@ namespace Immutable.Audience.Tests
         public void ExistingFile_ReturnsPreviousId_WithoutGeneratingNew()
         {
             // Simulate a returning player by pre-writing an identity file (as a previous launch would have done).
-            var expectedId = "pre-existing-id-from-last-launch";
+            var expectedId = TestFixtures.PreExistingIdFromLastLaunch;
             var dir = AudiencePaths.AudienceDir(_testDir);
             Directory.CreateDirectory(dir);
             File.WriteAllText(AudiencePaths.IdentityFile(_testDir), expectedId);
@@ -93,7 +93,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Get_ExistingFile_ReturnsPersistedId()
         {
-            var expectedId = "pre-existing-id";
+            var expectedId = TestFixtures.PreExistingId;
             var dir = AudiencePaths.AudienceDir(_testDir);
             Directory.CreateDirectory(dir);
             File.WriteAllText(AudiencePaths.IdentityFile(_testDir), expectedId);

--- a/src/Packages/Audience/Tests/Runtime/DeleteDataTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/DeleteDataTests.cs
@@ -74,7 +74,7 @@ namespace Immutable.Audience.Tests
             var handler = new CapturingHandler();
             ImmutableAudience.Init(MakeConfig(handler));
 
-            ImmutableAudience.DeleteData(userId: "player-42");
+            ImmutableAudience.DeleteData(userId: TestFixtures.PlayerCustomId);
             WaitForRequest(handler);
 
             // Filter out the game_launch POST from Init.
@@ -151,7 +151,7 @@ namespace Immutable.Audience.Tests
             var handler = new CapturingHandler();
             ImmutableAudience.Init(MakeConfig(handler));
 
-            var task = ImmutableAudience.DeleteData(userId: "player-42");
+            var task = ImmutableAudience.DeleteData(userId: TestFixtures.PlayerCustomId);
             Assert.IsNotNull(task, "DeleteData must return a non-null Task");
 
             // Await directly: no need for the RequestSent gate when the task
@@ -168,7 +168,7 @@ namespace Immutable.Audience.Tests
             // Not initialised: must not throw, must return a completed Task.
             ImmutableAudience.ResetState();
 
-            var task = ImmutableAudience.DeleteData(userId: "player-42");
+            var task = ImmutableAudience.DeleteData(userId: TestFixtures.PlayerCustomId);
 
             Assert.IsNotNull(task);
             Assert.IsTrue(task.IsCompleted, "DeleteData before Init must return an already-completed Task");
@@ -189,7 +189,7 @@ namespace Immutable.Audience.Tests
             };
             ImmutableAudience.Init(config);
 
-            ImmutableAudience.DeleteData(userId: "player-42");
+            ImmutableAudience.DeleteData(userId: TestFixtures.PlayerCustomId);
 
             Assert.IsTrue(received.Wait(TimeSpan.FromSeconds(5)),
                 "OnError should fire when DeleteData's response is non-2xx");

--- a/src/Packages/Audience/Tests/Runtime/DeleteDataTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/DeleteDataTests.cs
@@ -136,7 +136,7 @@ namespace Immutable.Audience.Tests
             var handler = new CapturingHandler();
             ImmutableAudience.Init(MakeConfig(handler, ConsentLevel.None));
 
-            ImmutableAudience.DeleteData(userId: "some-user");
+            ImmutableAudience.DeleteData(userId: TestFixtures.SomeUser);
             // Even with a userId request, the anonymousId file must not materialise.
             Thread.Sleep(250);
 

--- a/src/Packages/Audience/Tests/Runtime/Events/MessageBuilderTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Events/MessageBuilderTests.cs
@@ -13,7 +13,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Track_RequiredFieldsPresent()
         {
-            var result = MessageBuilder.Track(TestEventNames.LevelComplete, "anon-1", null, PackageVersion);
+            var result = MessageBuilder.Track(TestEventNames.LevelComplete, TestFixtures.AnonId1, null, PackageVersion);
 
             Assert.AreEqual(MessageTypes.Track, result[MessageFields.Type]);
             Assert.IsTrue(result.ContainsKey(MessageFields.MessageId));
@@ -36,7 +36,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Track_NullUserId_NotPresentInDict()
         {
-            var result = MessageBuilder.Track("evt", "anon-1", null, PackageVersion);
+            var result = MessageBuilder.Track("evt", TestFixtures.AnonId1, null, PackageVersion);
 
             Assert.IsFalse(result.ContainsKey(MessageFields.UserId));
         }
@@ -44,20 +44,20 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Track_NonNullUserId_PresentInDict()
         {
-            var result = MessageBuilder.Track("evt", "anon-1", "user-99", PackageVersion);
+            var result = MessageBuilder.Track("evt", TestFixtures.AnonId1, TestFixtures.UserId99, PackageVersion);
 
             Assert.IsTrue(result.ContainsKey(MessageFields.UserId));
-            Assert.AreEqual("user-99", result[MessageFields.UserId]);
+            Assert.AreEqual(TestFixtures.UserId99, result[MessageFields.UserId]);
         }
 
         [Test]
         public void Identify_TypeAndIdentityFieldsPresent()
         {
-            var result = MessageBuilder.Identify("anon-42", "user-42", IdentityType.Steam.ToLowercaseString(), PackageVersion);
+            var result = MessageBuilder.Identify(TestFixtures.AnonId42, TestFixtures.UserId42, IdentityType.Steam.ToLowercaseString(), PackageVersion);
 
             Assert.AreEqual(MessageTypes.Identify, result[MessageFields.Type]);
-            Assert.AreEqual("anon-42", result[MessageFields.AnonymousId]);
-            Assert.AreEqual("user-42", result[MessageFields.UserId]);
+            Assert.AreEqual(TestFixtures.AnonId42, result[MessageFields.AnonymousId]);
+            Assert.AreEqual(TestFixtures.UserId42, result[MessageFields.UserId]);
             Assert.AreEqual(IdentityType.Steam.ToLowercaseString(), result[MessageFields.IdentityType]);
         }
 
@@ -65,14 +65,14 @@ namespace Immutable.Audience.Tests
         public void Alias_AllFourFieldsPresent()
         {
             var result = MessageBuilder.Alias(
-                "from-id", IdentityType.Email.ToLowercaseString(),
-                "to-id", IdentityType.Steam.ToLowercaseString(),
+                TestFixtures.AliasFromId, IdentityType.Email.ToLowercaseString(),
+                TestFixtures.AliasToId, IdentityType.Steam.ToLowercaseString(),
                 PackageVersion);
 
             Assert.AreEqual(MessageTypes.Alias, result[MessageFields.Type]);
-            Assert.AreEqual("from-id", result[MessageFields.FromId]);
+            Assert.AreEqual(TestFixtures.AliasFromId, result[MessageFields.FromId]);
             Assert.AreEqual(IdentityType.Email.ToLowercaseString(), result[MessageFields.FromType]);
-            Assert.AreEqual("to-id", result[MessageFields.ToId]);
+            Assert.AreEqual(TestFixtures.AliasToId, result[MessageFields.ToId]);
             Assert.AreEqual(IdentityType.Steam.ToLowercaseString(), result[MessageFields.ToType]);
         }
 

--- a/src/Packages/Audience/Tests/Runtime/Events/MessageBuilderTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Events/MessageBuilderTests.cs
@@ -80,8 +80,8 @@ namespace Immutable.Audience.Tests
         public void AllMessages_ContextContainsLibraryAndLibraryVersion()
         {
             var track = MessageBuilder.Track(TestEventNames.PlaceholderEvt, null, null, PackageVersion);
-            var identify = MessageBuilder.Identify(null, "u1", IdentityType.Steam.ToLowercaseString(), PackageVersion);
-            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", PackageVersion);
+            var identify = MessageBuilder.Identify(null, TestFixtures.GenericUserId, IdentityType.Steam.ToLowercaseString(), PackageVersion);
+            var alias = MessageBuilder.Alias(TestFixtures.GenericFromId, TestFixtures.GenericFromType, TestFixtures.GenericToId, TestFixtures.GenericToType, PackageVersion);
 
             foreach (var msg in new[] { track, identify, alias })
             {
@@ -95,8 +95,8 @@ namespace Immutable.Audience.Tests
         public void AllMessages_SurfaceIsUnity()
         {
             var track = MessageBuilder.Track(TestEventNames.PlaceholderEvt, null, null, PackageVersion);
-            var identify = MessageBuilder.Identify(null, "u1", IdentityType.Steam.ToLowercaseString(), PackageVersion);
-            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", PackageVersion);
+            var identify = MessageBuilder.Identify(null, TestFixtures.GenericUserId, IdentityType.Steam.ToLowercaseString(), PackageVersion);
+            var alias = MessageBuilder.Alias(TestFixtures.GenericFromId, TestFixtures.GenericFromType, TestFixtures.GenericToId, TestFixtures.GenericToType, PackageVersion);
 
             Assert.AreEqual(Constants.Surface, track[MessageFields.Surface]);
             Assert.AreEqual(Constants.Surface, identify[MessageFields.Surface]);
@@ -162,8 +162,8 @@ namespace Immutable.Audience.Tests
         private static IEnumerable<Dictionary<string, object>> EveryMessageType()
         {
             yield return MessageBuilder.Track(TestEventNames.PlaceholderEvt, null, null, PackageVersion);
-            yield return MessageBuilder.Identify(null, "u1", IdentityType.Steam.ToLowercaseString(), PackageVersion);
-            yield return MessageBuilder.Alias("f", "t1", "t", "t2", PackageVersion);
+            yield return MessageBuilder.Identify(null, TestFixtures.GenericUserId, IdentityType.Steam.ToLowercaseString(), PackageVersion);
+            yield return MessageBuilder.Alias(TestFixtures.GenericFromId, TestFixtures.GenericFromType, TestFixtures.GenericToId, TestFixtures.GenericToType, PackageVersion);
         }
     }
 }

--- a/src/Packages/Audience/Tests/Runtime/Events/MessageBuilderTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Events/MessageBuilderTests.cs
@@ -13,14 +13,14 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Track_RequiredFieldsPresent()
         {
-            var result = MessageBuilder.Track("level_complete", "anon-1", null, PackageVersion);
+            var result = MessageBuilder.Track(TestEventNames.LevelComplete, "anon-1", null, PackageVersion);
 
             Assert.AreEqual(MessageTypes.Track, result[MessageFields.Type]);
             Assert.IsTrue(result.ContainsKey(MessageFields.MessageId));
             Assert.IsTrue(result.ContainsKey(MessageFields.EventTimestamp));
             Assert.IsTrue(result.ContainsKey(MessageFields.Context));
             Assert.IsTrue(result.ContainsKey(MessageFields.Surface));
-            Assert.AreEqual("level_complete", result[MessageFields.EventName]);
+            Assert.AreEqual(TestEventNames.LevelComplete, result[MessageFields.EventName]);
         }
 
         [Test]

--- a/src/Packages/Audience/Tests/Runtime/Events/MessageBuilderTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Events/MessageBuilderTests.cs
@@ -36,7 +36,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Track_NullUserId_NotPresentInDict()
         {
-            var result = MessageBuilder.Track("evt", TestFixtures.AnonId1, null, PackageVersion);
+            var result = MessageBuilder.Track(TestEventNames.PlaceholderEvt, TestFixtures.AnonId1, null, PackageVersion);
 
             Assert.IsFalse(result.ContainsKey(MessageFields.UserId));
         }
@@ -44,7 +44,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Track_NonNullUserId_PresentInDict()
         {
-            var result = MessageBuilder.Track("evt", TestFixtures.AnonId1, TestFixtures.UserId99, PackageVersion);
+            var result = MessageBuilder.Track(TestEventNames.PlaceholderEvt, TestFixtures.AnonId1, TestFixtures.UserId99, PackageVersion);
 
             Assert.IsTrue(result.ContainsKey(MessageFields.UserId));
             Assert.AreEqual(TestFixtures.UserId99, result[MessageFields.UserId]);
@@ -79,7 +79,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void AllMessages_ContextContainsLibraryAndLibraryVersion()
         {
-            var track = MessageBuilder.Track("evt", null, null, PackageVersion);
+            var track = MessageBuilder.Track(TestEventNames.PlaceholderEvt, null, null, PackageVersion);
             var identify = MessageBuilder.Identify(null, "u1", IdentityType.Steam.ToLowercaseString(), PackageVersion);
             var alias = MessageBuilder.Alias("f", "t1", "t", "t2", PackageVersion);
 
@@ -94,7 +94,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void AllMessages_SurfaceIsUnity()
         {
-            var track = MessageBuilder.Track("evt", null, null, PackageVersion);
+            var track = MessageBuilder.Track(TestEventNames.PlaceholderEvt, null, null, PackageVersion);
             var identify = MessageBuilder.Identify(null, "u1", IdentityType.Steam.ToLowercaseString(), PackageVersion);
             var alias = MessageBuilder.Alias("f", "t1", "t", "t2", PackageVersion);
 
@@ -120,7 +120,7 @@ namespace Immutable.Audience.Tests
             // Backend deduplicates on messageId; collisions silently drop events.
             var ids = new HashSet<string>();
             for (var i = 0; i < 1000; i++)
-                ids.Add((string)MessageBuilder.Track("evt", null, null, PackageVersion)[MessageFields.MessageId]);
+                ids.Add((string)MessageBuilder.Track(TestEventNames.PlaceholderEvt, null, null, PackageVersion)[MessageFields.MessageId]);
             Assert.AreEqual(1000, ids.Count);
         }
 
@@ -161,7 +161,7 @@ namespace Immutable.Audience.Tests
 
         private static IEnumerable<Dictionary<string, object>> EveryMessageType()
         {
-            yield return MessageBuilder.Track("evt", null, null, PackageVersion);
+            yield return MessageBuilder.Track(TestEventNames.PlaceholderEvt, null, null, PackageVersion);
             yield return MessageBuilder.Identify(null, "u1", IdentityType.Steam.ToLowercaseString(), PackageVersion);
             yield return MessageBuilder.Alias("f", "t1", "t", "t2", PackageVersion);
         }

--- a/src/Packages/Audience/Tests/Runtime/Events/TypedEventTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Events/TypedEventTests.cs
@@ -61,19 +61,19 @@ namespace Immutable.Audience.Tests
             var evt = new Resource
             {
                 Flow = ResourceFlow.Source,
-                Currency = "gold",
+                Currency = TestFixtures.ResourceCurrency,
                 Amount = 100,
-                ItemType = "quest_reward",
-                ItemId = "main_quest_01"
+                ItemType = TestFixtures.ResourceItemType,
+                ItemId = TestFixtures.ResourceItemId
             };
 
             var props = evt.ToProperties();
 
             Assert.AreEqual(ResourceFlow.Source.ToLowercaseString(), props[EventPropertyKeys.Flow]);
-            Assert.AreEqual("gold", props[EventPropertyKeys.Currency]);
+            Assert.AreEqual(TestFixtures.ResourceCurrency, props[EventPropertyKeys.Currency]);
             Assert.AreEqual(100m, props[EventPropertyKeys.Amount]);
-            Assert.AreEqual("quest_reward", props[EventPropertyKeys.ItemType]);
-            Assert.AreEqual("main_quest_01", props[EventPropertyKeys.ItemId]);
+            Assert.AreEqual(TestFixtures.ResourceItemType, props[EventPropertyKeys.ItemType]);
+            Assert.AreEqual(TestFixtures.ResourceItemId, props[EventPropertyKeys.ItemId]);
         }
 
         [Test]
@@ -85,7 +85,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Resource_WithoutFlow_ThrowsOnToProperties()
         {
-            var evt = new Resource { Currency = "gold", Amount = 100 };
+            var evt = new Resource { Currency = TestFixtures.ResourceCurrency, Amount = 100 };
 
             var ex = Assert.Throws<ArgumentException>(() => evt.ToProperties());
             Assert.That(ex!.Message, Does.Contain("Flow"));
@@ -103,7 +103,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Resource_WithoutAmount_ThrowsOnToProperties()
         {
-            var evt = new Resource { Flow = ResourceFlow.Source, Currency = "gold" };
+            var evt = new Resource { Flow = ResourceFlow.Source, Currency = TestFixtures.ResourceCurrency };
 
             var ex = Assert.Throws<ArgumentException>(() => evt.ToProperties());
             Assert.That(ex!.Message, Does.Contain("Amount"));
@@ -116,20 +116,20 @@ namespace Immutable.Audience.Tests
             {
                 Currency = "USD",
                 Value = 9.99m,
-                ItemId = "gem_pack_01",
-                ItemName = "Starter Gem Pack",
+                ItemId = TestFixtures.PurchaseItemId,
+                ItemName = TestFixtures.PurchaseItemName,
                 Quantity = 1,
-                TransactionId = "txn_abc123"
+                TransactionId = TestFixtures.PurchaseTransactionId
             };
 
             var props = evt.ToProperties();
 
             Assert.AreEqual("USD", props[EventPropertyKeys.Currency]);
             Assert.AreEqual(9.99m, props[EventPropertyKeys.Value]);
-            Assert.AreEqual("gem_pack_01", props[EventPropertyKeys.ItemId]);
-            Assert.AreEqual("Starter Gem Pack", props[EventPropertyKeys.ItemName]);
+            Assert.AreEqual(TestFixtures.PurchaseItemId, props[EventPropertyKeys.ItemId]);
+            Assert.AreEqual(TestFixtures.PurchaseItemName, props[EventPropertyKeys.ItemName]);
             Assert.AreEqual(1, props[EventPropertyKeys.Quantity]);
-            Assert.AreEqual("txn_abc123", props[EventPropertyKeys.TransactionId]);
+            Assert.AreEqual(TestFixtures.PurchaseTransactionId, props[EventPropertyKeys.TransactionId]);
         }
 
         [Test]
@@ -172,9 +172,9 @@ namespace Immutable.Audience.Tests
         [Test]
         public void MilestoneReached_ProducesCorrectProperties()
         {
-            var props = new MilestoneReached { Name = "first_boss_defeated" }.ToProperties();
+            var props = new MilestoneReached { Name = TestFixtures.MilestoneName }.ToProperties();
 
-            Assert.AreEqual("first_boss_defeated", props[EventPropertyKeys.Name]);
+            Assert.AreEqual(TestFixtures.MilestoneName, props[EventPropertyKeys.Name]);
             Assert.AreEqual(1, props.Count);
         }
 

--- a/src/Packages/Audience/Tests/Runtime/Events/TypedEventTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Events/TypedEventTests.cs
@@ -15,7 +15,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Progression_WithoutStatus_ThrowsOnToProperties()
         {
-            var evt = new Progression { World = "tutorial" };
+            var evt = new Progression { World = TestFixtures.ProgressionWorldTutorial };
 
             var ex = Assert.Throws<ArgumentException>(() => evt.ToProperties());
             Assert.That(ex!.Message, Does.Contain("Status"));
@@ -27,7 +27,7 @@ namespace Immutable.Audience.Tests
             var evt = new Progression
             {
                 Status = ProgressionStatus.Complete,
-                World = "tutorial",
+                World = TestFixtures.ProgressionWorldTutorial,
                 Level = "1",
                 Score = 1500,
                 DurationSec = 120.5f
@@ -36,7 +36,7 @@ namespace Immutable.Audience.Tests
             var props = evt.ToProperties();
 
             Assert.AreEqual(ProgressionStatus.Complete.ToLowercaseString(), props[EventPropertyKeys.Status]);
-            Assert.AreEqual("tutorial", props[EventPropertyKeys.World]);
+            Assert.AreEqual(TestFixtures.ProgressionWorldTutorial, props[EventPropertyKeys.World]);
             Assert.AreEqual("1", props[EventPropertyKeys.Level]);
             Assert.AreEqual(1500, props[EventPropertyKeys.Score]);
             Assert.AreEqual(120.5f, props[EventPropertyKeys.DurationSec]);
@@ -114,7 +114,7 @@ namespace Immutable.Audience.Tests
         {
             var evt = new Purchase
             {
-                Currency = "USD",
+                Currency = TestFixtures.UsdCurrency,
                 Value = 9.99m,
                 ItemId = TestFixtures.PurchaseItemId,
                 ItemName = TestFixtures.PurchaseItemName,
@@ -124,7 +124,7 @@ namespace Immutable.Audience.Tests
 
             var props = evt.ToProperties();
 
-            Assert.AreEqual("USD", props[EventPropertyKeys.Currency]);
+            Assert.AreEqual(TestFixtures.UsdCurrency, props[EventPropertyKeys.Currency]);
             Assert.AreEqual(9.99m, props[EventPropertyKeys.Value]);
             Assert.AreEqual(TestFixtures.PurchaseItemId, props[EventPropertyKeys.ItemId]);
             Assert.AreEqual(TestFixtures.PurchaseItemName, props[EventPropertyKeys.ItemName]);
@@ -135,7 +135,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Purchase_OptionalFieldsOmitted_WhenNull()
         {
-            var props = new Purchase { Currency = "EUR", Value = 5.00m }.ToProperties();
+            var props = new Purchase { Currency = TestFixtures.EurCurrency, Value = 5.00m }.ToProperties();
 
             Assert.IsTrue(props.ContainsKey(EventPropertyKeys.Currency));
             Assert.IsTrue(props.ContainsKey(EventPropertyKeys.Value));
@@ -163,7 +163,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Purchase_WithoutValue_ThrowsOnToProperties()
         {
-            var evt = new Purchase { Currency = "USD" };
+            var evt = new Purchase { Currency = TestFixtures.UsdCurrency };
 
             var ex = Assert.Throws<ArgumentException>(() => evt.ToProperties());
             Assert.That(ex!.Message, Does.Contain("Value"));

--- a/src/Packages/Audience/Tests/Runtime/IdentityTypeTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/IdentityTypeTests.cs
@@ -19,6 +19,37 @@ namespace Immutable.Audience.Tests
             Assert.AreEqual(expected, type.ToLowercaseString());
         }
 
+        [TestCase("passport", IdentityType.Passport)]
+        [TestCase("steam", IdentityType.Steam)]
+        [TestCase("epic", IdentityType.Epic)]
+        [TestCase("google", IdentityType.Google)]
+        [TestCase("apple", IdentityType.Apple)]
+        [TestCase("discord", IdentityType.Discord)]
+        [TestCase("email", IdentityType.Email)]
+        [TestCase("custom", IdentityType.Custom)]
+        public void ParseLowercaseString_MapsKnownStringToEnum(string wire, IdentityType expected)
+        {
+            Assert.AreEqual(expected, IdentityTypeExtensions.ParseLowercaseString(wire));
+        }
+
+        [TestCase("Steam", IdentityType.Steam)]
+        [TestCase("STEAM", IdentityType.Steam)]
+        [TestCase("Passport", IdentityType.Passport)]
+        public void ParseLowercaseString_AcceptsMixedCase(string wire, IdentityType expected)
+        {
+            Assert.AreEqual(expected, IdentityTypeExtensions.ParseLowercaseString(wire));
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("unknown_provider")]
+        [TestCase("steamX")]
+        public void ParseLowercaseString_FallsBackToCustomForUnknownOrEmpty(string? wire)
+        {
+            // ParseLowercaseString never throws; unknown values map to Custom.
+            Assert.AreEqual(IdentityType.Custom, IdentityTypeExtensions.ParseLowercaseString(wire));
+        }
+
         [Test]
         public void ToLowercaseString_UnknownValue_Throws()
         {

--- a/src/Packages/Audience/Tests/Runtime/IdentityTypeTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/IdentityTypeTests.cs
@@ -42,7 +42,7 @@ namespace Immutable.Audience.Tests
 
         [TestCase(null)]
         [TestCase("")]
-        [TestCase("unknown_provider")]
+        [TestCase(TestFixtures.UnknownProvider)]
         [TestCase("steamX")]
         public void ParseLowercaseString_FallsBackToCustomForUnknownOrEmpty(string? wire)
         {

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -231,7 +231,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void ContextProvider_ThrowingDelegate_SwallowsAndShipsBaseContext()
         {
-            ImmutableAudience.ContextProvider = () => throw new InvalidOperationException("boom");
+            ImmutableAudience.ContextProvider = () => throw new InvalidOperationException(TestFixtures.ContextProviderBoomMessage);
 
             ImmutableAudience.Init(MakeConfig());
             ImmutableAudience.Track(TestEventNames.UnitTestEvent);
@@ -319,7 +319,7 @@ namespace Immutable.Audience.Tests
             {
                 // Purchase with no Value set: ToProperties throws; Track must
                 // catch, warn, and drop rather than ship an incomplete event.
-                Assert.DoesNotThrow(() => ImmutableAudience.Track(new Purchase { Currency = "USD" }));
+                Assert.DoesNotThrow(() => ImmutableAudience.Track(new Purchase { Currency = TestFixtures.UsdCurrency }));
                 // Assert the stable parts (event-type name and trailing "Dropping")
                 // so the test survives any change to the exception type or message.
                 Assert.That(lines, Has.Some.Contains(nameof(Purchase)));
@@ -408,7 +408,7 @@ namespace Immutable.Audience.Tests
             var invalid = (IdentityType)999;
 
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => ImmutableAudience.Alias("fromId", invalid, "toId", IdentityType.Steam),
+                () => ImmutableAudience.Alias(TestFixtures.GenericAliasFromId, invalid, TestFixtures.GenericAliasToId, IdentityType.Steam),
                 "invalid enum cast must throw so a broken alias call fails loud rather " +
                 "than shipping an event that cannot be matched for deletion");
         }
@@ -419,7 +419,7 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
 
             Assert.DoesNotThrow(() => ImmutableAudience.Alias(null, IdentityType.Passport, "to", IdentityType.Steam));
-            Assert.DoesNotThrow(() => ImmutableAudience.Alias("from", IdentityType.Passport, "", IdentityType.Steam));
+            Assert.DoesNotThrow(() => ImmutableAudience.Alias(TestFixtures.GenericAliasFromShort, IdentityType.Passport, "", IdentityType.Steam));
         }
 
         [Test]
@@ -581,7 +581,7 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.Track(new Progression
             {
                 Status = ProgressionStatus.Complete,
-                World = "tutorial",
+                World = TestFixtures.ProgressionWorldTutorial,
                 Level = "1"
             });
             ImmutableAudience.Shutdown();
@@ -600,7 +600,7 @@ namespace Immutable.Audience.Tests
 
             ImmutableAudience.Track(new Purchase
             {
-                Currency = "USD",
+                Currency = TestFixtures.UsdCurrency,
                 Value = 9.99m
             });
             ImmutableAudience.Shutdown();
@@ -1124,7 +1124,7 @@ namespace Immutable.Audience.Tests
         public void Init_LowercasesDistributionPlatform_WhenCallerPassesMixedCase()
         {
             var config = MakeConfig();
-            config.DistributionPlatform = "Steam";
+            config.DistributionPlatform = TestFixtures.DistributionPlatformSteamCased;
             ImmutableAudience.Init(config);
 
             Assert.AreEqual(DistributionPlatforms.Steam, config.DistributionPlatform,
@@ -1135,7 +1135,7 @@ namespace Immutable.Audience.Tests
         public void Init_LowercasesDistributionPlatform_WhenCallerPassesAllUpperCase()
         {
             var config = MakeConfig();
-            config.DistributionPlatform = "STEAM";
+            config.DistributionPlatform = TestFixtures.DistributionPlatformSteamUppercase;
             ImmutableAudience.Init(config);
 
             Assert.AreEqual(DistributionPlatforms.Steam, config.DistributionPlatform);
@@ -1199,7 +1199,7 @@ namespace Immutable.Audience.Tests
         {
             ImmutableAudience.LaunchContextProvider = () => new Dictionary<string, object>
             {
-                [GameLaunchPropertyKeys.Platform] = "WindowsPlayer",
+                [GameLaunchPropertyKeys.Platform] = TestFixtures.PlatformWindows,
                 [GameLaunchPropertyKeys.Version] = "1.2.3",
                 [GameLaunchPropertyKeys.BuildGuid] = "a1b2c3d4e5f6",
                 [GameLaunchPropertyKeys.UnityVersion] = "2022.3.20f1",

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -490,7 +490,7 @@ namespace Immutable.Audience.Tests
 
             ImmutableAudience.Track(TestEventNames.CraftingStarted, new Dictionary<string, object>
             {
-                { "recipe_id", "iron_sword" }
+                { TestFixtures.CustomPropKeyRecipeId, TestFixtures.CraftingRecipeIronSword }
             });
 
             // Flush memory → disk
@@ -968,7 +968,7 @@ namespace Immutable.Audience.Tests
             // EnqueueTrack and this test leaks reproducibly.
             const int iterations = 200;
             const int trackersPerIteration = 4;
-            const string testUserId = "user_race_stress";
+            const string testUserId = TestFixtures.UserRaceStress;
 
             for (int iter = 0; iter < iterations; iter++)
             {
@@ -1224,7 +1224,7 @@ namespace Immutable.Audience.Tests
         {
             ImmutableAudience.LaunchContextProvider = () => new Dictionary<string, object>
             {
-                [GameLaunchPropertyKeys.DistributionPlatform] = "provider_value",
+                [GameLaunchPropertyKeys.DistributionPlatform] = TestFixtures.ProviderValue,
             };
 
             var config = MakeConfig();
@@ -1237,7 +1237,7 @@ namespace Immutable.Audience.Tests
                 .Select(File.ReadAllText)
                 .First(c => c.Contains($"\"{EventNames.GameLaunch}\""));
             StringAssert.Contains($"\"{GameLaunchPropertyKeys.DistributionPlatform}\":\"{DistributionPlatforms.Steam}\"", launchFile);
-            Assert.IsFalse(launchFile.Contains("provider_value"),
+            Assert.IsFalse(launchFile.Contains(TestFixtures.ProviderValue),
                 "config.DistributionPlatform should win over the provider's value");
         }
 

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -1151,6 +1151,21 @@ namespace Immutable.Audience.Tests
             Assert.AreEqual(DistributionPlatforms.Steam, config.DistributionPlatform);
         }
 
+        // Lowercase normalisation must apply to every DistributionPlatforms value.
+        [TestCase(DistributionPlatforms.Steam)]
+        [TestCase(DistributionPlatforms.Epic)]
+        [TestCase(DistributionPlatforms.GOG)]
+        [TestCase(DistributionPlatforms.Itch)]
+        [TestCase(DistributionPlatforms.Standalone)]
+        public void Init_LowercasesDistributionPlatform_AcrossAllPublicValues(string canonical)
+        {
+            var config = MakeConfig();
+            config.DistributionPlatform = canonical.ToUpperInvariant();
+            ImmutableAudience.Init(config);
+
+            Assert.AreEqual(canonical, config.DistributionPlatform);
+        }
+
         [Test]
         public void Init_LeavesDistributionPlatformNull_WhenNotSet()
         {

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -105,8 +105,8 @@ namespace Immutable.Audience.Tests
             Assert.IsNull(ImmutableAudience.UserId,
                 "UserId should be null until Identify is called");
 
-            ImmutableAudience.Identify("player-42", IdentityType.Custom);
-            Assert.AreEqual("player-42", ImmutableAudience.UserId,
+            ImmutableAudience.Identify(TestFixtures.PlayerCustomId, IdentityType.Custom);
+            Assert.AreEqual(TestFixtures.PlayerCustomId, ImmutableAudience.UserId,
                 "UserId must reflect the most recent Identify call");
 
             ImmutableAudience.Reset();
@@ -215,7 +215,7 @@ namespace Immutable.Audience.Tests
             };
 
             ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
-            ImmutableAudience.Identify("player-42", IdentityType.Custom);
+            ImmutableAudience.Identify(TestFixtures.PlayerCustomId, IdentityType.Custom);
             ImmutableAudience.Shutdown();
 
             var queueDir = AudiencePaths.QueueDir(_testDir);
@@ -1325,8 +1325,8 @@ namespace Immutable.Audience.Tests
         {
             ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
 
-            ImmutableAudience.Identify("player_steam", IdentityType.Steam);
-            ImmutableAudience.Alias("player_steam", IdentityType.Steam, "player_passport", IdentityType.Passport);
+            ImmutableAudience.Identify(TestFixtures.PlayerSteamId, IdentityType.Steam);
+            ImmutableAudience.Alias(TestFixtures.PlayerSteamId, IdentityType.Steam, TestFixtures.PlayerPassportId, IdentityType.Passport);
             ImmutableAudience.Track(TestEventNames.TrackedBeforeDowngrade);
 
             ImmutableAudience.FlushQueueToDiskForTesting();
@@ -1351,7 +1351,7 @@ namespace Immutable.Audience.Tests
         public void FullToAnonymous_FutureTracksOmitUserId()
         {
             ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
-            ImmutableAudience.Identify("player_steam", IdentityType.Steam);
+            ImmutableAudience.Identify(TestFixtures.PlayerSteamId, IdentityType.Steam);
             ImmutableAudience.SetConsent(ConsentLevel.Anonymous);
 
             ImmutableAudience.Track(TestEventNames.TrackedAfterDowngrade);

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -129,7 +129,7 @@ namespace Immutable.Audience.Tests
         {
             ImmutableAudience.Init(MakeConfig(ConsentLevel.Anonymous));
             // Track once so Identity.GetOrCreate runs and writes the id file.
-            ImmutableAudience.Track("warmup_event");
+            ImmutableAudience.Track(TestEventNames.WarmupEvent);
 
             var id = ImmutableAudience.AnonymousId;
             Assert.IsFalse(string.IsNullOrEmpty(id),
@@ -165,7 +165,7 @@ namespace Immutable.Audience.Tests
             Assert.Greater(afterInit, 0,
                 "QueueSize should include session_start and game_launch after Init");
 
-            ImmutableAudience.Track("explicit_track_event");
+            ImmutableAudience.Track(TestEventNames.ExplicitTrackEvent);
             Assert.Greater(ImmutableAudience.QueueSize, afterInit,
                 "QueueSize should grow when a new event is enqueued");
         }
@@ -186,7 +186,7 @@ namespace Immutable.Audience.Tests
             };
 
             ImmutableAudience.Init(MakeConfig());
-            ImmutableAudience.Track("unit_test_event");
+            ImmutableAudience.Track(TestEventNames.UnitTestEvent);
             ImmutableAudience.Shutdown();
 
             var queueDir = AudiencePaths.QueueDir(_testDir);
@@ -234,7 +234,7 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.ContextProvider = () => throw new InvalidOperationException("boom");
 
             ImmutableAudience.Init(MakeConfig());
-            ImmutableAudience.Track("unit_test_event");
+            ImmutableAudience.Track(TestEventNames.UnitTestEvent);
             ImmutableAudience.Shutdown();
 
             var queueDir = AudiencePaths.QueueDir(_testDir);
@@ -250,7 +250,7 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.ContextProvider = () => null;
 
             ImmutableAudience.Init(MakeConfig());
-            ImmutableAudience.Track("unit_test_event");
+            ImmutableAudience.Track(TestEventNames.UnitTestEvent);
             ImmutableAudience.Shutdown();
 
             var queueDir = AudiencePaths.QueueDir(_testDir);
@@ -488,7 +488,7 @@ namespace Immutable.Audience.Tests
         {
             ImmutableAudience.Init(MakeConfig());
 
-            ImmutableAudience.Track("crafting_started", new Dictionary<string, object>
+            ImmutableAudience.Track(TestEventNames.CraftingStarted, new Dictionary<string, object>
             {
                 { "recipe_id", "iron_sword" }
             });
@@ -511,7 +511,7 @@ namespace Immutable.Audience.Tests
         {
             ImmutableAudience.Init(MakeConfig());
 
-            ImmutableAudience.Track("main_menu_opened");
+            ImmutableAudience.Track(TestEventNames.MainMenuOpened);
             ImmutableAudience.Shutdown();
 
             var queueDir = AudiencePaths.QueueDir(_testDir);
@@ -525,7 +525,7 @@ namespace Immutable.Audience.Tests
         {
             ImmutableAudience.Init(MakeConfig(ConsentLevel.None));
 
-            ImmutableAudience.Track("should_not_appear");
+            ImmutableAudience.Track(TestEventNames.ShouldNotAppear);
             ImmutableAudience.Shutdown();
 
             var queueDir = AudiencePaths.QueueDir(_testDir);
@@ -669,12 +669,12 @@ namespace Immutable.Audience.Tests
         {
             ImmutableAudience.Init(MakeConfig());
 
-            ImmutableAudience.Track("before_reset");
+            ImmutableAudience.Track(TestEventNames.BeforeReset);
             var id1 = Identity.GetOrCreate(_testDir, ConsentLevel.Anonymous);
 
             ImmutableAudience.Reset();
 
-            ImmutableAudience.Track("after_reset");
+            ImmutableAudience.Track(TestEventNames.AfterReset);
             var id2 = Identity.GetOrCreate(_testDir, ConsentLevel.Anonymous);
 
             Assert.AreNotEqual(id1, id2, "Reset should generate a new anonymousId");
@@ -685,7 +685,7 @@ namespace Immutable.Audience.Tests
         {
             ImmutableAudience.Init(MakeConfig());
 
-            ImmutableAudience.Track("before_reset");
+            ImmutableAudience.Track(TestEventNames.BeforeReset);
             ImmutableAudience.FlushQueueToDiskForTesting();
 
             var queueDir = AudiencePaths.QueueDir(_testDir);
@@ -707,7 +707,7 @@ namespace Immutable.Audience.Tests
         {
             ImmutableAudience.Init(MakeConfig());
 
-            ImmutableAudience.Track("event_under_old_consent");
+            ImmutableAudience.Track(TestEventNames.EventUnderOldConsent);
 
             var queueDir = AudiencePaths.QueueDir(_testDir);
             // Force memory → disk so we can verify the purge wipes both layers.
@@ -746,7 +746,7 @@ namespace Immutable.Audience.Tests
             var trackTask = Task.Run(() =>
             {
                 trackStarted.Set();
-                ImmutableAudience.Track("racing_event");
+                ImmutableAudience.Track(TestEventNames.RacingEvent);
             });
 
             trackStarted.Wait();
@@ -799,7 +799,7 @@ namespace Immutable.Audience.Tests
                     trackers[t] = Task.Run(() =>
                     {
                         barrier.SignalAndWait();
-                        ImmutableAudience.Track("race_stress");
+                        ImmutableAudience.Track(TestEventNames.RaceStress);
                     });
                 }
 
@@ -988,7 +988,7 @@ namespace Immutable.Audience.Tests
                     trackers[t] = Task.Run(() =>
                     {
                         barrier.SignalAndWait();
-                        ImmutableAudience.Track("race_stress");
+                        ImmutableAudience.Track(TestEventNames.RaceStress);
                     });
                 }
 
@@ -1275,7 +1275,7 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.Init(MakeConfig());
             ImmutableAudience.Shutdown();
 
-            Assert.DoesNotThrow(() => ImmutableAudience.Track("should_not_crash"));
+            Assert.DoesNotThrow(() => ImmutableAudience.Track(TestEventNames.ShouldNotCrash));
         }
 
         [Test]
@@ -1291,7 +1291,7 @@ namespace Immutable.Audience.Tests
             config.ShutdownFlushTimeoutMs = 10_000;
 
             ImmutableAudience.Init(config);
-            ImmutableAudience.Track("ensure_nonempty_queue");
+            ImmutableAudience.Track(TestEventNames.EnsureNonemptyQueue);
             ImmutableAudience.FlushQueueToDiskForTesting();
 
             // Phase 1 flips _initialized and releases the lock; Phase 2 enters
@@ -1327,7 +1327,7 @@ namespace Immutable.Audience.Tests
 
             ImmutableAudience.Identify("player_steam", IdentityType.Steam);
             ImmutableAudience.Alias("player_steam", IdentityType.Steam, "player_passport", IdentityType.Passport);
-            ImmutableAudience.Track("tracked_before_downgrade");
+            ImmutableAudience.Track(TestEventNames.TrackedBeforeDowngrade);
 
             ImmutableAudience.FlushQueueToDiskForTesting();
 
@@ -1354,7 +1354,7 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.Identify("player_steam", IdentityType.Steam);
             ImmutableAudience.SetConsent(ConsentLevel.Anonymous);
 
-            ImmutableAudience.Track("tracked_after_downgrade");
+            ImmutableAudience.Track(TestEventNames.TrackedAfterDowngrade);
             ImmutableAudience.FlushQueueToDiskForTesting();
 
             var queueDir = AudiencePaths.QueueDir(_testDir);
@@ -1362,7 +1362,7 @@ namespace Immutable.Audience.Tests
                 .Select(f => JsonReader.DeserializeObject(File.ReadAllText(f)))
                 .Where(m => (string)m[MessageFields.Type] == MessageTypes.Track
                             && m.ContainsKey(MessageFields.EventName)
-                            && (string)m[MessageFields.EventName] == "tracked_after_downgrade")
+                            && (string)m[MessageFields.EventName] == TestEventNames.TrackedAfterDowngrade)
                 .ToList();
 
             Assert.AreEqual(1, trackFiles.Count);
@@ -1382,7 +1382,7 @@ namespace Immutable.Audience.Tests
             config.HttpHandler = handler;
 
             ImmutableAudience.Init(config);
-            ImmutableAudience.Track("event_to_send");
+            ImmutableAudience.Track(TestEventNames.EventToSend);
             ImmutableAudience.FlushQueueToDiskForTesting();
 
             // Kick off one SendBatch on a worker. It will block inside the
@@ -1417,7 +1417,7 @@ namespace Immutable.Audience.Tests
             config.HttpHandler = handler;
 
             ImmutableAudience.Init(config);
-            ImmutableAudience.Track("event_to_send");
+            ImmutableAudience.Track(TestEventNames.EventToSend);
             ImmutableAudience.FlushQueueToDiskForTesting();
 
             // First caller enters SendAsync and blocks on handler.Release.
@@ -1453,7 +1453,7 @@ namespace Immutable.Audience.Tests
             config.HttpHandler = handler;
 
             ImmutableAudience.Init(config);
-            ImmutableAudience.Track("event_to_send");
+            ImmutableAudience.Track(TestEventNames.EventToSend);
             ImmutableAudience.FlushQueueToDiskForTesting();
 
             using var cts = new CancellationTokenSource();

--- a/src/Packages/Audience/Tests/Runtime/MessagesTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/MessagesTests.cs
@@ -1,0 +1,133 @@
+using System;
+using NUnit.Framework;
+
+namespace Immutable.Audience.Tests
+{
+    // Pins each message constant to its exact wording so a reword breaks the build.
+    [TestFixture]
+    internal class AudienceErrorMessagesTests
+    {
+        [Test]
+        public void LocalStorageReadFailed_PrefixesAndAppendsExceptionMessage()
+        {
+            var ex = new InvalidOperationException("disk full");
+            Assert.AreEqual(
+                "Local storage read failed: disk full",
+                AudienceErrorMessages.LocalStorageReadFailed(ex));
+        }
+
+        [Test]
+        public void BatchPartiallyRejected_FormatsRejectedAndTotalCounts()
+        {
+            Assert.AreEqual(
+                "Batch partially rejected: 3 of 20 events dropped",
+                AudienceErrorMessages.BatchPartiallyRejected(3, 20));
+        }
+
+        [Test]
+        public void BatchRejectedPrefix_IsExactWording()
+        {
+            Assert.AreEqual("Batch rejected", AudienceErrorMessages.BatchRejectedPrefix);
+        }
+
+        [Test]
+        public void ServerErrorWillRetryPrefix_IsExactWording()
+        {
+            Assert.AreEqual("Server error, will retry", AudienceErrorMessages.ServerErrorWillRetryPrefix);
+        }
+
+        [Test]
+        public void ConsentSyncFailedWithStatus_FormatsStatusCode()
+        {
+            Assert.AreEqual(
+                "Consent sync failed with status 503",
+                AudienceErrorMessages.ConsentSyncFailedWithStatus(503));
+        }
+
+        [Test]
+        public void ConsentSyncThrew_PrefixesAndAppendsExceptionMessage()
+        {
+            var ex = new TimeoutException("timed out");
+            Assert.AreEqual(
+                "Consent sync threw: timed out",
+                AudienceErrorMessages.ConsentSyncThrew(ex));
+        }
+    }
+
+    [TestFixture]
+    internal class AudienceArgumentMessagesTests
+    {
+        [Test]
+        public void PublishableKeyRequired_IsExactWording()
+        {
+            Assert.AreEqual("PublishableKey is required",
+                AudienceArgumentMessages.PublishableKeyRequired);
+        }
+
+        [Test]
+        public void PersistentDataPathRequired_IsExactWording()
+        {
+            Assert.AreEqual("PersistentDataPath is required",
+                AudienceArgumentMessages.PersistentDataPathRequired);
+        }
+
+        [Test]
+        public void ProgressionStatusRequired_IsExactWording()
+        {
+            Assert.AreEqual(
+                "Progression.Status is required. Set it before calling Track(IEvent).",
+                AudienceArgumentMessages.ProgressionStatusRequired);
+        }
+
+        [Test]
+        public void ResourceFlowRequired_IsExactWording()
+        {
+            Assert.AreEqual(
+                "Resource.Flow is required. Set it before calling Track(IEvent).",
+                AudienceArgumentMessages.ResourceFlowRequired);
+        }
+
+        [Test]
+        public void ResourceCurrencyRequired_IsExactWording()
+        {
+            Assert.AreEqual(
+                "Resource.Currency is required. Set a non-empty string before calling Track(IEvent).",
+                AudienceArgumentMessages.ResourceCurrencyRequired);
+        }
+
+        [Test]
+        public void ResourceAmountRequired_IsExactWording()
+        {
+            Assert.AreEqual(
+                "Resource.Amount is required. Set it before calling Track(IEvent).",
+                AudienceArgumentMessages.ResourceAmountRequired);
+        }
+
+        [Test]
+        public void PurchaseValueRequired_IsExactWording()
+        {
+            Assert.AreEqual(
+                "Purchase.Value is required. Set it before calling Track(IEvent).",
+                AudienceArgumentMessages.PurchaseValueRequired);
+        }
+
+        [Test]
+        public void MilestoneReachedNameRequired_IsExactWording()
+        {
+            Assert.AreEqual(
+                "MilestoneReached.Name must not be null or empty",
+                AudienceArgumentMessages.MilestoneReachedNameRequired);
+        }
+
+        [TestCase("USD",
+            "Purchase.Currency 'USD' must be a three-letter uppercase ISO 4217 code")]
+        [TestCase(null,
+            "Purchase.Currency '' must be a three-letter uppercase ISO 4217 code")]
+        [TestCase("usd",
+            "Purchase.Currency 'usd' must be a three-letter uppercase ISO 4217 code")]
+        public void PurchaseCurrencyInvalid_FormatsCurrencyValue(string? currency, string expected)
+        {
+            Assert.AreEqual(expected, AudienceArgumentMessages.PurchaseCurrencyInvalid(currency));
+        }
+    }
+}

--- a/src/Packages/Audience/Tests/Runtime/OfflineResilienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/OfflineResilienceTests.cs
@@ -79,7 +79,7 @@ namespace Immutable.Audience.Tests
 
             Assert.DoesNotThrow(() =>
             {
-                for (int i = 0; i < 50; i++) ImmutableAudience.Track($"blocked_{i}");
+                for (int i = 0; i < 50; i++) ImmutableAudience.Track($"{TestEventNames.BlockedPrefix}{i}");
                 ImmutableAudience.FlushQueueToDiskForTesting();
             }, "Track must not propagate disk-write IOException to callers");
 
@@ -95,7 +95,7 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.Init(MakeConfig());
             ImmutableAudience.Track(TestEventNames.EventPreBlock);
             BlockDiskWrites();
-            for (int i = 0; i < 20; i++) ImmutableAudience.Track($"blocked_{i}");
+            for (int i = 0; i < 20; i++) ImmutableAudience.Track($"{TestEventNames.BlockedPrefix}{i}");
 
             Assert.DoesNotThrow(() => ImmutableAudience.Shutdown(),
                 "Shutdown must absorb disk-write failure during the final drain");
@@ -114,7 +114,7 @@ namespace Immutable.Audience.Tests
             BlockDiskWrites();
 
             const int eventCount = 50;
-            for (int i = 0; i < eventCount; i++) ImmutableAudience.Track($"blocked_{i}");
+            for (int i = 0; i < eventCount; i++) ImmutableAudience.Track($"{TestEventNames.BlockedPrefix}{i}");
             ImmutableAudience.FlushQueueToDiskForTesting();
 
             Assert.GreaterOrEqual(ImmutableAudience.QueueSize, eventCount,

--- a/src/Packages/Audience/Tests/Runtime/OfflineResilienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/OfflineResilienceTests.cs
@@ -64,7 +64,7 @@ namespace Immutable.Audience.Tests
                 foreach (var f in Directory.GetFiles(queueDir, AudiencePaths.QueueGlob)) File.Delete(f);
                 Directory.Delete(queueDir);
             }
-            File.WriteAllText(queueDir, "blocker");
+            File.WriteAllText(queueDir, TestFixtures.DiskBlockerContent);
         }
 
         // -----------------------------------------------------------------

--- a/src/Packages/Audience/Tests/Runtime/OfflineResilienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/OfflineResilienceTests.cs
@@ -93,7 +93,7 @@ namespace Immutable.Audience.Tests
             // Shutdown is invoked from app-quit handlers; an exception would
             // crash the process.
             ImmutableAudience.Init(MakeConfig());
-            ImmutableAudience.Track("event_pre_block");
+            ImmutableAudience.Track(TestEventNames.EventPreBlock);
             BlockDiskWrites();
             for (int i = 0; i < 20; i++) ImmutableAudience.Track($"blocked_{i}");
 

--- a/src/Packages/Audience/Tests/Runtime/PublishableKeyPrefixTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/PublishableKeyPrefixTests.cs
@@ -180,7 +180,7 @@ namespace Immutable.Audience.Tests
             config.OnError = errors.Add;
 
             ImmutableAudience.Init(config);
-            ImmutableAudience.Track("event_against_prod_with_test_key");
+            ImmutableAudience.Track(TestEventNames.EventAgainstProdWithTestKey);
             await ImmutableAudience.FlushAsync();
 
             Assert.IsTrue(errors.Any(e => e.Code == AudienceErrorCode.ValidationRejected),

--- a/src/Packages/Audience/Tests/Runtime/TestEventNames.cs
+++ b/src/Packages/Audience/Tests/Runtime/TestEventNames.cs
@@ -1,0 +1,30 @@
+namespace Immutable.Audience.Tests
+{
+    // Per-test event names. Each names what the test measures.
+    internal static class TestEventNames
+    {
+        internal const string Warmup = "warmup";
+        internal const string WarmupEvent = "warmup_event";
+        internal const string ExplicitTrackEvent = "explicit_track_event";
+        internal const string UnitTestEvent = "unit_test_event";
+        internal const string CraftingStarted = "crafting_started";
+        internal const string MainMenuOpened = "main_menu_opened";
+        internal const string ShouldNotAppear = "should_not_appear";
+        internal const string BeforeReset = "before_reset";
+        internal const string AfterReset = "after_reset";
+        internal const string EventUnderOldConsent = "event_under_old_consent";
+        internal const string RacingEvent = "racing_event";
+        internal const string RaceStress = "race_stress";
+        internal const string ShouldNotCrash = "should_not_crash";
+        internal const string EnsureNonemptyQueue = "ensure_nonempty_queue";
+        internal const string TrackedBeforeDowngrade = "tracked_before_downgrade";
+        internal const string TrackedAfterDowngrade = "tracked_after_downgrade";
+        internal const string EventToSend = "event_to_send";
+        internal const string EventPreBlock = "event_pre_block";
+        internal const string EventAgainstProdWithTestKey = "event_against_prod_with_test_key";
+        internal const string StressTrack = "stress_track";
+        internal const string MixedLoadTrack = "mixed_load_track";
+        internal const string SteadyState = "steady_state";
+        internal const string LevelComplete = "level_complete";
+    }
+}

--- a/src/Packages/Audience/Tests/Runtime/TestEventNames.cs
+++ b/src/Packages/Audience/Tests/Runtime/TestEventNames.cs
@@ -26,5 +26,20 @@ namespace Immutable.Audience.Tests
         internal const string MixedLoadTrack = "mixed_load_track";
         internal const string SteadyState = "steady_state";
         internal const string LevelComplete = "level_complete";
+
+        // EventQueue scenario names where the event name is meaningful in the test description.
+        internal const string IntervalFlush = "interval_flush";
+        internal const string DisposeTest = "dispose_test";
+
+        // Placeholder event names for tests where the event name itself is irrelevant.
+        internal const string PlaceholderA = "a";
+        internal const string PlaceholderB = "b";
+        internal const string PlaceholderTest = "test";
+        internal const string PlaceholderTrack = "track";
+        internal const string PlaceholderIgnored = "ignored";
+        internal const string PlaceholderEvt = "evt";
+
+        // Prefix for OfflineResilienceTests' $"blocked_{i}" loop.
+        internal const string BlockedPrefix = "blocked_";
     }
 }

--- a/src/Packages/Audience/Tests/Runtime/TestEventNames.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/TestEventNames.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0913bc77fd8c4a419bfcdb5dcfebb4e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Tests/Runtime/TestFixtures.cs
+++ b/src/Packages/Audience/Tests/Runtime/TestFixtures.cs
@@ -33,5 +33,38 @@ namespace Immutable.Audience.Tests
 
         // MilestoneReached event payload values
         internal const string MilestoneName = "first_boss_defeated";
+
+        // Track properties scenario data
+        internal const string CustomPropKeyRecipeId = "recipe_id";
+        internal const string CraftingRecipeIronSword = "iron_sword";
+
+        // Distribution platform fixture for the "platform from outside SDK" path.
+        internal const string ProviderValue = "provider_value";
+
+        // IdentityTypeExtensions.ParseLowercaseString fallback fixture.
+        internal const string UnknownProvider = "unknown_provider";
+
+        // Identity persistence fixtures (id read back from disk on next launch).
+        internal const string PreExistingId = "pre-existing-id";
+        internal const string PreExistingIdFromLastLaunch = "pre-existing-id-from-last-launch";
+
+        // ConsentStore corruption fixture (non-integer file content).
+        internal const string NotAnInt = "not-an-int";
+
+        // ThreadSafetyStressTests userId for race-stress scenarios.
+        internal const string UserRaceStress = "user_race_stress";
+
+        // DeleteDataTests generic userId.
+        internal const string SomeUser = "some-user";
+
+        // Prefix for GzipTests' $"anon-{i}" loop (per-message anonymous IDs).
+        internal const string AnonIdPrefix = "anon-";
+
+        // Placeholders for fixture slots where the value itself is not under test.
+        internal const string GenericUserId = "u1";
+        internal const string GenericFromId = "f";
+        internal const string GenericToId = "t";
+        internal const string GenericFromType = "t1";
+        internal const string GenericToType = "t2";
     }
 }

--- a/src/Packages/Audience/Tests/Runtime/TestFixtures.cs
+++ b/src/Packages/Audience/Tests/Runtime/TestFixtures.cs
@@ -66,5 +66,31 @@ namespace Immutable.Audience.Tests
         internal const string GenericToId = "t";
         internal const string GenericFromType = "t1";
         internal const string GenericToType = "t2";
+
+        // ISO 4217 currency codes used by Purchase / Resource tests.
+        internal const string UsdCurrency = "USD";
+        internal const string EurCurrency = "EUR";
+
+        // Progression.World fixture (used in three typed-event tests).
+        internal const string ProgressionWorldTutorial = "tutorial";
+
+        // Exception message fixture for the ContextProvider sabotage test.
+        internal const string ContextProviderBoomMessage = "boom";
+
+        // File body that occupies the queue directory path so directory creation fails.
+        internal const string DiskBlockerContent = "blocker";
+
+        // DistributionPlatform mixed-case fixtures for Init's lowercase
+        // normalisation test.
+        internal const string DistributionPlatformSteamCased = "Steam";
+        internal const string DistributionPlatformSteamUppercase = "STEAM";
+
+        // Unity Application.platform string for the GameLaunch.Platform test.
+        internal const string PlatformWindows = "WindowsPlayer";
+
+        // Longer generic alias endpoint fixtures, for readability in Alias calls.
+        internal const string GenericAliasFromId = "fromId";
+        internal const string GenericAliasToId = "toId";
+        internal const string GenericAliasFromShort = "from";
     }
 }

--- a/src/Packages/Audience/Tests/Runtime/TestFixtures.cs
+++ b/src/Packages/Audience/Tests/Runtime/TestFixtures.cs
@@ -1,0 +1,37 @@
+namespace Immutable.Audience.Tests
+{
+    // Per-fixture data values shared across the SDK test suite.
+    internal static class TestFixtures
+    {
+        // Anonymous IDs
+        internal const string AnonId1 = "anon-1";
+        internal const string AnonId42 = "anon-42";
+        internal const string AnonId123 = "anon-123";
+
+        // User IDs
+        internal const string UserId42 = "user-42";
+        internal const string UserId99 = "user-99";
+
+        // Alias endpoints
+        internal const string AliasFromId = "from-id";
+        internal const string AliasToId = "to-id";
+
+        // Identity values keyed to IdentityType.Custom / Steam / Passport
+        internal const string PlayerCustomId = "player-42";
+        internal const string PlayerSteamId = "player_steam";
+        internal const string PlayerPassportId = "player_passport";
+
+        // Resource event payload values
+        internal const string ResourceCurrency = "gold";
+        internal const string ResourceItemType = "quest_reward";
+        internal const string ResourceItemId = "main_quest_01";
+
+        // Purchase event payload values
+        internal const string PurchaseItemId = "gem_pack_01";
+        internal const string PurchaseItemName = "Starter Gem Pack";
+        internal const string PurchaseTransactionId = "txn_abc123";
+
+        // MilestoneReached event payload values
+        internal const string MilestoneName = "first_boss_defeated";
+    }
+}

--- a/src/Packages/Audience/Tests/Runtime/TestFixtures.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/TestFixtures.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd6da3a651764490959fa341975848f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Tests/Runtime/ThreadSafetyStressTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ThreadSafetyStressTests.cs
@@ -92,7 +92,7 @@ namespace Immutable.Audience.Tests
                         int count = 0;
                         while (DateTime.UtcNow < deadline)
                         {
-                            ImmutableAudience.Track("stress_track");
+                            ImmutableAudience.Track(TestEventNames.StressTrack);
                             count++;
                         }
                         firedPerThread[idx] = count;
@@ -155,7 +155,7 @@ namespace Immutable.Audience.Tests
                     {
                         barrier.SignalAndWait();
                         while (DateTime.UtcNow < deadline)
-                            ImmutableAudience.Track("mixed_load_track");
+                            ImmutableAudience.Track(TestEventNames.MixedLoadTrack);
                     }
                     catch (Exception ex) { exceptions.Add(ex); }
                 });
@@ -216,7 +216,7 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.Init(MakeConfig());
 
             // Warm up so JIT and one-time allocations are out of the measured window.
-            for (int i = 0; i < 200; i++) ImmutableAudience.Track("warmup");
+            for (int i = 0; i < 200; i++) ImmutableAudience.Track(TestEventNames.Warmup);
             ImmutableAudience.FlushQueueToDiskForTesting();
             GC.Collect();
             GC.WaitForPendingFinalizers();
@@ -226,7 +226,7 @@ namespace Immutable.Audience.Tests
 
             const int iterations = 10_000;
             for (int i = 0; i < iterations; i++)
-                ImmutableAudience.Track("steady_state");
+                ImmutableAudience.Track(TestEventNames.SteadyState);
 
             long allocDelta = GC.GetAllocatedBytesForCurrentThread() - allocBefore;
             double bytesPerCall = (double)allocDelta / iterations;

--- a/src/Packages/Audience/Tests/Runtime/Transport/EventQueueTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Transport/EventQueueTests.cs
@@ -35,7 +35,7 @@ namespace Immutable.Audience.Tests
         {
             using var queue = new EventQueue(_store, flushIntervalSeconds: 60, flushSize: 100);
 
-            queue.Enqueue(Msg("track"));
+            queue.Enqueue(Msg(TestEventNames.PlaceholderTrack));
             queue.FlushSync();
 
             Assert.AreEqual(1, _store.Count(), "event should be on disk after FlushSync");
@@ -77,8 +77,8 @@ namespace Immutable.Audience.Tests
         {
             var queue = new EventQueue(_store, flushIntervalSeconds: 60, flushSize: 100);
 
-            queue.Enqueue(Msg("a"));
-            queue.Enqueue(Msg("b"));
+            queue.Enqueue(Msg(TestEventNames.PlaceholderA));
+            queue.Enqueue(Msg(TestEventNames.PlaceholderB));
 
             queue.Shutdown();
 
@@ -99,7 +99,7 @@ namespace Immutable.Audience.Tests
             var queue = new EventQueue(_store, flushIntervalSeconds: 60, flushSize: 100);
             queue.Shutdown();
 
-            queue.Enqueue(Msg("ignored"));
+            queue.Enqueue(Msg(TestEventNames.PlaceholderIgnored));
 
             Assert.AreEqual(0, _store.Count(), "events enqueued after Shutdown should be discarded");
         }
@@ -110,7 +110,7 @@ namespace Immutable.Audience.Tests
             // Very short interval to make the test fast
             using var queue = new EventQueue(_store, flushIntervalSeconds: 1, flushSize: 100);
 
-            queue.Enqueue(Msg("interval_flush"));
+            queue.Enqueue(Msg(TestEventNames.IntervalFlush));
 
             // Wait slightly longer than the flush interval
             var deadline = DateTime.UtcNow.AddSeconds(4);
@@ -125,7 +125,7 @@ namespace Immutable.Audience.Tests
         {
             using (var queue = new EventQueue(_store, flushIntervalSeconds: 60, flushSize: 100))
             {
-                queue.Enqueue(Msg("dispose_test"));
+                queue.Enqueue(Msg(TestEventNames.DisposeTest));
             } // Dispose called here
 
             Assert.AreEqual(1, _store.Count(), "Dispose should flush events to disk");

--- a/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
@@ -217,7 +217,7 @@ namespace Immutable.Audience.Tests
 
             Assert.AreEqual(1, _store.Count(), "429 must keep files for retry");
             Assert.IsTrue(transport.IsInBackoffWindow);
-            Assert.AreEqual(5_000, transport.BackoffMs);
+            Assert.AreEqual(Constants.HttpBackoff1stMs, transport.BackoffMs);
             Assert.IsNull(reportedError, "429 is transient; must not fire onError");
         }
 
@@ -282,7 +282,7 @@ namespace Immutable.Audience.Tests
 
             await transport.SendBatchAsync();
 
-            Assert.AreEqual(5_000, transport.BackoffMs);
+            Assert.AreEqual(Constants.HttpBackoff1stMs, transport.BackoffMs);
             Assert.IsTrue(transport.IsInBackoffWindow);
         }
 
@@ -306,7 +306,7 @@ namespace Immutable.Audience.Tests
 
             await transport.SendBatchAsync();
             Assert.AreEqual(1, _store.Count(), "429 keeps the batch");
-            Assert.AreEqual(5_000, transport.BackoffMs);
+            Assert.AreEqual(Constants.HttpBackoff1stMs, transport.BackoffMs);
 
             Advance(5_001);
             await transport.SendBatchAsync();
@@ -384,7 +384,7 @@ namespace Immutable.Audience.Tests
 
             Assert.AreEqual(1, _store.Count(), "5xx should keep files for retry");
             Assert.IsTrue(transport.IsInBackoffWindow);
-            Assert.AreEqual(5000, transport.BackoffMs, "first failure = 5s backoff");
+            Assert.AreEqual(Constants.HttpBackoff1stMs, transport.BackoffMs, "first failure = HttpBackoff1stMs");
             Assert.IsNotNull(reportedError);
             Assert.AreEqual(AudienceErrorCode.FlushFailed, reportedError!.Code);
         }
@@ -400,27 +400,27 @@ namespace Immutable.Audience.Tests
             // Schedule: 5s → 10s → 20s → 40s → 60s cap.
             // Each escalation requires the previous window to have elapsed.
             await transport.SendBatchAsync();
-            Assert.AreEqual(5_000, transport.BackoffMs);
+            Assert.AreEqual(Constants.HttpBackoff1stMs, transport.BackoffMs);
 
             Advance(5_001);
             await transport.SendBatchAsync();
-            Assert.AreEqual(10_000, transport.BackoffMs);
+            Assert.AreEqual(Constants.HttpBackoff2ndMs, transport.BackoffMs);
 
             Advance(10_001);
             await transport.SendBatchAsync();
-            Assert.AreEqual(20_000, transport.BackoffMs);
+            Assert.AreEqual(Constants.HttpBackoff3rdMs, transport.BackoffMs);
 
             Advance(20_001);
             await transport.SendBatchAsync();
-            Assert.AreEqual(40_000, transport.BackoffMs);
+            Assert.AreEqual(Constants.HttpBackoff4thMs, transport.BackoffMs);
 
             Advance(40_001);
             await transport.SendBatchAsync();
-            Assert.AreEqual(60_000, transport.BackoffMs, "reaches 60s cap after 40s step");
+            Assert.AreEqual(Constants.HttpBackoffCapMs, transport.BackoffMs, "reaches cap after 4th step");
 
             Advance(60_001);
             await transport.SendBatchAsync();
-            Assert.AreEqual(60_000, transport.BackoffMs, "stays at cap");
+            Assert.AreEqual(Constants.HttpBackoffCapMs, transport.BackoffMs, "stays at cap");
         }
 
         [Test]
@@ -432,7 +432,7 @@ namespace Immutable.Audience.Tests
                 handler: handler, getUtcNow: _getUtcNow);
 
             await transport.SendBatchAsync();
-            Assert.AreEqual(5_000, transport.BackoffMs);
+            Assert.AreEqual(Constants.HttpBackoff1stMs, transport.BackoffMs);
             var firstDeadline = transport.NextAttemptAt;
             Assert.IsNotNull(firstDeadline);
 
@@ -447,12 +447,12 @@ namespace Immutable.Audience.Tests
             // Another premature retry: still no escalation.
             Advance(3_000);
             await transport.SendBatchAsync();
-            Assert.AreEqual(5_000, transport.BackoffMs);
+            Assert.AreEqual(Constants.HttpBackoff1stMs, transport.BackoffMs);
 
             // Wait out the window, fail again → now we escalate.
             _utcNow = firstDeadline.Value.AddMilliseconds(1);
             await transport.SendBatchAsync();
-            Assert.AreEqual(10_000, transport.BackoffMs);
+            Assert.AreEqual(Constants.HttpBackoff2ndMs, transport.BackoffMs);
         }
 
         [Test]
@@ -474,11 +474,11 @@ namespace Immutable.Audience.Tests
                 handler: handler, getUtcNow: _getUtcNow);
 
             await transport.SendBatchAsync();
-            Assert.AreEqual(5_000, transport.BackoffMs);
+            Assert.AreEqual(Constants.HttpBackoff1stMs, transport.BackoffMs);
 
             Advance(5_001);
             await transport.SendBatchAsync();
-            Assert.AreEqual(10_000, transport.BackoffMs);
+            Assert.AreEqual(Constants.HttpBackoff2ndMs, transport.BackoffMs);
 
             Advance(10_001);
             await transport.SendBatchAsync();
@@ -580,7 +580,7 @@ namespace Immutable.Audience.Tests
             await transport.SendBatchAsync();
 
             Assert.IsTrue(transport.IsInBackoffWindow, "within window immediately after failure");
-            Assert.AreEqual(now.AddMilliseconds(5_000), transport.NextAttemptAt);
+            Assert.AreEqual(now.AddMilliseconds(Constants.HttpBackoff1stMs), transport.NextAttemptAt);
 
             // Advance the clock just before NextAttemptAt: still backing off.
             now = now.AddMilliseconds(4_999);

--- a/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
@@ -17,6 +17,15 @@ namespace Immutable.Audience.Tests
     [TestFixture]
     internal class HttpTransportTests
     {
+        // Response body fixtures.
+        private const string MalformedResponseBody = "not-json";
+        private const string EmptyJsonObjectBody = "{}";
+
+        // Exception messages thrown by MockHandler factories.
+        private const string ConnectionRefusedMessage = "connection refused";
+        private const string RequestTimedOutMessage = "Request timed out";
+        private const string SimulatedCancellationMessage = "simulated";
+
         private string _testDir = null!;
         private DiskStore _store = null!;
 
@@ -176,7 +185,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public async Task SendBatchAsync_EmptyQueue_ReturnsFalse()
         {
-            var handler = new MockHandler(HttpStatusCode.OK, "{}");
+            var handler = new MockHandler(HttpStatusCode.OK, EmptyJsonObjectBody);
             using var transport = new HttpTransport(_store, TestDefaults.PublishableKey, handler: handler);
 
             var sent = await transport.SendBatchAsync();
@@ -359,7 +368,7 @@ namespace Immutable.Audience.Tests
             // Malformed diagnostic body must not block the success path.
             _store.Write(WireFixture.Track((MessageFields.EventName, TestEventNames.PlaceholderA)));
 
-            var handler = new MockHandler(HttpStatusCode.OK, "not-json");
+            var handler = new MockHandler(HttpStatusCode.OK, MalformedResponseBody);
             AudienceError? reportedError = null;
             using var transport = new HttpTransport(_store, TestDefaults.PublishableKey,
                 onError: e => reportedError = e, handler: handler);
@@ -491,7 +500,7 @@ namespace Immutable.Audience.Tests
         {
             _store.Write(WireFixture.Track());
 
-            var handler = new MockHandler(() => throw new HttpRequestException("connection refused"));
+            var handler = new MockHandler(() => throw new HttpRequestException(ConnectionRefusedMessage));
             AudienceError? reportedError = null;
             using var transport = new HttpTransport(_store, TestDefaults.PublishableKey,
                 onError: e => reportedError = e, handler: handler);
@@ -514,7 +523,7 @@ namespace Immutable.Audience.Tests
             // NetworkError path.
             _store.Write(WireFixture.Track());
 
-            var handler = new MockHandler(() => throw new TaskCanceledException("Request timed out"));
+            var handler = new MockHandler(() => throw new TaskCanceledException(RequestTimedOutMessage));
             AudienceError? reportedError = null;
             using var transport = new HttpTransport(_store, TestDefaults.PublishableKey,
                 onError: e => reportedError = e, handler: handler);
@@ -540,7 +549,7 @@ namespace Immutable.Audience.Tests
             // forever: nothing ever drains, nothing ever throws.
             _store.Write(WireFixture.Track());
 
-            var handler = new MockHandler(() => throw new OperationCanceledException("simulated"));
+            var handler = new MockHandler(() => throw new OperationCanceledException(SimulatedCancellationMessage));
             AudienceError? reportedError = null;
             using var transport = new HttpTransport(_store, TestDefaults.PublishableKey,
                 onError: e => reportedError = e, handler: handler);

--- a/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Transport/HttpTransportTests.cs
@@ -49,8 +49,8 @@ namespace Immutable.Audience.Tests
         [Test]
         public async Task SendBatchAsync_200_DeletesFilesFromDisk()
         {
-            _store.Write(WireFixture.Track((MessageFields.EventName, "a")));
-            _store.Write(WireFixture.Track((MessageFields.EventName, "b")));
+            _store.Write(WireFixture.Track((MessageFields.EventName, TestEventNames.PlaceholderA)));
+            _store.Write(WireFixture.Track((MessageFields.EventName, TestEventNames.PlaceholderB)));
 
             var handler = new MockHandler(HttpStatusCode.OK, $"{{\"accepted\":2,\"{ResponseFields.Rejected}\":0}}");
             using var transport = new HttpTransport(_store, TestDefaults.PublishableKey, handler: handler);
@@ -65,7 +65,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public async Task SendBatchAsync_200_SendsGzippedPayloadWithCorrectHeaders()
         {
-            _store.Write(WireFixture.Track((MessageFields.EventName, "test")));
+            _store.Write(WireFixture.Track((MessageFields.EventName, TestEventNames.PlaceholderTest)));
 
             byte[]? capturedBody = null;
             string? capturedKey = null;
@@ -97,7 +97,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public async Task SendBatchAsync_200_SendsPlainJsonPayloadWithoutContentEncoding()
         {
-            _store.Write(WireFixture.Track((MessageFields.EventName, "test")));
+            _store.Write(WireFixture.Track((MessageFields.EventName, TestEventNames.PlaceholderTest)));
 
             string? capturedKey = null;
             string? capturedContentType = null;
@@ -322,8 +322,8 @@ namespace Immutable.Audience.Tests
             // per-message validation errors. The batch is deleted (retries
             // would not help) and the count is surfaced via onError so
             // studios can observe silently dropped events.
-            _store.Write(WireFixture.Track((MessageFields.EventName, "a")));
-            _store.Write(WireFixture.Track((MessageFields.EventName, "b")));
+            _store.Write(WireFixture.Track((MessageFields.EventName, TestEventNames.PlaceholderA)));
+            _store.Write(WireFixture.Track((MessageFields.EventName, TestEventNames.PlaceholderB)));
 
             var handler = new MockHandler(HttpStatusCode.OK, $"{{\"accepted\":1,\"{ResponseFields.Rejected}\":1}}");
             AudienceError? reportedError = null;
@@ -341,7 +341,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public async Task SendBatchAsync_200_ZeroRejected_DoesNotFireOnError()
         {
-            _store.Write(WireFixture.Track((MessageFields.EventName, "a")));
+            _store.Write(WireFixture.Track((MessageFields.EventName, TestEventNames.PlaceholderA)));
 
             var handler = new MockHandler(HttpStatusCode.OK, $"{{\"accepted\":1,\"{ResponseFields.Rejected}\":0}}");
             AudienceError? reportedError = null;
@@ -357,7 +357,7 @@ namespace Immutable.Audience.Tests
         public async Task SendBatchAsync_200_MalformedBody_TreatsAsZeroRejected()
         {
             // Malformed diagnostic body must not block the success path.
-            _store.Write(WireFixture.Track((MessageFields.EventName, "a")));
+            _store.Write(WireFixture.Track((MessageFields.EventName, TestEventNames.PlaceholderA)));
 
             var handler = new MockHandler(HttpStatusCode.OK, "not-json");
             AudienceError? reportedError = null;

--- a/src/Packages/Audience/Tests/Runtime/Utility/GzipTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Utility/GzipTests.cs
@@ -35,7 +35,7 @@ namespace Immutable.Audience.Tests
                 if (i > 0) sb.Append(',');
                 sb.Append(WireFixture.Track(
                     (MessageFields.EventName, TestEventNames.LevelComplete),
-                    (MessageFields.AnonymousId, $"anon-{i}")));
+                    (MessageFields.AnonymousId, $"{TestFixtures.AnonIdPrefix}{i}")));
             }
 
             sb.Append("]}");

--- a/src/Packages/Audience/Tests/Runtime/Utility/GzipTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Utility/GzipTests.cs
@@ -34,7 +34,7 @@ namespace Immutable.Audience.Tests
             {
                 if (i > 0) sb.Append(',');
                 sb.Append(WireFixture.Track(
-                    (MessageFields.EventName, "level_complete"),
+                    (MessageFields.EventName, TestEventNames.LevelComplete),
                     (MessageFields.AnonymousId, $"anon-{i}")));
             }
 

--- a/src/Packages/Audience/Tests/Runtime/Utility/JsonReaderTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Utility/JsonReaderTests.cs
@@ -16,15 +16,15 @@ namespace Immutable.Audience.Tests
         [Test]
         public void StringValue()
         {
-            var result = JsonReader.DeserializeObject("{\"key\":\"hello\"}");
-            Assert.AreEqual("hello", result["key"]);
+            var result = JsonReader.DeserializeObject(JsonRoundTripFixtures.KeyHelloEncoded);
+            Assert.AreEqual(JsonRoundTripFixtures.HelloValue, result[JsonRoundTripFixtures.KeyName]);
         }
 
         [Test]
         public void StringWithEscapes()
         {
-            var result = JsonReader.DeserializeObject("{\"val\":\"say \\\"hi\\\"\\nback\\\\slash\\ttab\"}");
-            Assert.AreEqual("say \"hi\"\nback\\slash\ttab", result["val"]);
+            var result = JsonReader.DeserializeObject(JsonRoundTripFixtures.ValEscapeRichEncoded);
+            Assert.AreEqual(JsonRoundTripFixtures.EscapeRichString, result[JsonRoundTripFixtures.ValName]);
         }
 
         [Test]
@@ -47,9 +47,9 @@ namespace Immutable.Audience.Tests
         [Test]
         public void NestedObject()
         {
-            var result = JsonReader.DeserializeObject("{\"outer\":{\"inner\":\"value\"}}");
-            var inner = (Dictionary<string, object>)result["outer"];
-            Assert.AreEqual("value", inner["inner"]);
+            var result = JsonReader.DeserializeObject(JsonRoundTripFixtures.OuterInnerEncoded);
+            var inner = (Dictionary<string, object>)result[JsonRoundTripFixtures.OuterKey];
+            Assert.AreEqual(JsonRoundTripFixtures.InnerValue, inner[JsonRoundTripFixtures.InnerKey]);
         }
 
         [Test]

--- a/src/Packages/Audience/Tests/Runtime/Utility/JsonRoundTripFixtures.cs
+++ b/src/Packages/Audience/Tests/Runtime/Utility/JsonRoundTripFixtures.cs
@@ -1,0 +1,24 @@
+namespace Immutable.Audience.Tests
+{
+    // Paired serialise/deserialise fixtures shared between JsonTests and JsonReaderTests.
+    // Each pair pins the round-trip guarantee.
+    internal static class JsonRoundTripFixtures
+    {
+        // Single string key / value pair.
+        internal const string KeyName = "key";
+        internal const string HelloValue = "hello";
+        internal const string KeyHelloEncoded = "{\"key\":\"hello\"}";
+
+        // String containing every escape sequence the codec handles
+        // (escaped quote, newline, backslash, tab).
+        internal const string ValName = "val";
+        internal const string EscapeRichString = "say \"hi\"\nback\\slash\ttab";
+        internal const string ValEscapeRichEncoded = "{\"val\":\"say \\\"hi\\\"\\nback\\\\slash\\ttab\"}";
+
+        // Nested object.
+        internal const string OuterKey = "outer";
+        internal const string InnerKey = "inner";
+        internal const string InnerValue = "value";
+        internal const string OuterInnerEncoded = "{\"outer\":{\"inner\":\"value\"}}";
+    }
+}

--- a/src/Packages/Audience/Tests/Runtime/Utility/JsonRoundTripFixtures.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/Utility/JsonRoundTripFixtures.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0203f7f2c4e64d7f86b9734903dce417
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Tests/Runtime/Utility/JsonTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Utility/JsonTests.cs
@@ -18,11 +18,11 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Serialize_StringValue_ReturnsQuotedString()
         {
-            var data = new Dictionary<string, object> { { "key", "hello" } };
+            var data = new Dictionary<string, object> { { JsonRoundTripFixtures.KeyName, JsonRoundTripFixtures.HelloValue } };
 
             var result = Json.Serialize(data);
 
-            Assert.AreEqual("{\"key\":\"hello\"}", result);
+            Assert.AreEqual(JsonRoundTripFixtures.KeyHelloEncoded, result);
         }
 
         [Test]
@@ -30,12 +30,12 @@ namespace Immutable.Audience.Tests
         {
             var data = new Dictionary<string, object>
             {
-                { "val", "say \"hi\"\nback\\slash\ttab" }
+                { JsonRoundTripFixtures.ValName, JsonRoundTripFixtures.EscapeRichString }
             };
 
             var result = Json.Serialize(data);
 
-            Assert.AreEqual("{\"val\":\"say \\\"hi\\\"\\nback\\\\slash\\ttab\"}", result);
+            Assert.AreEqual(JsonRoundTripFixtures.ValEscapeRichEncoded, result);
         }
 
         [Test]
@@ -84,14 +84,14 @@ namespace Immutable.Audience.Tests
             var data = new Dictionary<string, object>
             {
                 {
-                    "outer", new Dictionary<string, object>
+                    JsonRoundTripFixtures.OuterKey, new Dictionary<string, object>
                     {
-                        { "inner", "value" }
+                        { JsonRoundTripFixtures.InnerKey, JsonRoundTripFixtures.InnerValue }
                     }
                 }
             };
 
-            Assert.AreEqual("{\"outer\":{\"inner\":\"value\"}}", Json.Serialize(data));
+            Assert.AreEqual(JsonRoundTripFixtures.OuterInnerEncoded, Json.Serialize(data));
         }
 
         [Test]

--- a/src/Packages/Audience/Tests/Runtime/Utility/JsonTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Utility/JsonTests.cs
@@ -182,7 +182,7 @@ namespace Immutable.Audience.Tests
             var data = new Dictionary<string, object>
             {
                 { MessageFields.Type, MessageTypes.Track },
-                { MessageFields.EventName, "level_complete" },
+                { MessageFields.EventName, TestEventNames.LevelComplete },
                 { MessageFields.AnonymousId, "anon-123" },
                 { MessageFields.UserId, null },
                 { MessageFields.Properties, new Dictionary<string, object>

--- a/src/Packages/Audience/Tests/Runtime/Utility/JsonTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Utility/JsonTests.cs
@@ -183,7 +183,7 @@ namespace Immutable.Audience.Tests
             {
                 { MessageFields.Type, MessageTypes.Track },
                 { MessageFields.EventName, TestEventNames.LevelComplete },
-                { MessageFields.AnonymousId, "anon-123" },
+                { MessageFields.AnonymousId, TestFixtures.AnonId123 },
                 { MessageFields.UserId, null },
                 { MessageFields.Properties, new Dictionary<string, object>
                     {


### PR DESCRIPTION
## Summary

- Pins `Constants.LibraryName` against the `name` field in `package.json`.
- Pins backoff assertions in transport tests against `Constants.HttpBackoff*Ms` instead of magic numbers.
- Covers `IdentityTypeExtensions.ParseLowercaseString` cases (known platform, unknown, null, empty, mixed case fallback to `Custom`).
- Parametrises `DistributionPlatform` casing tests across all platform values.
- Pins `AudienceErrorMessages` and `AudienceArgumentMessages` constants and formatters to their exact wording so a reword fails the build.
- Adds Unity-only `DeviceCollectorTests` and `SampleAppUxmlAlignmentTests` drafts; both gated by `UNITY_INCLUDE_TESTS` and excluded from the headless `dotnet` build via `Audience.Tests.csproj`.
- Adds `TestEventNames` for per-test event-name strings.
- Adds `SampleAppCustomEvents` and `SampleAppCustomEventPropertyKeys` for the sample-app demo catalogue's custom event names and property keys.
- Routes typed-event field lookups in `SampleAppLiveFireTests` through `EventPropertyKeys`.
- No behaviour change. Wire format and `OnError` callback contract unchanged.

Linear: [SDK-277](https://linear.app/imtbl/issue/SDK-277/centralise-duplicated-literals-across-unity-audience-sdk-runtime-tests)
