### PR TITLE
feat(audience-sdk): iOS IDFV bridge and device signals (SDK-297, SDK-298)

### DIFF
--- a/src/Packages/Audience/Runtime/Plugins.meta
+++ b/src/Packages/Audience/Runtime/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Runtime/Plugins/iOS.meta
+++ b/src/Packages/Audience/Runtime/Plugins/iOS.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a8b9c0d1e2f3a4b5c6f1a2b3c4d5e6f7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Runtime/Plugins/iOS/AudienceMobileBridge.mm
+++ b/src/Packages/Audience/Runtime/Plugins/iOS/AudienceMobileBridge.mm
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+extern "C" {
+
+const char* _AudienceGetIDFV(void)
+{
+    NSString *idfv = [[UIDevice currentDevice].identifierForVendor UUIDString];
+    // strdup: IL2CPP calls free() on the returned pointer after copying into a
+    // managed string. UTF8String is autoreleased (not malloc'd), so free() would
+    // crash — strdup gives IL2CPP a heap-allocated copy it can safely free.
+    return idfv ? strdup([idfv UTF8String]) : NULL;
+}
+
+}

--- a/src/Packages/Audience/Runtime/Plugins/iOS/AudienceMobileBridge.mm.meta
+++ b/src/Packages/Audience/Runtime/Plugins/iOS/AudienceMobileBridge.mm.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: d5e6f7a8b9c0d1e2f3a4b5c6f1a2b3c4
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any:
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Runtime/Unity/DeviceCollector.cs
+++ b/src/Packages/Audience/Runtime/Unity/DeviceCollector.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using Immutable.Audience.Unity.Mobile;
 using UnityEngine;
 
 namespace Immutable.Audience.Unity
@@ -45,11 +46,13 @@ namespace Immutable.Audience.Unity
             return $"{width}x{height}";
         }
 
-        internal static Dictionary<string, object> CollectGameLaunchProperties()
+        internal static Dictionary<string, object> CollectGameLaunchProperties(
+            RuntimePlatform? platformOverride = null)
         {
+            var platform = platformOverride ?? Application.platform;
             var props = new Dictionary<string, object>
             {
-                ["platform"] = Application.platform.ToString(),
+                ["platform"] = PlatformName(platform),
                 ["version"] = Truncate(Application.version, 256),
                 ["buildGuid"] = Truncate(Application.buildGUID, 256),
                 ["unityVersion"] = Truncate(Application.unityVersion, 256),
@@ -66,8 +69,17 @@ namespace Immutable.Audience.Unity
             var dpi = (int)Screen.dpi;
             if (dpi > 0) props["screenDpi"] = dpi;
 
-            if (Application.platform == RuntimePlatform.Android)
+            if (platform == RuntimePlatform.Android)
                 props["androidId"] = Truncate(SystemInfo.deviceUniqueIdentifier, 256);
+
+            if (platform == RuntimePlatform.IPhonePlayer)
+            {
+                var idfv = IDFVBridge.GetIDFV();
+                if (idfv != null) props["idfv"] = Truncate(idfv, 256);
+
+                // iOS baseline is 163 DPI (1×); 326 → 2×, 401-460 → 3×.
+                if (dpi > 0) props["screenScale"] = (int)Math.Round(dpi / 163.0);
+            }
 
             return props;
         }
@@ -91,6 +103,12 @@ namespace Immutable.Audience.Unity
                 return null;
             }
         }
