### PR TITLE
chore(audience-sample): remove page() button from sample app (SDK-314)

### DIFF
--- a/examples/audience/Assets/SampleApp/Resources/AudienceSample.uxml
+++ b/examples/audience/Assets/SampleApp/Resources/AudienceSample.uxml
@@ -125,11 +125,6 @@
                         <ui:VisualElement class="actions last">
                             <ui:Button name="btn-init" text="Init" />
 
-                            <ui:Button name="btn-page" class="with-sig">
-                                <ui:Label class="btn-label" text="Page" />
-                                <ui:Label class="btn-sig" text="page()" />
-                            </ui:Button>
-
                             <ui:Button name="btn-flush" class="with-sig">
                                 <ui:Label class="btn-label" text="Flush" />
                                 <ui:Label class="btn-sig" text="flush()" />

--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.UI.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.UI.cs
@@ -53,7 +53,7 @@ namespace Immutable.Audience.Samples.SampleApp
         private TextField _publishableKey, _baseUrl, _flushInterval, _flushSize;
         private DropdownField _initialConsent;
         private Toggle _debug;
-        private Button _btnInit, _btnPage, _btnFlush, _btnReset, _btnShutdown, _btnDeleteData;
+        private Button _btnInit, _btnFlush, _btnReset, _btnShutdown, _btnDeleteData;
 
         // ---- UXML element fields (Consent tab) ----
 
@@ -195,7 +195,7 @@ namespace Immutable.Audience.Samples.SampleApp
             _flushInterval = Require<TextField>("flush-interval");
             _flushSize     = Require<TextField>("flush-size");
             _btnInit       = Require<Button>("btn-init");
-            _btnPage       = Require<Button>("btn-page");
+
             _btnFlush      = Require<Button>("btn-flush");
             _btnReset      = Require<Button>("btn-reset");
             _btnShutdown   = Require<Button>("btn-shutdown");
@@ -304,7 +304,7 @@ namespace Immutable.Audience.Samples.SampleApp
             _baseUrl.RegisterValueChangedCallback(_ => RefreshStatusBar());
 
             _btnInit.clicked += OnInit;
-            _btnPage.clicked += OnPage;
+
             _btnFlush.clicked += async () => await OnFlushAsync();
             _btnReset.clicked += OnReset;
             _btnShutdown.clicked += OnShutdown;
@@ -614,7 +614,7 @@ namespace Immutable.Audience.Samples.SampleApp
 
         private void RefreshInitState()
         {
-            foreach (var b in new[] { _btnPage, _btnFlush, _btnReset, _btnShutdown, _btnDeleteData, _btnCustomEvent, _btnIdentify, _btnIdentifyTraits })
+            foreach (var b in new[] { _btnFlush, _btnReset, _btnShutdown, _btnDeleteData, _btnCustomEvent, _btnIdentify, _btnIdentifyTraits })
                 b.SetEnabled(_initialised);
             foreach (var p in _consentPills.Values) p.SetEnabled(_initialised);
             foreach (var btn in _typedEventsHost.Query<Button>().ToList()) btn.SetEnabled(_initialised);

--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using UnityEngine.UIElements;
 
 namespace Immutable.Audience.Samples.SampleApp
@@ -103,17 +102,6 @@ namespace Immutable.Audience.Samples.SampleApp
         }
 
         // ---- SDK action handlers: telemetry ----
-
-        // v1 has no typed Screen API; Plan §10 specifies a custom Track call
-        // as the studio-facing pattern for scene coverage. Demo follows that.
-        private void OnPage() => RunAndLog("page()", () =>
-        {
-            GuardConsentForTrack();
-            var screen = SceneManager.GetActiveScene().name;
-            var props = new Dictionary<string, object> { ["path"] = screen };
-            ImmutableAudience.Track("screen_viewed", props);
-            return Json.Serialize(props, 2);
-        });
 
         // Prefers the typed overload for the four events with public C#
         // classes (Progression, Resource, Purchase, MilestoneReached); the

--- a/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
@@ -133,8 +133,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         {
             yield return LoadAndInit();
 
-            // Page-view track via btn-page; the test doesn't wait on its row.
-            _root!.Q<Button>(SampleAppUi.Buttons.Page).Click();
+            _root!.Q<Button>(SampleAppUi.Buttons.TypedEvent("progression")).Click();
             yield return null;
 
             yield return FlushAndAssertNoErrors();
@@ -228,7 +227,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
             // Init at default Anonymous; enqueue an event; revoke; flush — no errors.
             yield return LoadAndInit();
 
-            _root!.Q<Button>(SampleAppUi.Buttons.Page).Click();
+            _root!.Q<Button>(SampleAppUi.Buttons.TypedEvent("progression")).Click();
             yield return null;
 
             yield return SetConsentVia(SampleAppUi.Buttons.ConsentNone);
@@ -281,7 +280,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
             // those if their types/methods aren't reachable from a root assembly.
             yield return LoadAndInit();
 
-            _root!.Q<Button>(SampleAppUi.Buttons.Page).Click();
+            _root!.Q<Button>(SampleAppUi.Buttons.TypedEvent("progression")).Click();
             yield return null;
 
             _root.Q<Button>(SampleAppUi.Buttons.Shutdown).Click();
@@ -298,13 +297,13 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
             // round-trip to sandbox without errors.
             yield return LoadAndInit();
 
-            _root!.Q<Button>(SampleAppUi.Buttons.Page).Click();
+            _root!.Q<Button>(SampleAppUi.Buttons.TypedEvent("progression")).Click();
             yield return null;
 
             _root.Q<Button>(SampleAppUi.Buttons.Reset).Click();
             yield return SampleAppTestHelpers.WaitForLogEntry(_root, SampleAppUi.LogLabels.Reset, LogLevels.Ok, 5f);
 
-            _root.Q<Button>(SampleAppUi.Buttons.Page).Click();
+            _root.Q<Button>(SampleAppUi.Buttons.TypedEvent("progression")).Click();
             yield return null;
 
             yield return FlushAndAssertNoErrors();
@@ -347,7 +346,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
             Assert.Greater(SampleAppTestHelpers.CountLogEntriesAtLevel(_root, LogLevels.Ok), 1,
                 "expected a second INIT@Ok row after re-init");
 
-            _root.Q<Button>(SampleAppUi.Buttons.Page).Click();
+            _root.Q<Button>(SampleAppUi.Buttons.TypedEvent("progression")).Click();
             yield return null;
 
             yield return FlushAndAssertNoErrors();
@@ -368,7 +367,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
 
             yield return SetConsentVia(SampleAppUi.Buttons.ConsentAnon);
 
-            _root.Q<Button>(SampleAppUi.Buttons.Page).Click();
+            _root.Q<Button>(SampleAppUi.Buttons.TypedEvent("progression")).Click();
             yield return null;
 
             yield return FlushAndAssertNoErrors();
@@ -467,7 +466,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
                 root.Q<TextField>(SampleAppUi.Setup.BaseUrl).value = SampleAppUi.SandboxBaseUrl;
             });
 
