### PR TITLE
ci(audience): add Android + iOS IL2CPP build cells via GameCI (SDK-313)

### DIFF
--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -86,6 +86,57 @@ jobs:
             unity: 2022.3.62f2
             changeset: 7670c08855a9
             runner: [self-hosted, macOS, ARM64]
+          # Mobile IL2CPP build cells — macOS only, no device required.
+          # Validates the IL2CPP compile pipeline; runtime tests need a real device
+          # and are out of scope until a device farm is available.
+          - target: Android
+            backend: IL2CPP
+            unity: 2021.3.45f2
+            changeset: 88f88f591b2e
+            runner: [self-hosted, macOS, ARM64]
+            mobile: true
+            module: android
+            method: AndroidBuilder.Build
+          - target: Android
+            backend: IL2CPP
+            unity: 2022.3.62f2
+            changeset: 7670c08855a9
+            runner: [self-hosted, macOS, ARM64]
+            mobile: true
+            module: android
+            method: AndroidBuilder.Build
+          - target: Android
+            backend: IL2CPP
+            unity: 6000.4.0f1
+            changeset: 8cf496087c8f
+            runner: [self-hosted, macOS, ARM64]
+            mobile: true
+            module: android
+            method: AndroidBuilder.Build
+          - target: iOS
+            backend: IL2CPP
+            unity: 2021.3.45f2
+            changeset: 88f88f591b2e
+            runner: [self-hosted, macOS, ARM64]
+            mobile: true
+            module: ios
+            method: IosBuilder.Build
+          - target: iOS
+            backend: IL2CPP
+            unity: 2022.3.62f2
+            changeset: 7670c08855a9
+            runner: [self-hosted, macOS, ARM64]
+            mobile: true
+            module: ios
+            method: IosBuilder.Build
+          - target: iOS
+            backend: IL2CPP
+            unity: 6000.4.0f1
+            changeset: 8cf496087c8f
+            runner: [self-hosted, macOS, ARM64]
+            mobile: true
+            module: ios
+            method: IosBuilder.Build
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
 
@@ -200,7 +251,14 @@ jobs:
             || echo "(install non-zero — OK if 'Editor already installed in this location')"
           echo "::endgroup::"
 
-          if [ "${{ matrix.backend }}" = "IL2CPP" ]; then
+          if [ "${{ matrix.mobile }}" = "true" ]; then
+            echo "::group::install ${{ matrix.module }} module"
+            "$HUB" -- --headless install-modules \
+              --version "$UNITY_VER" --changeset "$UNITY_CS" --architecture arm64 \
+              --module "${{ matrix.module }}" \
+              || echo "(install-modules non-zero — OK if 'No modules found to install')"
+            echo "::endgroup::"
+          elif [ "${{ matrix.backend }}" = "IL2CPP" ]; then
             echo "::group::install mac-il2cpp module"
             "$HUB" -- --headless install-modules \
               --version "$UNITY_VER" --changeset "$UNITY_CS" --architecture arm64 \
@@ -227,7 +285,7 @@ jobs:
 
           MISSING=""
           [ -z "$EDITOR_APP" ] && MISSING="editor"
-          [ "${{ matrix.backend }}" = "IL2CPP" ] && [ -z "$IL2CPP_DIR" ] && MISSING="${MISSING:+$MISSING+}mac-il2cpp"
+          [ "${{ matrix.backend }}" = "IL2CPP" ] && [ "${{ matrix.mobile }}" != "true" ] && [ -z "$IL2CPP_DIR" ] && MISSING="${MISSING:+$MISSING+}mac-il2cpp"
           if [ -n "$MISSING" ]; then
             echo "::error::Unity $UNITY_VER missing: $MISSING"
             ls -la /Applications/Unity/Hub/Editor/ 2>&1 || true
@@ -281,7 +339,7 @@ jobs:
           "UNITY_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Run PlayMode tests (macOS)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && matrix.mobile != true
         shell: bash
         env:
           AUDIENCE_TEST_PUBLISHABLE_KEY: ${{ secrets.AUDIENCE_TEST_PUBLISHABLE_KEY }}
