### PR TITLE
feat(audience-sdk): add EnableMobileAttribution + SKAdNetworkIds config (SDK-305)

### DIFF
--- a/src/Packages/Audience/Runtime/AudienceConfig.cs
+++ b/src/Packages/Audience/Runtime/AudienceConfig.cs
@@ -50,6 +50,40 @@ namespace Immutable.Audience
         public bool Debug { get; set; } = false;
 
         /// <summary>
+        /// Opts into mobile install-attribution signals (iOS ATT / IDFA /
+        /// SKAdNetwork, Android Advertising ID / Install Referrer). Default
+        /// <c>false</c>.
+        /// </summary>
+        /// <remarks>
+        /// Two gates control attribution; both must be set for any data to
+        /// ship:
+        ///
+        /// 1. Build-time: add <c>AUDIENCE_MOBILE_ATTRIBUTION</c> to Player
+        ///    Settings → Other Settings → Scripting Define Symbols. Controls
+        ///    the AD_ID Android manifest permission, the iOS Privacy Manifest
+        ///    variant (<c>NSPrivacyTracking</c>), and whether native
+        ///    attribution code is compiled into the binary.
+        ///
+        /// 2. Runtime: this flag. Controls whether attribution data is
+        ///    collected at runtime. Without the define, this setter is a
+        ///    no-op.
+        ///
+        /// Studios who set neither ship a clean binary — no AD_ID permission,
+        /// no native attribution code, <c>NSPrivacyTracking = false</c>.
+        /// </remarks>
+        public bool EnableMobileAttribution { get; set; } = false;
+
+        /// <summary>
+        /// SKAdNetwork IDs the iOS post-processor injects into <c>Info.plist</c>
+        /// at build time. Ignored on Android.
+        /// </summary>
+        /// <remarks>
+        /// Read only when <see cref="EnableMobileAttribution"/> and the
+        /// <c>AUDIENCE_MOBILE_ATTRIBUTION</c> scripting define are both set.
+        /// </remarks>
+        public string[]? SKAdNetworkIds { get; set; }
+
+        /// <summary>
         /// Interval between automatic flushes to the backend, in seconds.
         /// </summary>
         public int FlushIntervalSeconds { get; set; } = Constants.DefaultFlushIntervalSeconds;

--- a/src/Packages/Audience/Tests/Runtime/AudienceConfigTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/AudienceConfigTests.cs
@@ -1,0 +1,41 @@
+#nullable enable
+
+using NUnit.Framework;
+
+namespace Immutable.Audience.Tests
+{
+    [TestFixture]
+    internal class AudienceConfigTests
+    {
+        [Test]
+        public void EnableMobileAttribution_DefaultsToFalse()
+        {
+            // Default-off matters: a studio that never opts in must ship a
+            // clean binary, no AD_ID permission, NSPrivacyTracking false.
+            var config = new AudienceConfig();
+            Assert.IsFalse(config.EnableMobileAttribution);
+        }
+
+        [Test]
+        public void SKAdNetworkIds_DefaultsToNull()
+        {
+            var config = new AudienceConfig();
+            Assert.IsNull(config.SKAdNetworkIds);
+        }
+
+        [Test]
+        public void EnableMobileAttribution_RoundTrips()
+        {
+            var config = new AudienceConfig { EnableMobileAttribution = true };
+            Assert.IsTrue(config.EnableMobileAttribution);
+        }
+
+        [Test]
+        public void SKAdNetworkIds_RoundTrips()
+        {
+            var ids = new[] { "abc123.skadnetwork", "def456.skadnetwork" };
+            var config = new AudienceConfig { SKAdNetworkIds = ids };
+            Assert.AreSame(ids, config.SKAdNetworkIds);
+        }
+    }
+}

--- a/src/Packages/Audience/Tests/Runtime/AudienceConfigTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/AudienceConfigTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7a0b1d2e3f4a5b6c7d8e9f0a1b2c3d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

Entry-point ticket for the mobile attribution stretch work. Adds two opt-in surfaces on `AudienceConfig`; downstream tickets (SDK-306, SDK-308, SDK-309, SDK-315) will wire them up to the manifest, Privacy Manifest, and native code paths.

- **`EnableMobileAttribution`** (default `false`) — runtime gate for whether attribution data is collected and emitted on `game_launch`.
- **`SKAdNetworkIds`** (`string[]`, optional) — list of SKAdNetwork IDs the iOS post-processor injects into `Info.plist` at build time.

## Two-gate model

The XML doc on `EnableMobileAttribution` spells this out, but in short: studios opt into attribution via **both** gates.

| Scripting define `AUDIENCE_MOBILE_ATTRIBUTION` | `EnableMobileAttribution` | Result |
| --- | --- | --- |
| unset | any | clean binary, no AD_ID permission, `NSPrivacyTracking = false`, no native attribution code |
| set | `false` | native code compiled in but no data collected (staged rollout) |
| set | `true` | full attribution flow |

The build-time gate keeps the binary clean for studios that never opt in (no Apple review flag, no Play Store warning). The runtime gate allows staged rollouts via remote config.

## Notes

- Mobile-specific fields are intentionally **not** wrapped in `#if UNITY_IOS || UNITY_ANDROID` — that would force studios to wrap their bootstrap code in matching guards. Same convention as Firebase, Sentry, Unity Analytics: fields exist on all platforms, no-op where irrelevant.
- No behavior changes yet. Setters compile and round-trip; nothing reads them.

## Test plan

- [x] Unit tests for default values + round-trip on both new properties (`AudienceConfigTests.cs`)
- [ ] CI green