-            _root!.Q<Button>(SampleAppUi.Buttons.Page).Click();
+            _root!.Q<Button>(SampleAppUi.Buttons.TypedEvent("progression")).Click();
             yield return null;
 
             yield return FlushAndAssertNoErrors();
@@ -499,7 +498,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
                 root.Q<TextField>(SampleAppUi.Setup.FlushSize).value = "5";
             });
 
-            _root!.Q<Button>(SampleAppUi.Buttons.Page).Click();
+            _root!.Q<Button>(SampleAppUi.Buttons.TypedEvent("progression")).Click();
             yield return null;
 
             yield return FlushAndAssertNoErrors();
@@ -515,7 +514,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
                 root.Q<Toggle>(SampleAppUi.Setup.Debug).value = false;
             });
 
-            _root!.Q<Button>(SampleAppUi.Buttons.Page).Click();
+            _root!.Q<Button>(SampleAppUi.Buttons.TypedEvent("progression")).Click();
             yield return null;
 
             yield return FlushAndAssertNoErrors();
@@ -524,13 +523,13 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         [UnityTest]
         public IEnumerator MultiEvent_SingleFlush_NoErrors()
         {
-            // Five page Tracks queued up, single Flush. Exercises queue
+            // Five Tracks queued up, single Flush. Exercises queue
             // batching + gzip + multi-event payload serialisation under IL2CPP.
             yield return LoadAndInit();
 
             for (var i = 0; i < 5; i++)
             {
-                _root!.Q<Button>(SampleAppUi.Buttons.Page).Click();
+                _root!.Q<Button>(SampleAppUi.Buttons.TypedEvent("progression")).Click();
                 yield return null;
             }
 
@@ -609,14 +608,14 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         {
             // Init auto-fires session_start + game_launch so the queue is
             // already non-zero by the time the status label paints. Capture
-            // the baseline and assert btn-page bumps it by at least one.
+            // the baseline and assert a progression Track bumps it by at least one.
             yield return LoadAndInit();
             yield return null;
 
             var queueLabel = _root!.Q<Label>(SampleAppUi.StatusBar.Queue);
             int.TryParse(queueLabel.text, out var baseline);
 
-            _root.Q<Button>(SampleAppUi.Buttons.Page).Click();
+            _root.Q<Button>(SampleAppUi.Buttons.TypedEvent("progression")).Click();
             yield return null;
             var deadline = Time.realtimeSinceStartup + 2f;
             while (Time.realtimeSinceStartup < deadline)
@@ -628,7 +627,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
 
             int.TryParse(queueLabel.text, out var finalCount);
             Assert.Greater(finalCount, baseline,
-                $"queue should grow past baseline {baseline} after btn-page Track; got {finalCount}");
+                $"queue should grow past baseline {baseline} after progression Track; got {finalCount}");
         }
 
         [UnityTest]

--- a/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppUi.cs
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppUi.cs
@@ -48,7 +48,6 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         internal static class Buttons
         {
             internal const string Init = "btn-init";
-            internal const string Page = "btn-page";
             internal const string Flush = "btn-flush";
             internal const string Reset = "btn-reset";
             internal const string Shutdown = "btn-shutdown";
@@ -152,7 +151,6 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         internal static class LogLabels
         {
             internal const string Init = "INIT";
-            internal const string Page = "page()";
             internal const string Flush = "flush()";
             internal const string Reset = "reset()";
             internal const string Shutdown = "shutdown()";


### PR DESCRIPTION
The `page()` button called `Track("screen_viewed")` via a custom event rather than a dedicated SDK Page API, and was out of place sitting alongside Init/Teardown controls. Studios can replicate the pattern from the Typed Events tab using a custom Track call.

Removes the button from UXML, the `_btnPage` field, `OnPage()` handler, and the now-unused `SceneManagement` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk sample-app-only UI/test refactor that removes a non-SDK `page()` helper; main risk is minor test/UI wiring regressions (missing element names/callbacks).
> 
> **Overview**
> Removes the `page()` button from the sample app setup UXML and deletes the associated `_btnPage` wiring, enable/disable logic, and `OnPage()` handler (including the now-unused `SceneManagement` dependency).
> 
> Updates runtime live-fire tests and shared UI constants to stop referencing `btn-page`/`page()` and instead enqueue a representative typed event (e.g., `progression`) before flushing or asserting queue growth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f283d49a92a4c08c7a152916a95d075046a3e02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->