@@ -301,6 +359,20 @@ jobs:
             -runTests \
             -testPlatform ${{ matrix.target }} \
             -testResults "$(pwd)/artifacts/test-results.xml" \
+            -logFile - 2>&1 | tee "$(pwd)/artifacts/unity.log"
+
+      - name: Build mobile target (macOS)
+        if: runner.os == 'macOS' && matrix.mobile == true
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          "$UNITY_PATH" \
+            -batchmode -nographics \
+            -projectPath examples/audience \
+            -buildTarget ${{ matrix.target }} \
+            -executeMethod Immutable.Audience.Samples.SampleApp.Editor.${{ matrix.method }} \
+            -quit \
             -logFile - 2>&1 | tee "$(pwd)/artifacts/unity.log"
 
       - name: Run PlayMode tests (Windows)
@@ -336,7 +408,7 @@ jobs:
           git config --global --add safe.directory $env:GITHUB_WORKSPACE.Replace('\','/')
 
       - name: Capture player log (macOS)
-        if: always() && runner.os == 'macOS'
+        if: always() && runner.os == 'macOS' && matrix.mobile != true
         shell: bash
         run: |
           # The test-runner builds + launches a player binary that writes its own
@@ -416,7 +488,7 @@ jobs:
 
       - name: Publish test report
         uses: dorny/test-reporter@v3
-        if: always()
+        if: always() && matrix.mobile != true
         with:
           name: PlayMode (${{ matrix.backend }} / ${{ matrix.target }})
           path: artifacts/test-results.xml
@@ -424,11 +496,21 @@ jobs:
           fail-on-error: true
 
       - uses: actions/upload-artifact@v4
-        if: always()
+        if: always() && matrix.mobile != true
         with:
           name: playmode-${{ matrix.backend }}-${{ matrix.target }}-${{ matrix.unity }}
           path: |
             artifacts/test-results.xml
             artifacts/unity.log
             artifacts/Player-*.log
+            examples/audience/Logs/**
+
+      - uses: actions/upload-artifact@v4
+        if: always() && matrix.mobile == true
+        with:
+          name: mobile-build-${{ matrix.target }}-${{ matrix.unity }}
+          if-no-files-found: ignore
+          path: |
+            artifacts/unity.log
+            examples/audience/Builds/Android/*.apk
             examples/audience/Logs/**

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -86,57 +86,6 @@ jobs:
             unity: 2022.3.62f2
             changeset: 7670c08855a9
             runner: [self-hosted, macOS, ARM64]
-          # Mobile IL2CPP build cells — macOS only, no device required.
-          # Validates the IL2CPP compile pipeline; runtime tests need a real device
-          # and are out of scope until a device farm is available.
-          - target: Android
-            backend: IL2CPP
-            unity: 2021.3.45f2
-            changeset: 88f88f591b2e
-            runner: [self-hosted, macOS, ARM64]
-            mobile: true
-            module: android
-            method: AndroidBuilder.Build
-          - target: Android
-            backend: IL2CPP
-            unity: 2022.3.62f2
-            changeset: 7670c08855a9
-            runner: [self-hosted, macOS, ARM64]
-            mobile: true
-            module: android
-            method: AndroidBuilder.Build
-          - target: Android
-            backend: IL2CPP
-            unity: 6000.4.0f1
-            changeset: 8cf496087c8f
-            runner: [self-hosted, macOS, ARM64]
-            mobile: true
-            module: android
-            method: AndroidBuilder.Build
-          - target: iOS
-            backend: IL2CPP
-            unity: 2021.3.45f2
-            changeset: 88f88f591b2e
-            runner: [self-hosted, macOS, ARM64]
-            mobile: true
-            module: ios
-            method: IosBuilder.Build
-          - target: iOS
-            backend: IL2CPP
-            unity: 2022.3.62f2
-            changeset: 7670c08855a9
-            runner: [self-hosted, macOS, ARM64]
-            mobile: true
-            module: ios
-            method: IosBuilder.Build
-          - target: iOS
-            backend: IL2CPP
-            unity: 6000.4.0f1
-            changeset: 8cf496087c8f
-            runner: [self-hosted, macOS, ARM64]
-            mobile: true
-            module: ios
-            method: IosBuilder.Build
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
 
@@ -251,14 +200,7 @@ jobs:
             || echo "(install non-zero — OK if 'Editor already installed in this location')"
           echo "::endgroup::"
 
-          if [ "${{ matrix.mobile }}" = "true" ]; then
-            echo "::group::install ${{ matrix.module }} module"
-            "$HUB" -- --headless install-modules \
-              --version "$UNITY_VER" --changeset "$UNITY_CS" --architecture arm64 \
-              --module "${{ matrix.module }}" \
-              || echo "(install-modules non-zero — OK if 'No modules found to install')"
-            echo "::endgroup::"
-          elif [ "${{ matrix.backend }}" = "IL2CPP" ]; then
+          if [ "${{ matrix.backend }}" = "IL2CPP" ]; then
             echo "::group::install mac-il2cpp module"
             "$HUB" -- --headless install-modules \
               --version "$UNITY_VER" --changeset "$UNITY_CS" --architecture arm64 \
@@ -285,7 +227,7 @@ jobs:
 
           MISSING=""
           [ -z "$EDITOR_APP" ] && MISSING="editor"
-          [ "${{ matrix.backend }}" = "IL2CPP" ] && [ "${{ matrix.mobile }}" != "true" ] && [ -z "$IL2CPP_DIR" ] && MISSING="${MISSING:+$MISSING+}mac-il2cpp"
+          [ "${{ matrix.backend }}" = "IL2CPP" ] && [ -z "$IL2CPP_DIR" ] && MISSING="${MISSING:+$MISSING+}mac-il2cpp"
           if [ -n "$MISSING" ]; then
             echo "::error::Unity $UNITY_VER missing: $MISSING"
             ls -la /Applications/Unity/Hub/Editor/ 2>&1 || true
@@ -339,7 +281,7 @@ jobs:
           "UNITY_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Run PlayMode tests (macOS)
-        if: runner.os == 'macOS' && matrix.mobile != true
+        if: runner.os == 'macOS'
         shell: bash
         env:
           AUDIENCE_TEST_PUBLISHABLE_KEY: ${{ secrets.AUDIENCE_TEST_PUBLISHABLE_KEY }}
@@ -359,20 +301,6 @@ jobs:
             -runTests \
             -testPlatform ${{ matrix.target }} \
             -testResults "$(pwd)/artifacts/test-results.xml" \
-            -logFile - 2>&1 | tee "$(pwd)/artifacts/unity.log"
-
-      - name: Build mobile target (macOS)
-        if: runner.os == 'macOS' && matrix.mobile == true
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p artifacts
-          "$UNITY_PATH" \
-            -batchmode -nographics \
-            -projectPath examples/audience \
-            -buildTarget ${{ matrix.target }} \
-            -executeMethod Immutable.Audience.Samples.SampleApp.Editor.${{ matrix.method }} \
-            -quit \
             -logFile - 2>&1 | tee "$(pwd)/artifacts/unity.log"
 
       - name: Run PlayMode tests (Windows)
@@ -408,7 +336,7 @@ jobs:
           git config --global --add safe.directory $env:GITHUB_WORKSPACE.Replace('\','/')
 
       - name: Capture player log (macOS)
-        if: always() && runner.os == 'macOS' && matrix.mobile != true
+        if: always() && runner.os == 'macOS'
         shell: bash
         run: |
           # The test-runner builds + launches a player binary that writes its own
@@ -488,7 +416,7 @@ jobs:
 
       - name: Publish test report
         uses: dorny/test-reporter@v3
-        if: always() && matrix.mobile != true
+        if: always()
         with:
           name: PlayMode (${{ matrix.backend }} / ${{ matrix.target }})
           path: artifacts/test-results.xml
@@ -496,7 +424,7 @@ jobs:
           fail-on-error: true
 
       - uses: actions/upload-artifact@v4
-        if: always() && matrix.mobile != true
+        if: always()
         with:
           name: playmode-${{ matrix.backend }}-${{ matrix.target }}-${{ matrix.unity }}
           path: |
@@ -505,12 +433,68 @@ jobs:
             artifacts/Player-*.log
             examples/audience/Logs/**
 
+  # Mobile IL2CPP build validation — runs on GitHub-hosted Ubuntu via GameCI Docker
+  # containers so self-hosted macOS/Windows machines are not occupied.
+  # Scope: IL2CPP compile pipeline only. Runtime tests require a real device and
+  # are out of scope until a device farm is available.
+  # Note: Unity 6 cells use 6000.4.5f1 (the latest patch with a GameCI image);
+  # 6000.4.0f1 does not have a published GameCI Docker image.
+  mobile-build:
+    if: github.event.pull_request.head.repo.fork == false || github.event_name == 'workflow_dispatch'
+    name: ${{ matrix.target }} / IL2CPP / Unity ${{ matrix.unity }}
+    runs-on: ubuntu-latest-8-cores
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: Android
+            unity: 2021.3.45f2
+            method: AndroidBuilder.Build
+          - target: Android
+            unity: 2022.3.62f2
+            method: AndroidBuilder.Build
+          - target: Android
+            unity: 6000.4.5f1
+            method: AndroidBuilder.Build
+          - target: iOS
+            unity: 2021.3.45f2
+            method: IosBuilder.Build
+          - target: iOS
+            unity: 2022.3.62f2
+            method: IosBuilder.Build
+          - target: iOS
+            unity: 6000.4.5f1
+            method: IosBuilder.Build
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - uses: actions/cache@v4
+        with:
+          path: examples/audience/Library
+          key: Library-mobile-${{ matrix.target }}-${{ matrix.unity }}-${{ hashFiles('examples/audience/Assets/**', 'examples/audience/Packages/**', 'examples/audience/ProjectSettings/**', 'src/Packages/Audience/**') }}
+          restore-keys: |
+            Library-mobile-${{ matrix.target }}-${{ matrix.unity }}-
+            Library-mobile-${{ matrix.target }}-
+
+      - uses: game-ci/unity-builder@v4
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+        with:
+          unityVersion: ${{ matrix.unity }}
+          targetPlatform: ${{ matrix.target }}
+          projectPath: examples/audience
+          buildMethod: Immutable.Audience.Samples.SampleApp.Editor.${{ matrix.method }}
+
       - uses: actions/upload-artifact@v4
-        if: always() && matrix.mobile == true
+        if: always()
         with:
           name: mobile-build-${{ matrix.target }}-${{ matrix.unity }}
           if-no-files-found: ignore
           path: |
-            artifacts/unity.log
             examples/audience/Builds/Android/*.apk
             examples/audience/Logs/**

--- a/examples/audience/ProjectSettings/ProjectSettings.asset
+++ b/examples/audience/ProjectSettings/ProjectSettings.asset
@@ -829,6 +829,7 @@ PlayerSettings:
     WebGL: 1
     Windows Store Apps: 1
     XboxOne: 1
+    Android: 3
     iPhone: 3
     tvOS: 1
   incrementalIl2cppBuild: {}


### PR DESCRIPTION
## Summary

Adds a dedicated `mobile-build` job using `game-ci/unity-builder@v4` on `ubuntu-latest-8-cores` (GitHub-hosted Linux), keeping self-hosted macOS/Windows machines free for PlayMode tests only.

6 new cells — Android + iOS × Unity 2021.3.45f2 / 2022.3.62f2 / 6000.4.5f1 — each producing an APK or Xcode project via the existing `AndroidBuilder`/`IosBuilder` `-executeMethod` entry points. The `playmode` job is unchanged.

## Scope limitations

No real devices are connected to the self-hosted runners and there are no plans for a device farm. CI is scoped to **IL2CPP compile pipeline only** — catching compile errors, missing references, and NDK/linker failures. Runtime PlayMode tests on mobile require a physical device.

**Unity 6 note:** GameCI does not publish a Docker image for `6000.4.0f1`. The mobile cells use `6000.4.5f1` (the latest available patch), which is acceptable for build validation.

Closes SDK-313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)