### PR TITLE
feat(audience-sample): enable iOS build target (SDK-295)

### DIFF
--- a/examples/audience/Assets/Editor/IosBuilder.cs
+++ b/examples/audience/Assets/Editor/IosBuilder.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace Immutable.Audience.Samples.SampleApp.Editor
+{
+    // Invoked by CI via:
+    //   Unity -batchmode -buildTarget iOS \
+    //         -executeMethod Immutable.Audience.Samples.SampleApp.Editor.IosBuilder.Build \
+    //         -quit
+    //
+    // Optional CLI arg:
+    //   --buildPath <path>   Output directory for the Xcode project (default: Builds/iOS)
+    internal static class IosBuilder
+    {
+        private const string DefaultBuildPath = "Builds/iOS";
+
+        public static void Build()
+        {
+            string buildPath = GetArgValue("--buildPath") ?? DefaultBuildPath;
+
+            var options = new BuildPlayerOptions
+            {
+                scenes = new[] { "Assets/SampleApp/Scenes/SampleApp.unity" },
+                locationPathName = buildPath,
+                target = BuildTarget.iOS,
+                targetGroup = BuildTargetGroup.iOS,
+                options = BuildOptions.None,
+            };
+
+            Debug.Log($"[IosBuilder] Building Xcode project → {buildPath}");
+
+            var report = BuildPipeline.BuildPlayer(options);
+            var summary = report.summary;
+
+            if (summary.result == UnityEditor.Build.Reporting.BuildResult.Succeeded)
+            {
+                Debug.Log($"[IosBuilder] Build succeeded ({summary.totalSize / 1024 / 1024} MB).");
+            }
+            else
+            {
+                Debug.LogError($"[IosBuilder] Build failed: {summary.totalErrors} error(s).");
+                EditorApplication.Exit(1);
+            }
+        }
+
+        private static string? GetArgValue(string flag)
+        {
+            var args = Environment.GetCommandLineArgs();
+            for (int i = 0; i < args.Length - 1; i++)
+            {
+                if (args[i] == flag)
+                    return args[i + 1];
+            }
+            return null;
+        }
+    }
+}

--- a/examples/audience/Assets/Editor/IosBuilder.cs.meta
+++ b/examples/audience/Assets/Editor/IosBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d43b5059882b14bf5ad2ca931fa8c788
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/examples/audience/Assets/Editor/ScriptingBackendOverride.cs
+++ b/examples/audience/Assets/Editor/ScriptingBackendOverride.cs
@@ -18,11 +18,12 @@ namespace Immutable.Audience.Samples.SampleApp.Editor
     //   Mono   → Disabled (Mono studios rarely strip; High under Mono can
     //                      strip Net.Http SSL chain code paths).
     //
-    // Supported targets: Standalone, Android.
+    // Supported targets: Standalone, Android, iOS.
     //
     // Usage:
     //   AUDIENCE_SCRIPTING_BACKEND=Mono2x Unity -batchmode -runTests ...
     //   AUDIENCE_SCRIPTING_BACKEND=IL2CPP Unity -batchmode -buildTarget Android ...
+    //   AUDIENCE_SCRIPTING_BACKEND=IL2CPP Unity -batchmode -buildTarget iOS ...
     //
     // Unset means "respect ProjectSettings.asset as-is".
     internal sealed class ScriptingBackendOverride : IPreprocessBuildWithReport
@@ -45,7 +46,7 @@ namespace Immutable.Audience.Samples.SampleApp.Editor
             };
 
             var group = report.summary.platformGroup;
-            if (group != BuildTargetGroup.Standalone && group != BuildTargetGroup.Android)
+            if (group != BuildTargetGroup.Standalone && group != BuildTargetGroup.Android && group != BuildTargetGroup.iOS)
                 return;
 
             var currentBackend = PlayerSettings.GetScriptingBackend(group);

--- a/examples/audience/ProjectSettings/ProjectSettings.asset
+++ b/examples/audience/ProjectSettings/ProjectSettings.asset
@@ -12,7 +12,7 @@ PlayerSettings:
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
-  companyName: DefaultCompany
+  companyName: Immutable
   productName: audience
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
@@ -157,7 +157,9 @@ PlayerSettings:
   resetResolutionOnWindowResize: 0
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
-  applicationIdentifier: {}
+  applicationIdentifier:
+    iPhone: com.immutable.audience
+    Android: com.immutable.audience
   buildNumber:
     Standalone: 0
     iPhone: 0
@@ -179,7 +181,7 @@ PlayerSettings:
   StripUnusedMeshComponents: 1
   VertexChannelCompressionMask: 4054
   iPhoneSdkVersion: 988
-  iOSTargetOSVersionString: 12.0
+  iOSTargetOSVersionString: 13.0
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0
   tvOSTargetOSVersionString: 12.0
@@ -232,7 +234,7 @@ PlayerSettings:
   tvOSManualSigningProvisioningProfileID: 
   iOSManualSigningProvisioningProfileType: 0
   tvOSManualSigningProvisioningProfileType: 0
