### PR TITLE
refactor(audience): sample-app reflection helpers and fixture extensions (SDK-277)

### DIFF
--- a/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
@@ -13,6 +13,12 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
     [TestFixture]
     internal class SampleAppLiveFireTests
     {
+        // Reflection target for ImmutableAudience.ResetState (invoked from SetUp).
+        private const string ResetStateMethodName = "ResetState";
+
+        // Per-test prefix combined with UtcNow.Ticks for a unique userId per Identify run.
+        private const string PanelUserPrefix = "panel-user-";
+
         // Cached allocations for fixed-delay yields (SDK needs time to flush
         // rather than "wait up to N seconds for a condition"). Static readonly
         // so the WaitForSecondsRealtime instance is created once per class load.
@@ -28,7 +34,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
             // ResetState is internal — reached via reflection (BindingFlags.NonPublic
             // bypasses C# access checks; no InternalsVisibleTo required).
             var t = typeof(ImmutableAudience);
-            var m = t.GetMethod("ResetState",
+            var m = t.GetMethod(ResetStateMethodName,
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
             m?.Invoke(null, null);
 
@@ -687,7 +693,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         {
             yield return LoadAndInit(initialConsent: SampleAppUi.Consent.Full);
 
-            var userId = "panel-user-" + DateTime.UtcNow.Ticks;
+            var userId = PanelUserPrefix + DateTime.UtcNow.Ticks;
             _root!.Q<TextField>(SampleAppUi.IdentityFields.Id).value = userId;
             _root.Q<Button>(SampleAppUi.Buttons.Identify).Click();
             yield return SampleAppTestHelpers.WaitForLogEntry(_root, SampleAppUi.LogLabels.Identify, LogLevels.Ok, 5f);

--- a/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppTestHelpers.cs
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppTestHelpers.cs
@@ -15,6 +15,15 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
     // the log pane via the userData stash on each log row.
     internal static class SampleAppTestHelpers
     {
+        // Reflection field names for AudienceSample's LogEntry.
+        // No InternalsVisibleTo on the sample-app assembly, so nameof() is unreachable.
+        private const string LogEntryLabelField = "Label";
+        private const string LogEntryBodyField = "Body";
+        private const string LogEntryLevelField = "Level";
+
+        // UI Toolkit's Clickable.clicked is non-public; ButtonTestExtensions.Click reflects through this name.
+        internal const string ClickableClickedField = "clicked";
+
         // Polls predicate once per frame until it returns true or the deadline
         // elapses. Calls Assert.Fail with description when the deadline is hit.
         // Use this instead of WaitForSecondsRealtime when a test is waiting
@@ -104,16 +113,16 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
             internal LogEntryShim(object entry) { _entry = entry; }
 
             internal string Label =>
-                (string)(_entry.GetType().GetField("Label")?.GetValue(_entry) ?? "");
+                (string)(_entry.GetType().GetField(LogEntryLabelField)?.GetValue(_entry) ?? "");
 
             internal string Body =>
-                (string)(_entry.GetType().GetField("Body")?.GetValue(_entry) ?? "");
+                (string)(_entry.GetType().GetField(LogEntryBodyField)?.GetValue(_entry) ?? "");
 
             internal int Level
             {
                 get
                 {
-                    var v = _entry.GetType().GetField("Level")?.GetValue(_entry);
+                    var v = _entry.GetType().GetField(LogEntryLevelField)?.GetValue(_entry);
                     return v == null ? -1 : Convert.ToInt32(v);
                 }
             }
@@ -146,7 +155,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         {
             var clickable = button?.clickable;
             if (clickable == null) return;
-            var field = typeof(Clickable).GetField("clicked",
+            var field = typeof(Clickable).GetField(SampleAppTestHelpers.ClickableClickedField,
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             var handler = field?.GetValue(clickable) as Delegate;
             handler?.DynamicInvoke();

--- a/src/Packages/Audience/README.md.meta
+++ b/src/Packages/Audience/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3a7aa885aa8a74671bf944c82635a3c5
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Runtime/Transport/EventQueue.cs
+++ b/src/Packages/Audience/Runtime/Transport/EventQueue.cs
@@ -15,6 +15,9 @@ namespace Immutable.Audience
     // Call Shutdown before process exit.
     internal sealed class EventQueue : IDisposable
     {
+        // Drain thread name. Surfaces in profilers, debuggers, and crash dumps.
+        private const string DrainThreadName = "imtbl-audience-drain";
+
         private readonly DiskStore _store;
         private readonly int _flushIntervalMs;
         private readonly int _flushSize;
@@ -44,7 +47,7 @@ namespace Immutable.Audience
             _drainThread = new Thread(DrainLoop)
             {
                 IsBackground = true,
-                Name = "imtbl-audience-drain"
+                Name = DrainThreadName
             };
             _drainThread.Start();
         }

--- a/src/Packages/Audience/Tests/Editor.meta
+++ b/src/Packages/Audience/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 17962ad3281d3448db3de81755e12182
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Editor/DeviceCollectorTests.cs.meta
+++ b/src/Packages/Audience/Tests/Editor/DeviceCollectorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ddbec2eae65154d9aa98c4002dfbe197
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/ConsentSyncTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ConsentSyncTests.cs
@@ -172,8 +172,8 @@ namespace Immutable.Audience.Tests
                 PublishableKey = TestDefaults.PublishableKey,
                 Consent = consent,
                 PersistentDataPath = _testDir,
-                FlushIntervalSeconds = 600,
-                FlushSize = 1000,
+                FlushIntervalSeconds = TestDefaults.FlushIntervalSeconds,
+                FlushSize = TestDefaults.FlushSize,
                 HttpHandler = handler,
             };
 

--- a/src/Packages/Audience/Tests/Runtime/Core/SessionTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Core/SessionTests.cs
@@ -700,8 +700,8 @@ namespace Immutable.Audience.Tests
                 PublishableKey = TestDefaults.PublishableKey,
                 Consent = consent,
                 PersistentDataPath = _testDir,
-                FlushIntervalSeconds = 600,
-                FlushSize = 1000,
+                FlushIntervalSeconds = TestDefaults.FlushIntervalSeconds,
+                FlushSize = TestDefaults.FlushSize,
                 HttpHandler = new KeepOnDiskHandler()
             };
         }

--- a/src/Packages/Audience/Tests/Runtime/Core/SessionTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Core/SessionTests.cs
@@ -13,6 +13,9 @@ namespace Immutable.Audience.Tests
         // Exception thrown by the ThrowingTrack sabotage delegate across four scenarios.
         private const string TrackExplodeMessage = "track explode";
 
+        // Fixed virtual "now" used as the starting point for every Session lifecycle test.
+        private static readonly DateTime FixedNowUtc = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
+
         private List<(string name, Dictionary<string, object> props)> _events;
 
         [SetUp]
@@ -59,7 +62,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void End_FiresSessionEnd_WithDuration()
         {
-            var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
+            var now = FixedNowUtc;
             using var session = new Session(MockTrack, getUtcNow: () => now);
             session.Start();
             now = now.AddSeconds(2);
@@ -136,7 +139,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Pause_ThenResume_ShortPause_ContinuesSession()
         {
-            var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
+            var now = FixedNowUtc;
             using var session = new Session(MockTrack, getUtcNow: () => now);
             session.Start();
             var originalId = session.SessionId;
@@ -155,7 +158,7 @@ namespace Immutable.Audience.Tests
         {
             // Uses the injected clock to jump past the 30-second threshold
             // without sleeping.
-            var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
+            var now = FixedNowUtc;
             using var session = new Session(MockTrack, getUtcNow: () => now);
             session.Start();
             var id1 = session.SessionId;
@@ -182,7 +185,7 @@ namespace Immutable.Audience.Tests
             // _pausedAt jump to the second Pause and this test reports a
             // larger duration (over-crediting engagement by the double-pause
             // gap).
-            var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
+            var now = FixedNowUtc;
             DateTime Clock() => now;
 
             using var session = new Session(MockTrack, getUtcNow: Clock);
@@ -233,7 +236,7 @@ namespace Immutable.Audience.Tests
             // artificial engagement credit. Sabotage: removing the clamp
             // would let this test report a duration that exceeds the
             // wall-clock window, which the assertion below pins.
-            var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
+            var now = FixedNowUtc;
             DateTime Clock() => now;
 
             using var session = new Session(MockTrack, getUtcNow: Clock);
@@ -270,7 +273,7 @@ namespace Immutable.Audience.Tests
             // because it only fires when _pausedAt was set. Sabotage:
             // removing `if (engagedSeconds < 0) return 0;` would let this
             // test report -3 instead of 0.
-            var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
+            var now = FixedNowUtc;
             DateTime Clock() => now;
 
             using var session = new Session(MockTrack, getUtcNow: Clock);
@@ -296,7 +299,7 @@ namespace Immutable.Audience.Tests
             // (the final engagedSeconds ≥ 0 clamp only catches negatives,
             // not over-credit). Sabotage: removing the livePause clamp lets
             // this test report 15s instead of the ≤ 5s wall-clock window.
-            var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
+            var now = FixedNowUtc;
             DateTime Clock() => now;
 
             using var session = new Session(MockTrack, getUtcNow: Clock);
@@ -318,7 +321,7 @@ namespace Immutable.Audience.Tests
         public void End_AfterShortPause_ReportsDurationMinusPause()
         {
             // 10 seconds session, 3 seconds paused inside it → 7 seconds engaged.
-            var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
+            var now = FixedNowUtc;
             DateTime Clock() => now;
 
             using var session = new Session(MockTrack, getUtcNow: Clock);
@@ -343,7 +346,7 @@ namespace Immutable.Audience.Tests
         public void End_WhilePaused_ExcludesInFlightPauseFromDuration()
         {
             // Session running 5s, then paused for 2s and ended without resuming.
-            var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
+            var now = FixedNowUtc;
             DateTime Clock() => now;
 
             using var session = new Session(MockTrack, getUtcNow: Clock);
@@ -371,7 +374,7 @@ namespace Immutable.Audience.Tests
             // for the extended-pause rollover path: a naive duration that
             // forgot to credit the in-flight pause before End fires would
             // ship wall-clock seconds and break engagement dashboards.
-            var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
+            var now = FixedNowUtc;
             DateTime Clock() => now;
 
             using var session = new Session(MockTrack, getUtcNow: Clock);
@@ -393,7 +396,7 @@ namespace Immutable.Audience.Tests
         public void Heartbeat_AfterShortPause_ReportsPauseAdjustedDuration()
         {
             // Engaged 6s, paused 2s, resumed, then heartbeat → 6 s engaged.
-            var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
+            var now = FixedNowUtc;
             DateTime Clock() => now;
 
             using var session = new Session(MockTrack, getUtcNow: Clock);

--- a/src/Packages/Audience/Tests/Runtime/DeleteDataTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/DeleteDataTests.cs
@@ -38,8 +38,8 @@ namespace Immutable.Audience.Tests
                 PublishableKey = TestDefaults.PublishableKey,
                 Consent = consent,
                 PersistentDataPath = _testDir,
-                FlushIntervalSeconds = 600,
-                FlushSize = 1000,
+                FlushIntervalSeconds = TestDefaults.FlushIntervalSeconds,
+                FlushSize = TestDefaults.FlushSize,
                 HttpHandler = handler
             };
         }

--- a/src/Packages/Audience/Tests/Runtime/Events/TypedEventTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Events/TypedEventTests.cs
@@ -28,18 +28,18 @@ namespace Immutable.Audience.Tests
             {
                 Status = ProgressionStatus.Complete,
                 World = TestFixtures.ProgressionWorldTutorial,
-                Level = "1",
-                Score = 1500,
-                DurationSec = 120.5f
+                Level = TestFixtures.ProgressionLevelFixture,
+                Score = TestFixtures.ProgressionScoreFixture,
+                DurationSec = TestFixtures.ProgressionDurationSecFixture
             };
 
             var props = evt.ToProperties();
 
             Assert.AreEqual(ProgressionStatus.Complete.ToLowercaseString(), props[EventPropertyKeys.Status]);
             Assert.AreEqual(TestFixtures.ProgressionWorldTutorial, props[EventPropertyKeys.World]);
-            Assert.AreEqual("1", props[EventPropertyKeys.Level]);
-            Assert.AreEqual(1500, props[EventPropertyKeys.Score]);
-            Assert.AreEqual(120.5f, props[EventPropertyKeys.DurationSec]);
+            Assert.AreEqual(TestFixtures.ProgressionLevelFixture, props[EventPropertyKeys.Level]);
+            Assert.AreEqual(TestFixtures.ProgressionScoreFixture, props[EventPropertyKeys.Score]);
+            Assert.AreEqual(TestFixtures.ProgressionDurationSecFixture, props[EventPropertyKeys.DurationSec]);
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace Immutable.Audience.Tests
             {
                 Flow = ResourceFlow.Source,
                 Currency = TestFixtures.ResourceCurrency,
-                Amount = 100,
+                Amount = TestFixtures.ResourceAmountFixture,
                 ItemType = TestFixtures.ResourceItemType,
                 ItemId = TestFixtures.ResourceItemId
             };
@@ -71,7 +71,7 @@ namespace Immutable.Audience.Tests
 
             Assert.AreEqual(ResourceFlow.Source.ToLowercaseString(), props[EventPropertyKeys.Flow]);
             Assert.AreEqual(TestFixtures.ResourceCurrency, props[EventPropertyKeys.Currency]);
-            Assert.AreEqual(100m, props[EventPropertyKeys.Amount]);
+            Assert.AreEqual(TestFixtures.ResourceAmountFixture, props[EventPropertyKeys.Amount]);
             Assert.AreEqual(TestFixtures.ResourceItemType, props[EventPropertyKeys.ItemType]);
             Assert.AreEqual(TestFixtures.ResourceItemId, props[EventPropertyKeys.ItemId]);
         }
@@ -85,7 +85,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Resource_WithoutFlow_ThrowsOnToProperties()
         {
-            var evt = new Resource { Currency = TestFixtures.ResourceCurrency, Amount = 100 };
+            var evt = new Resource { Currency = TestFixtures.ResourceCurrency, Amount = TestFixtures.ResourceAmountFixture };
 
             var ex = Assert.Throws<ArgumentException>(() => evt.ToProperties());
             Assert.That(ex!.Message, Does.Contain(nameof(Resource.Flow)));
@@ -94,7 +94,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Resource_WithoutCurrency_ThrowsOnToProperties()
         {
-            var evt = new Resource { Flow = ResourceFlow.Source, Amount = 100 };
+            var evt = new Resource { Flow = ResourceFlow.Source, Amount = TestFixtures.ResourceAmountFixture };
 
             var ex = Assert.Throws<ArgumentException>(() => evt.ToProperties());
             Assert.That(ex!.Message, Does.Contain(nameof(Resource.Currency)));

--- a/src/Packages/Audience/Tests/Runtime/Events/TypedEventTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Events/TypedEventTests.cs
@@ -115,27 +115,27 @@ namespace Immutable.Audience.Tests
             var evt = new Purchase
             {
                 Currency = TestFixtures.UsdCurrency,
-                Value = 9.99m,
+                Value = TestFixtures.PurchaseValueFixture,
                 ItemId = TestFixtures.PurchaseItemId,
                 ItemName = TestFixtures.PurchaseItemName,
-                Quantity = 1,
+                Quantity = TestFixtures.PurchaseQuantityFixture,
                 TransactionId = TestFixtures.PurchaseTransactionId
             };
 
             var props = evt.ToProperties();
 
             Assert.AreEqual(TestFixtures.UsdCurrency, props[EventPropertyKeys.Currency]);
-            Assert.AreEqual(9.99m, props[EventPropertyKeys.Value]);
+            Assert.AreEqual(TestFixtures.PurchaseValueFixture, props[EventPropertyKeys.Value]);
             Assert.AreEqual(TestFixtures.PurchaseItemId, props[EventPropertyKeys.ItemId]);
             Assert.AreEqual(TestFixtures.PurchaseItemName, props[EventPropertyKeys.ItemName]);
-            Assert.AreEqual(1, props[EventPropertyKeys.Quantity]);
+            Assert.AreEqual(TestFixtures.PurchaseQuantityFixture, props[EventPropertyKeys.Quantity]);
             Assert.AreEqual(TestFixtures.PurchaseTransactionId, props[EventPropertyKeys.TransactionId]);
         }
 
         [Test]
         public void Purchase_OptionalFieldsOmitted_WhenNull()
         {
-            var props = new Purchase { Currency = TestFixtures.EurCurrency, Value = 5.00m }.ToProperties();
+            var props = new Purchase { Currency = TestFixtures.EurCurrency, Value = TestFixtures.PurchaseValueLowFixture }.ToProperties();
 
             Assert.IsTrue(props.ContainsKey(EventPropertyKeys.Currency));
             Assert.IsTrue(props.ContainsKey(EventPropertyKeys.Value));
@@ -154,7 +154,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Purchase_WithoutCurrency_ThrowsOnToProperties()
         {
-            var evt = new Purchase { Value = 9.99m };
+            var evt = new Purchase { Value = TestFixtures.PurchaseValueFixture };
 
             var ex = Assert.Throws<ArgumentException>(() => evt.ToProperties());
             Assert.That(ex!.Message, Does.Contain(nameof(Purchase.Currency)));

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -41,8 +41,8 @@ namespace Immutable.Audience.Tests
                 PublishableKey = TestDefaults.PublishableKey,
                 Consent = consent,
                 PersistentDataPath = _testDir,
-                FlushIntervalSeconds = 600, // large; we flush manually in tests
-                FlushSize = 1000,
+                FlushIntervalSeconds = TestDefaults.FlushIntervalSeconds, // large; we flush manually in tests
+                FlushSize = TestDefaults.FlushSize,
                 HttpHandler = new KeepOnDiskHandler()
             };
         }

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -601,7 +601,7 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.Track(new Purchase
             {
                 Currency = TestFixtures.UsdCurrency,
-                Value = 9.99m
+                Value = TestFixtures.PurchaseValueFixture
             });
             ImmutableAudience.Shutdown();
 

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -582,7 +582,7 @@ namespace Immutable.Audience.Tests
             {
                 Status = ProgressionStatus.Complete,
                 World = TestFixtures.ProgressionWorldTutorial,
-                Level = "1"
+                Level = TestFixtures.ProgressionLevelFixture
             });
             ImmutableAudience.Shutdown();
 

--- a/src/Packages/Audience/Tests/Runtime/MessagesTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/MessagesTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9deb159621114444ca925f3f5614f912
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/TestEventNames.cs
+++ b/src/Packages/Audience/Tests/Runtime/TestEventNames.cs
@@ -34,6 +34,8 @@ namespace Immutable.Audience.Tests
         // Placeholder event names for tests where the event name itself is irrelevant.
         internal const string PlaceholderA = "a";
         internal const string PlaceholderB = "b";
+        internal const string PlaceholderX = "x";
+        internal const string PlaceholderY = "y";
         internal const string PlaceholderTest = "test";
         internal const string PlaceholderTrack = "track";
         internal const string PlaceholderIgnored = "ignored";

--- a/src/Packages/Audience/Tests/Runtime/TestFixtures.cs
+++ b/src/Packages/Audience/Tests/Runtime/TestFixtures.cs
@@ -114,5 +114,15 @@ namespace Immutable.Audience.Tests
         // Resource.Amount fixture used by three TypedEventTests scenarios
         // (Source flow, WithoutFlow guard, WithoutAmount guard).
         internal const float ResourceAmountFixture = 100f;
+
+        // Purchase.Value fixtures.
+        // PurchaseValueFixture (9.99m) is the standard shape; PurchaseValueLowFixture (5.00m) is the optional-fields-omitted variant.
+        internal const decimal PurchaseValueFixture = 9.99m;
+        internal const decimal PurchaseValueLowFixture = 5.00m;
+        internal const int PurchaseQuantityFixture = 1;
+
+        // One-char placeholders for identifier slots when the value content isn't tested.
+        internal const string MinimalIdentifierA = "a";
+        internal const string MinimalIdentifierU = "u";
     }
 }

--- a/src/Packages/Audience/Tests/Runtime/TestFixtures.cs
+++ b/src/Packages/Audience/Tests/Runtime/TestFixtures.cs
@@ -105,5 +105,14 @@ namespace Immutable.Audience.Tests
 
         // Generic single-user fixture for tests that just need any userId.
         internal const string GenericUserSingleId = "user1";
+
+        // Progression payload values used by TypedEventTests and the JsonReaderTests round-trip.
+        internal const string ProgressionLevelFixture = "1";
+        internal const int ProgressionScoreFixture = 1500;
+        internal const float ProgressionDurationSecFixture = 120.5f;
+
+        // Resource.Amount fixture used by three TypedEventTests scenarios
+        // (Source flow, WithoutFlow guard, WithoutAmount guard).
+        internal const float ResourceAmountFixture = 100f;
     }
 }

--- a/src/Packages/Audience/Tests/Runtime/Transport/DiskStoreTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Transport/DiskStoreTests.cs
@@ -165,18 +165,18 @@ namespace Immutable.Audience.Tests
         public void ApplyAnonymousDowngrade_DeletesIdentifyAndAlias_StripsUserIdFromTrack()
         {
             _store.Write(WireFixture.Identify(
-                (MessageFields.AnonymousId, "a"),
-                (MessageFields.UserId, "u")));
+                (MessageFields.AnonymousId, TestFixtures.MinimalIdentifierA),
+                (MessageFields.UserId, TestFixtures.MinimalIdentifierU)));
             _store.Write(WireFixture.Alias(
-                (MessageFields.FromId, "a"),
-                (MessageFields.ToId, "u")));
+                (MessageFields.FromId, TestFixtures.MinimalIdentifierA),
+                (MessageFields.ToId, TestFixtures.MinimalIdentifierU)));
             _store.Write(WireFixture.Track(
-                (MessageFields.EventName, "x"),
-                (MessageFields.AnonymousId, "a"),
-                (MessageFields.UserId, "u")));
+                (MessageFields.EventName, TestEventNames.PlaceholderX),
+                (MessageFields.AnonymousId, TestFixtures.MinimalIdentifierA),
+                (MessageFields.UserId, TestFixtures.MinimalIdentifierU)));
             _store.Write(WireFixture.Track(
-                (MessageFields.EventName, "y"),
-                (MessageFields.AnonymousId, "a")));
+                (MessageFields.EventName, TestEventNames.PlaceholderY),
+                (MessageFields.AnonymousId, TestFixtures.MinimalIdentifierA)));
 
             _store.ApplyAnonymousDowngrade();
 