+
+        private static string PlatformName(RuntimePlatform platform) => platform switch
+        {
+            RuntimePlatform.IPhonePlayer => "iOS",
+            _ => platform.ToString(),
+        };
 
         private static string Truncate(string s, int max)
         {

--- a/src/Packages/Audience/Runtime/Unity/Mobile.meta
+++ b/src/Packages/Audience/Runtime/Unity/Mobile.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c6f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Runtime/Unity/Mobile/IDFVBridge.cs
+++ b/src/Packages/Audience/Runtime/Unity/Mobile/IDFVBridge.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+using System;
+#if UNITY_IOS
+using System.Runtime.InteropServices;
+#endif
+
+namespace Immutable.Audience.Unity.Mobile
+{
+    internal static class IDFVBridge
+    {
+        // Replaceable in tests — captures NativeImpl by default.
+        internal static Func<string?> Impl = NativeImpl;
+
+        internal static string? GetIDFV() => Impl();
+
+#if UNITY_IOS
+        [DllImport("__Internal")]
+        private static extern string _AudienceGetIDFV();
+
+        private static string? NativeImpl() => _AudienceGetIDFV();
+#else
+        private static string? NativeImpl() => null;
+#endif
+    }
+}

--- a/src/Packages/Audience/Runtime/Unity/Mobile/IDFVBridge.cs.meta
+++ b/src/Packages/Audience/Runtime/Unity/Mobile/IDFVBridge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5c6f1a2b3c4d5e6f7a8b9c0d1e2f3a4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Tests/Runtime/Unity.meta
+++ b/src/Packages/Audience/Tests/Runtime/Unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a1e7b0311bc046c58431b2a9b9537ec0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Packages/Audience/Tests/Runtime/Unity/DeviceCollectorTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Unity/DeviceCollectorTests.cs
@@ -1,8 +1,11 @@
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using Immutable.Audience.Unity;
+using Immutable.Audience.Unity.Mobile;
+using UnityEngine;
 
 namespace Immutable.Audience.Tests
 {
@@ -88,6 +91,53 @@ namespace Immutable.Audience.Tests
             var props = DeviceCollector.CollectGameLaunchProperties();
             if (props.TryGetValue("screenDpi", out var dpi))
                 Assert.Greater((int)dpi, 0, "screenDpi must not be 0 when present");
+        }
+
+        // -----------------------------------------------------------------
+        // iOS-specific (IDFVBridge + screenScale)
+        // -----------------------------------------------------------------
+
+        private Func<string?>? _originalIDFVImpl;
+
+        [SetUp]
+        public void SetUp() => _originalIDFVImpl = IDFVBridge.Impl;
+
+        [TearDown]
+        public void TearDown() => IDFVBridge.Impl = _originalIDFVImpl!;
+
+        [Test]
+        public void CollectGameLaunchProperties_iOS_IdfvPresentWhenBridgeReturnsValue()
+        {
+            IDFVBridge.Impl = () => "12345678-ABCD-ABCD-ABCD-123456789ABC";
+            var props = DeviceCollector.CollectGameLaunchProperties(RuntimePlatform.IPhonePlayer);
+            Assert.IsTrue(props.ContainsKey("idfv"), "idfv must be present when bridge returns a value");
+            Assert.AreEqual("12345678-ABCD-ABCD-ABCD-123456789ABC", props["idfv"]);
+        }
+
+        [Test]
+        public void CollectGameLaunchProperties_iOS_IdfvAbsentWhenBridgeReturnsNull()
+        {
+            IDFVBridge.Impl = () => null;
+            var props = DeviceCollector.CollectGameLaunchProperties(RuntimePlatform.IPhonePlayer);
+            Assert.IsFalse(props.ContainsKey("idfv"), "idfv must be absent when bridge returns null");
+        }
+
+        [Test]
+        public void CollectGameLaunchProperties_NonIOS_DoesNotContainIdfv()
+        {
+            // IDFVBridge must never be called on non-iOS platforms.
+            IDFVBridge.Impl = () => "should-not-appear";
+            var props = DeviceCollector.CollectGameLaunchProperties();
+            Assert.IsFalse(props.ContainsKey("idfv"),
+                "idfv must not be present on non-iOS platforms");
+        }
+
+        [Test]
+        public void CollectGameLaunchProperties_iOS_ContainsPlatformIPhonePlayer()
+        {
+            IDFVBridge.Impl = () => null;
+            var props = DeviceCollector.CollectGameLaunchProperties(RuntimePlatform.IPhonePlayer);
+            Assert.AreEqual("iOS", props["platform"]);
         }
     }
 }

--- a/src/Packages/Audience/Tests/Runtime/Unity/DeviceCollectorTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/Unity/DeviceCollectorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e14410d1150445b88b78f29cb003d289
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

IDFV (Identifier for Vendor) is Apple's per-device, per-vendor UUID — the iOS equivalent of Android ID. It persists until all apps from the same vendor are uninstalled and does not require ATT permission.

- Adds `AudienceMobileBridge.mm` (iOS-only native plugin) to read IDFV from `UIDevice` and expose it via a `__Internal` C function
- Adds `IDFVBridge.cs` wrapping the native call on iOS, returning null on all other platforms
- Wires `idfv` and `screenScale` into `DeviceCollector` for `IPhonePlayer` only
- Normalises `platform` from `"IPhonePlayer"` → `"iOS"`

Closes SDK-297, closes SDK-298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)