-  appleEnableAutomaticSigning: 0
+  appleEnableAutomaticSigning: 1
   iOSRequireARKit: 0
   iOSAutomaticallyDetectAndAddCapabilities: 1
   appleEnableProMotion: 0
@@ -272,7 +274,196 @@ PlayerSettings:
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 150
   m_BuildTargetIcons: []
-  m_BuildTargetPlatformIcons: []
+  m_BuildTargetPlatformIcons:
+  - m_BuildTarget: iPhone
+    m_Icons:
+    - m_Textures: []
+      m_Width: 180
+      m_Height: 180
+      m_Kind: 0
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 120
+      m_Height: 120
+      m_Kind: 0
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 167
+      m_Height: 167
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 152
+      m_Height: 152
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 76
+      m_Height: 76
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 120
+      m_Height: 120
+      m_Kind: 3
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 80
+      m_Height: 80
+      m_Kind: 3
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 80
+      m_Height: 80
+      m_Kind: 3
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 40
+      m_Height: 40
+      m_Kind: 3
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 87
+      m_Height: 87
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 58
+      m_Height: 58
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 29
+      m_Height: 29
+      m_Kind: 1
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 58
+      m_Height: 58
+      m_Kind: 1
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 29
+      m_Height: 29
+      m_Kind: 1
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 60
+      m_Height: 60
+      m_Kind: 2
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 40
+      m_Height: 40
+      m_Kind: 2
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 40
+      m_Height: 40
+      m_Kind: 2
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 20
+      m_Height: 20
+      m_Kind: 2
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 1024
+      m_Height: 1024
+      m_Kind: 4
+      m_SubKind: App Store
+  - m_BuildTarget: Android
+    m_Icons:
+    - m_Textures: []
+      m_Width: 432
+      m_Height: 432
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 324
+      m_Height: 324
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 216
+      m_Height: 216
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 162
+      m_Height: 162
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 108
+      m_Height: 108
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 81
+      m_Height: 81
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 192
+      m_Height: 192
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 144
+      m_Height: 144
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 96
+      m_Height: 96
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 72
+      m_Height: 72
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 48
+      m_Height: 48
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 36
+      m_Height: 36
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 192
+      m_Height: 192
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 144
+      m_Height: 144
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 96
+      m_Height: 96
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 72
+      m_Height: 72
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 48
+      m_Height: 48
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 36
+      m_Height: 36
+      m_Kind: 0
+      m_SubKind: 
   m_BuildTargetBatching:
   - m_BuildTarget: Standalone
     m_StaticBatching: 1
@@ -623,6 +814,7 @@ PlayerSettings:
   scriptingBackend:
     Android: 1
     Standalone: 1
+    iPhone: 1
   il2cppCompilerConfiguration: {}
   managedStrippingLevel:
     EmbeddedLinux: 1
@@ -637,7 +829,7 @@ PlayerSettings:
     WebGL: 1
     Windows Store Apps: 1
     XboxOne: 1
-    iPhone: 1
+    iPhone: 3
     tvOS: 1
   incrementalIl2cppBuild: {}
   suppressCommonWarnings: 1

--- a/src/Packages/Audience/Runtime/Unity/com.immutable.audience.unity.asmdef
+++ b/src/Packages/Audience/Runtime/Unity/com.immutable.audience.unity.asmdef
@@ -2,7 +2,7 @@
     "name": "Immutable.Audience.Unity",
     "rootNamespace": "Immutable.Audience.Unity",
     "references": ["Immutable.Audience.Runtime"],
-    "includePlatforms": ["Android", "Editor", "macOSStandalone", "WindowsStandalone64"],
+    "includePlatforms": ["Android", "Editor", "iOS", "macOSStandalone", "WindowsStandalone64"],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/src/Packages/Audience/Runtime/com.immutable.audience.asmdef
+++ b/src/Packages/Audience/Runtime/com.immutable.audience.asmdef
@@ -2,7 +2,7 @@
     "name": "Immutable.Audience.Runtime",
     "rootNamespace": "Immutable.Audience",
     "references": [],
-    "includePlatforms": ["Android", "Editor", "macOSStandalone", "WindowsStandalone64"],
+    "includePlatforms": ["Android", "Editor", "iOS", "macOSStandalone", "WindowsStandalone64"],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
## Summary

- Add `iOS` to `includePlatforms` in both runtime asmdefs so SDK types compile for iOS target
- Add `IosBuilder.cs` editor script for batchmode Xcode project generation via `-executeMethod`
- Extend `ScriptingBackendOverride` to support `BuildTargetGroup.iOS`
- Bump `iOSTargetOSVersionString` 12.0 → 13.0 (`IPHONEOS_DEPLOYMENT_TARGET = 13.0` confirmed in generated project)
- Set iPhone scripting backend to IL2CPP and managed stripping to High
- Set bundle ID `com.immutable.audience` and enable automatic Xcode signing

Verified locally: `Unity -batchmode -buildTarget iOS -executeMethod ...IosBuilder.Build` produces an Xcode project with no IL2CPP errors and `IPHONEOS_DEPLOYMENT_TARGET = 13.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)