@@ -209,8 +209,8 @@ namespace Immutable.Audience.Tests
 
                 var json = $"{{\"{MessageFields.Type}\":\"{MessageTypes.Track}\","
                     + $"\"{MessageFields.EventName}\":\"{EventNames.Purchase}\","
-                    + $"\"{MessageFields.AnonymousId}\":\"{TestEventNames.PlaceholderA}\","
-                    + $"\"{MessageFields.UserId}\":\"u\","
+                    + $"\"{MessageFields.AnonymousId}\":\"{TestFixtures.MinimalIdentifierA}\","
+                    + $"\"{MessageFields.UserId}\":\"{TestFixtures.MinimalIdentifierU}\","
                     + $"\"{MessageFields.Properties}\":{{"
                     + $"\"{EventPropertyKeys.Currency}\":\"{TestFixtures.UsdCurrency}\","
                     + $"\"{EventPropertyKeys.Value}\":{amount}}}}}";

--- a/src/Packages/Audience/Tests/Runtime/Transport/DiskStoreTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Transport/DiskStoreTests.cs
@@ -9,6 +9,11 @@ namespace Immutable.Audience.Tests
     [TestFixture]
     internal class DiskStoreTests
     {
+        // File body fixtures for queue scenarios: stale, surviving, malformed.
+        private const string StaleFileBody = "{\"stale\":true}";
+        private const string SurvivingFileBody = "{\"survived\":true}";
+        private const string MalformedFileBody = "{not valid json";
+
         private string _testDir;
         private DiskStore _store;
 
@@ -98,7 +103,7 @@ namespace Immutable.Audience.Tests
             var staleTime = DateTime.UtcNow.AddDays(-(Constants.StaleEventDays + 1));
             var staleName = $"{staleTime.Ticks}_{Guid.NewGuid():N}{AudiencePaths.QueueFileExtension}";
             var queueDir = AudiencePaths.QueueDir(_testDir);
-            File.WriteAllText(Path.Combine(queueDir, staleName), "{\"stale\":true}");
+            File.WriteAllText(Path.Combine(queueDir, staleName), StaleFileBody);
 
             var batch = _store.ReadBatch(10);
 
@@ -152,7 +157,7 @@ namespace Immutable.Audience.Tests
             // Simulate a previous run by writing a file directly
             var queueDir = AudiencePaths.QueueDir(_testDir);
             var survivingName = $"{DateTime.UtcNow.Ticks}_{Guid.NewGuid():N}{AudiencePaths.QueueFileExtension}";
-            File.WriteAllText(Path.Combine(queueDir, survivingName), "{\"survived\":true}");
+            File.WriteAllText(Path.Combine(queueDir, survivingName), SurvivingFileBody);
 
             // Create a new DiskStore instance pointing at the same path (simulates restart)
             var store2 = new DiskStore(_testDir);
@@ -233,7 +238,7 @@ namespace Immutable.Audience.Tests
             // downgrade cannot leave it to potentially leak identified data.
             var queueDir = AudiencePaths.QueueDir(_testDir);
             var badName = $"{DateTime.UtcNow.Ticks}_{Guid.NewGuid():N}{AudiencePaths.QueueFileExtension}";
-            File.WriteAllText(Path.Combine(queueDir, badName), "{not valid json");
+            File.WriteAllText(Path.Combine(queueDir, badName), MalformedFileBody);
 
             _store.ApplyAnonymousDowngrade();
 

--- a/src/Packages/Audience/Tests/Runtime/Transport/EventQueueTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Transport/EventQueueTests.cs
@@ -159,7 +159,7 @@ namespace Immutable.Audience.Tests
         {
             using var queue = new EventQueue(_store, flushIntervalSeconds: 60, flushSize: 100);
 
-            queue.Enqueue(new Dictionary<string, object> { [MessageFields.Type] = MessageTypes.Track, [MessageFields.EventName] = "a" });
+            queue.Enqueue(new Dictionary<string, object> { [MessageFields.Type] = MessageTypes.Track, [MessageFields.EventName] = TestEventNames.PlaceholderA });
             queue.FlushSync();
             queue.Enqueue(new Dictionary<string, object> { [MessageFields.Type] = MessageTypes.Track, [MessageFields.EventName] = "b" });
 

--- a/src/Packages/Audience/Tests/Runtime/Utility/GzipTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Utility/GzipTests.cs
@@ -12,7 +12,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Compress_ProducesValidGzip_ThatDecompressesToOriginal()
         {
-            var original = WireFixture.Track((MessageFields.EventName, "test"));
+            var original = WireFixture.Track((MessageFields.EventName, TestEventNames.PlaceholderTest));
 
             var compressed = Gzip.Compress(original);
 

--- a/src/Packages/Audience/Tests/Runtime/Utility/JsonReaderTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Utility/JsonReaderTests.cs
@@ -92,7 +92,7 @@ namespace Immutable.Audience.Tests
                 [MessageFields.Properties] = new Dictionary<string, object>
                 {
                     [EventPropertyKeys.Status] = ProgressionStatus.Complete.ToLowercaseString(),
-                    [EventPropertyKeys.Score] = 1500
+                    [EventPropertyKeys.Score] = TestFixtures.ProgressionScoreFixture
                 },
                 [MessageFields.AnonymousId] = AnonymousIdFixture,
                 [MessageFields.UserId] = TestFixtures.SteamId64
@@ -107,7 +107,7 @@ namespace Immutable.Audience.Tests
             Assert.AreEqual(TestFixtures.SteamId64, parsed[MessageFields.UserId]);
             var props = (Dictionary<string, object>)parsed[MessageFields.Properties];
             Assert.AreEqual(ProgressionStatus.Complete.ToLowercaseString(), props[EventPropertyKeys.Status]);
-            Assert.AreEqual(1500, props[EventPropertyKeys.Score]);
+            Assert.AreEqual(TestFixtures.ProgressionScoreFixture, props[EventPropertyKeys.Score]);
         }
 
         [Test]

--- a/src/Packages/Audience/Tests/Runtime/WireFixture.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/WireFixture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f2986221b1d948c19e80a2094270d69
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- Centralises sample-app reflection field names (LogEntry struct fields, UI Toolkit `Clickable.clicked`) in `SampleAppTestHelpers`; centralises the per-test panel-user prefix in `SampleAppLiveFireTests`.
- Names the `EventQueue` background drain thread via a private const so the thread surfaces with a stable name in profilers, debuggers, and crash dumps.
- Routes inline `FlushIntervalSeconds` and `FlushSize` test values through `TestDefaults`.
- Centralises `Progression` and `Resource` numeric scenario fixtures in `TestFixtures`.
- Centralises `Purchase` numeric fixtures and minimal one-character identifier placeholders in `TestFixtures`.
- Cleans up missed `Progression.Level` and `Gzip` placeholder references.
- Centralises the `SessionTests` fixed virtual-now fixture used as the starting point for every Session lifecycle test.
- Centralises `DiskStoreTests` file body fixtures (stale, surviving, malformed).
- Adds the missing `.meta` files Unity flags on first project open: `README.md.meta`, `Tests/Editor.meta`, `DeviceCollectorTests.cs.meta`, `MessagesTests.cs.meta`, `WireFixture.cs.meta`.
- No behaviour change. Wire format and `OnError` callback contract unchanged.

Linear: [SDK-277](https://linear.app/imtbl/issue/SDK-277/centralise-duplicated-literals-across-unity-audience-sdk-runtime-tests)
