### PR TITLE
ci(audience): add StandaloneLinux64 PlayMode cells (SDK-255)

### DIFF
--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -369,32 +369,22 @@ jobs:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
         run: |
           set -uo pipefail
-          # Activate-once-and-cache. Unity Pro/Plus seats are scarce; the license
-          # file persists in $HOME on the self-hosted runner so subsequent runs
-          # detect it and skip activation. Win/macOS runners are pre-activated
-          # manually outside the workflow; Linux activates here because the host
-          # was provisioned fresh.
-          LICENSE_FILE="$HOME/.local/share/unity3d/Unity/Unity_lic.ulf"
-          if [ -f "$LICENSE_FILE" ]; then
-            echo "Unity license already cached at $LICENSE_FILE; skipping activation"
-            exit 0
-          fi
-
+          LOG="$(mktemp)"
           echo "::group::Activate Unity"
-          # Unity exits non-zero on -quit even when activation succeeds, so the
-          # license-file existence check below is the real success gate.
           "$UNITY_PATH" -batchmode -nographics -quit \
             -username "$UNITY_EMAIL" \
             -password "$UNITY_PASSWORD" \
             -serial   "$UNITY_SERIAL" \
-            -logFile - 2>&1 || true
+            -logFile - 2>&1 | tee "$LOG" || true
           echo "::endgroup::"
 
-          if [ ! -f "$LICENSE_FILE" ]; then
-            echo "::error::Unity activation failed: no license file at $LICENSE_FILE. Check UNITY_EMAIL/UNITY_PASSWORD/UNITY_SERIAL secrets and seat-pool availability."
-            exit 1
+          if grep -qE "(Successfully activated the entitlement license|Successfully processed license management request)" "$LOG"; then
+            echo "Unity license is active"
+            exit 0
           fi
-          echo "Activated; license file at $LICENSE_FILE"
+
+          echo "::error::Unity activation failed. Check UNITY_EMAIL/UNITY_PASSWORD/UNITY_SERIAL secrets and seat-pool availability."
+          exit 1
 
       - name: Run PlayMode tests (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -608,30 +608,6 @@ jobs:
           fi
           echo "UNITY_PATH=$UNITY" >> "$GITHUB_ENV"
 
-      - name: Activate Unity license
-        shell: bash
-        env:
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-        run: |
-          set -uo pipefail
-          LOG="$(mktemp)"
-          "$UNITY_PATH" -batchmode -nographics -quit \
-            -username "$UNITY_EMAIL" \
-            -password "$UNITY_PASSWORD" \
-            -serial   "$UNITY_SERIAL" \
-            -logFile - 2>&1 | tee "$LOG" || true
-
-          if grep -qE "(License activation has failed|\[Licensing::Client\] Error: Code [0-9]+)" "$LOG"; then
-            echo "::error::Unity activation failed."
-            exit 1
-          fi
-          if ! grep -qE "Successfully activated the entitlement license" "$LOG"; then
-            echo "::error::Unity activation: no success marker found."
-            exit 1
-          fi
-
       - name: Run PlayMode tests
         shell: bash
         env:
@@ -647,17 +623,6 @@ jobs:
             -testPlatform StandaloneLinux64 \
             -testResults "$(pwd)/artifacts/test-results.xml" \
             -logFile - 2>&1 | tee "$(pwd)/artifacts/unity.log"
-
-      - name: Return Unity license
-        if: always()
-        shell: bash
-        run: |
-          set -uo pipefail
-          # Releases the seat after every run so manual reruns do not exhaust
-          # the serial's activation pool.
-          if [ -n "${UNITY_PATH:-}" ] && [ -x "$UNITY_PATH" ]; then
-            "$UNITY_PATH" -returnlicense -batchmode -nographics -quit -logFile - 2>&1 || true
-          fi
 
       - name: Publish test report
         uses: dorny/test-reporter@v3

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   playmode:
-    if: github.event.pull_request.head.repo.fork == false || (github.event_name == 'workflow_dispatch' && inputs.selfhosted_only != true)
+    if: github.event.pull_request.head.repo.fork == false || (github.event_name == 'workflow_dispatch' && github.event.inputs.selfhosted_only != 'true')
     name: ${{ matrix.target }} / ${{ matrix.backend }} / Unity ${{ matrix.unity }}
     strategy:
       fail-fast: false
@@ -445,7 +445,7 @@ jobs:
   # Linux PlayMode runs on GitHub-hosted Ubuntu via GameCI Docker, not on the
   # self-hosted matrix above, to keep self-hosted machines free for Win/macOS.
   playmode-linux:
-    if: github.event.pull_request.head.repo.fork == false || (github.event_name == 'workflow_dispatch' && inputs.selfhosted_only != true)
+    if: github.event.pull_request.head.repo.fork == false || (github.event_name == 'workflow_dispatch' && github.event.inputs.selfhosted_only != 'true')
     name: ${{ matrix.target }} / ${{ matrix.backend }} / Unity ${{ matrix.unity }}
     runs-on: ubuntu-latest-8-cores
     strategy:
@@ -509,7 +509,7 @@ jobs:
   # Note: Unity 6 cells use 6000.4.5f1 (the latest patch with a GameCI image);
   # 6000.4.0f1 does not have a published GameCI Docker image.
   mobile-build:
-    if: github.event.pull_request.head.repo.fork == false || (github.event_name == 'workflow_dispatch' && inputs.selfhosted_only != true)
+    if: github.event.pull_request.head.repo.fork == false || (github.event_name == 'workflow_dispatch' && github.event.inputs.selfhosted_only != 'true')
     name: ${{ matrix.target }} / IL2CPP / Unity ${{ matrix.unity }}
     runs-on: ubuntu-latest-8-cores
     strategy:

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -13,6 +13,11 @@ on:
       - 'examples/audience/ProjectSettings/**'
       - '.github/workflows/test-audience-sample-app.yml'
   workflow_dispatch:
+    inputs:
+      selfhosted_only:
+        description: Run only the self-hosted Linux PlayMode validation (skip Win, macOS, GameCI Linux, mobile)
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,7 +25,7 @@ concurrency:
 
 jobs:
   playmode:
-    if: github.event.pull_request.head.repo.fork == false || github.event_name == 'workflow_dispatch'
+    if: github.event.pull_request.head.repo.fork == false || (github.event_name == 'workflow_dispatch' && inputs.selfhosted_only != true)
     name: ${{ matrix.target }} / ${{ matrix.backend }} / Unity ${{ matrix.unity }}
     strategy:
       fail-fast: false
@@ -440,7 +445,7 @@ jobs:
   # Linux PlayMode runs on GitHub-hosted Ubuntu via GameCI Docker, not on the
   # self-hosted matrix above, to keep self-hosted machines free for Win/macOS.
   playmode-linux:
-    if: github.event.pull_request.head.repo.fork == false || github.event_name == 'workflow_dispatch'
+    if: github.event.pull_request.head.repo.fork == false || (github.event_name == 'workflow_dispatch' && inputs.selfhosted_only != true)
     name: ${{ matrix.target }} / ${{ matrix.backend }} / Unity ${{ matrix.unity }}
     runs-on: ubuntu-latest-8-cores
     strategy:
@@ -504,7 +509,7 @@ jobs:
   # Note: Unity 6 cells use 6000.4.5f1 (the latest patch with a GameCI image);
   # 6000.4.0f1 does not have a published GameCI Docker image.
   mobile-build:
-    if: github.event.pull_request.head.repo.fork == false || github.event_name == 'workflow_dispatch'
+    if: github.event.pull_request.head.repo.fork == false || (github.event_name == 'workflow_dispatch' && inputs.selfhosted_only != true)
     name: ${{ matrix.target }} / IL2CPP / Unity ${{ matrix.unity }}
     runs-on: ubuntu-latest-8-cores
     strategy:

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -46,16 +46,6 @@ jobs:
             unity: 2021.3.45f2
             changeset: 88f88f591b2e
             runner: [self-hosted, macOS, ARM64]
-          - target: StandaloneLinux64
-            backend: IL2CPP
-            unity: 2021.3.45f2
-            changeset: 88f88f591b2e
-            runner: [self-hosted, X64, Linux]
-          - target: StandaloneLinux64
-            backend: Mono2x
-            unity: 2021.3.45f2
-            changeset: 88f88f591b2e
-            runner: [self-hosted, X64, Linux]
           - target: StandaloneWindows64
             backend: IL2CPP
             unity: 6000.4.0f1
@@ -198,25 +188,6 @@ jobs:
           Write-Host "Verified VC.Tools at: $($state.VcTools)"
           Write-Host "Verified Win10 SDK at: $($state.Win10Sdk)"
 
-      - name: Verify IL2CPP toolchain (Linux)
-        if: runner.os == 'Linux' && matrix.backend == 'IL2CPP'
-        shell: bash
-        run: |
-          # IL2CPP's C++ to native step links against gcc/g++ + glibc-dev (the
-          # build-essential package on Ubuntu). Without these, Unity fails late
-          # inside the IL2CPP build with a cryptic linker error. Fail fast here
-          # with a clear remediation message instead.
-          MISSING=""
-          for cmd in gcc g++; do
-            command -v "$cmd" >/dev/null 2>&1 || MISSING="${MISSING:+$MISSING+}$cmd"
-          done
-          if [ -n "$MISSING" ]; then
-            echo "::error::IL2CPP toolchain incomplete on runner: $MISSING. Run on the runner host: sudo apt install -y build-essential"
-            exit 1
-          fi
-          echo "gcc: $(gcc --version | head -1)"
-          echo "g++: $(g++ --version | head -1)"
-
       - name: Resolve Unity ${{ matrix.unity }} (macOS)
         if: runner.os == 'macOS'
         shell: bash
@@ -313,79 +284,6 @@ jobs:
           if ('${{ matrix.backend }}' -eq 'IL2CPP') { Write-Host "Found IL2CPP: $il2cpp" }
           "UNITY_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
-      - name: Resolve Unity ${{ matrix.unity }} (Linux)
-        if: runner.os == 'Linux'
-        shell: bash
-        env:
-          UNITY_VER: ${{ matrix.unity }}
-          UNITY_CS: ${{ matrix.changeset }}
-        run: |
-          set -uo pipefail
-          HUB="unityhub"
-
-          echo "::group::install editor"
-          "$HUB" --headless install \
-            --version "$UNITY_VER" --changeset "$UNITY_CS" --architecture x86_64 \
-            || echo "(install non-zero, OK if 'Editor already installed in this location')"
-          echo "::endgroup::"
-
-          if [ "${{ matrix.backend }}" = "IL2CPP" ]; then
-            echo "::group::install linux-il2cpp module"
-            "$HUB" --headless install-modules \
-              --version "$UNITY_VER" --changeset "$UNITY_CS" --architecture x86_64 \
-              --module linux-il2cpp \
-              || echo "(install-modules non-zero, OK if 'No modules found to install')"
-            echo "::endgroup::"
-          fi
-
-          EDITOR_PATH="$HOME/Unity/Hub/Editor/$UNITY_VER/Editor/Unity"
-
-          IL2CPP_DIR=""
-          if [ "${{ matrix.backend }}" = "IL2CPP" ] && [ -x "$EDITOR_PATH" ]; then
-            IL2CPP_DIR="$HOME/Unity/Hub/Editor/$UNITY_VER/Editor/Data/PlaybackEngines/LinuxStandaloneSupport/Variations/linux64_player_nondevelopment_il2cpp"
-            [ -d "$IL2CPP_DIR" ] || IL2CPP_DIR=""
-          fi
-
-          MISSING=""
-          [ -x "$EDITOR_PATH" ] || MISSING="editor"
-          [ "${{ matrix.backend }}" = "IL2CPP" ] && [ -z "$IL2CPP_DIR" ] && MISSING="${MISSING:+$MISSING+}linux-il2cpp"
-          if [ -n "$MISSING" ]; then
-            echo "::error::Unity $UNITY_VER missing: $MISSING"
-            ls -la "$HOME/Unity/Hub/Editor/" 2>&1 || true
-            "$HUB" --headless editors --installed 2>&1 || true
-            exit 1
-          fi
-
-          echo "Found Unity:  $EDITOR_PATH"
-          [ -n "$IL2CPP_DIR" ] && echo "Found IL2CPP: $IL2CPP_DIR"
-          echo "UNITY_PATH=$EDITOR_PATH" >> "$GITHUB_ENV"
-
-      - name: Activate Unity license (Linux)
-        if: runner.os == 'Linux'
-        shell: bash
-        env:
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-        run: |
-          set -uo pipefail
-          LOG="$(mktemp)"
-          echo "::group::Activate Unity"
-          "$UNITY_PATH" -batchmode -nographics -quit \
-            -username "$UNITY_EMAIL" \
-            -password "$UNITY_PASSWORD" \
-            -serial   "$UNITY_SERIAL" \
-            -logFile - 2>&1 | tee "$LOG" || true
-          echo "::endgroup::"
-
-          if grep -qE "(Successfully activated the entitlement license|Successfully processed license management request)" "$LOG"; then
-            echo "Unity license is active"
-            exit 0
-          fi
-
-          echo "::error::Unity activation failed. Check UNITY_EMAIL/UNITY_PASSWORD/UNITY_SERIAL secrets and seat-pool availability."
-          exit 1
-
       - name: Run PlayMode tests (macOS)
         if: runner.os == 'macOS'
         shell: bash
@@ -435,26 +333,6 @@ jobs:
           Write-Host "Unity exited with code $exit"
           if ($exit -ne 0) { exit $exit }
 
-      - name: Run PlayMode tests (Linux)
-        if: runner.os == 'Linux'
-        shell: bash
-        env:
-          AUDIENCE_TEST_PUBLISHABLE_KEY: ${{ secrets.AUDIENCE_TEST_PUBLISHABLE_KEY }}
-          AUDIENCE_SCRIPTING_BACKEND: ${{ matrix.backend }}
-        run: |
-          set -euo pipefail
-          mkdir -p artifacts
-          # Mirrors the macOS variant: tee Unity's stdout to artifacts/unity.log
-          # so the annotation step has a file to scan while progress streams to
-          # the job log. pipefail propagates Unity's exit code through tee.
-          "$UNITY_PATH" \
-            -batchmode -nographics \
-            -projectPath examples/audience \
-            -runTests \
-            -testPlatform ${{ matrix.target }} \
-            -testResults "$(pwd)/artifacts/test-results.xml" \
-            -logFile - 2>&1 | tee "$(pwd)/artifacts/unity.log"
-
       - name: Mark workspace safe for git (Windows)
         if: always() && runner.os == 'Windows'
         shell: pwsh
@@ -494,21 +372,6 @@ jobs:
                 Copy-Item -Path $_.FullName -Destination "artifacts/Player-$name.log" -ErrorAction SilentlyContinue
               }
           }
-
-      - name: Capture player log (Linux)
-        if: always() && runner.os == 'Linux'
-        shell: bash
-        run: |
-          # See macOS counterpart for rationale. Linux player log location:
-          # ~/.config/unity3d/<CompanyName>/<ProductName>/Player.log (Unity's
-          # standard persistent data path on Linux, matching $XDG_CONFIG_HOME).
-          mkdir -p artifacts
-          src="$HOME/.config/unity3d"
-          if [ -d "$src" ]; then
-            find "$src" -name "Player.log" 2>/dev/null | while IFS= read -r f; do
-              cp "$f" "artifacts/Player-$(basename "$(dirname "$f")").log" 2>/dev/null || true
-            done
-          fi
 
       - name: Surface Unity compile errors as annotations (macOS)
         if: always() && runner.os == 'macOS'
@@ -555,23 +418,6 @@ jobs:
               Write-Host "::error::$sanitized"
             }
 
-      - name: Surface Unity compile errors as annotations (Linux)
-        if: always() && runner.os == 'Linux'
-        shell: bash
-        run: |
-          set -uo pipefail
-          # See macOS counterpart for rationale.
-          LOG_FILE="artifacts/unity.log"
-          if [ ! -f "$LOG_FILE" ]; then
-            echo "::notice::No Unity log file at $LOG_FILE."
-            exit 0
-          fi
-          grep -E '(error CS[0-9]+:|Compilation failed:)' "$LOG_FILE" | sort -u | while IFS= read -r line; do
-            trimmed="${line#"${line%%[![:space:]]*}"}"
-            sanitized="${trimmed//::/%3A%3A}"
-            echo "::error::$sanitized"
-          done || true
-
       - name: Publish test report
         uses: dorny/test-reporter@v3
         if: always()
@@ -590,6 +436,66 @@ jobs:
             artifacts/unity.log
             artifacts/Player-*.log
             examples/audience/Logs/**
+
+  # Linux PlayMode runs on GitHub-hosted Ubuntu via GameCI Docker, not on the
+  # self-hosted matrix above, to keep self-hosted machines free for Win/macOS.
+  playmode-linux:
+    if: github.event.pull_request.head.repo.fork == false || github.event_name == 'workflow_dispatch'
+    name: ${{ matrix.target }} / ${{ matrix.backend }} / Unity ${{ matrix.unity }}
+    runs-on: ubuntu-latest-8-cores
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: StandaloneLinux64
+            backend: IL2CPP
+            unity: 2021.3.45f2
+          - target: StandaloneLinux64
+            backend: Mono2x
+            unity: 2021.3.45f2
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - uses: actions/cache@v4
+        with:
+          path: examples/audience/Library
+          key: Library-${{ matrix.backend }}-${{ matrix.target }}-${{ matrix.unity }}-${{ hashFiles('examples/audience/Assets/**', 'examples/audience/Packages/**', 'examples/audience/ProjectSettings/**', 'src/Packages/Audience/**') }}
+          restore-keys: |
+            Library-${{ matrix.backend }}-${{ matrix.target }}-${{ matrix.unity }}-
+            Library-${{ matrix.backend }}-${{ matrix.target }}-
+
+      - uses: game-ci/unity-test-runner@v4
+        id: playmode
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          AUDIENCE_TEST_PUBLISHABLE_KEY: ${{ secrets.AUDIENCE_TEST_PUBLISHABLE_KEY }}
+          AUDIENCE_SCRIPTING_BACKEND: ${{ matrix.backend }}
+        with:
+          unityVersion: ${{ matrix.unity }}
+          targetPlatform: ${{ matrix.target }}
+          projectPath: examples/audience
+          testMode: playmode
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish test report
+        uses: dorny/test-reporter@v3
+        if: always()
+        with:
+          name: PlayMode (${{ matrix.backend }} / ${{ matrix.target }})
+          path: ${{ steps.playmode.outputs.artifactsPath }}/playmode-results.xml
+          reporter: dotnet-nunit
+          fail-on-error: true
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playmode-${{ matrix.backend }}-${{ matrix.target }}-${{ matrix.unity }}
+          path: ${{ steps.playmode.outputs.artifactsPath }}
 
   # Mobile IL2CPP build validation — runs on GitHub-hosted Ubuntu via GameCI Docker
   # containers so self-hosted macOS/Windows machines are not occupied.

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -13,11 +13,6 @@ on:
       - 'examples/audience/ProjectSettings/**'
       - '.github/workflows/test-audience-sample-app.yml'
   workflow_dispatch:
-    inputs:
-      selfhosted_only:
-        description: Run only the self-hosted Linux PlayMode validation (skip Win, macOS, GameCI Linux, mobile)
-        type: boolean
-        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,7 +20,7 @@ concurrency:
 
 jobs:
   playmode:
-    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || (github.event_name == 'workflow_dispatch' && github.event.inputs.selfhosted_only != 'true')
+    if: github.event.pull_request.head.repo.fork == false || github.event_name == 'workflow_dispatch'
     name: ${{ matrix.target }} / ${{ matrix.backend }} / Unity ${{ matrix.unity }}
     strategy:
       fail-fast: false
@@ -445,7 +440,7 @@ jobs:
   # Linux PlayMode runs on GitHub-hosted Ubuntu via GameCI Docker, not on the
   # self-hosted matrix above, to keep self-hosted machines free for Win/macOS.
   playmode-linux:
-    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || (github.event_name == 'workflow_dispatch' && github.event.inputs.selfhosted_only != 'true')
+    if: github.event.pull_request.head.repo.fork == false || github.event_name == 'workflow_dispatch'
     name: ${{ matrix.target }} / ${{ matrix.backend }} / Unity ${{ matrix.unity }}
     runs-on: ubuntu-latest-8-cores
     strategy:
@@ -509,7 +504,7 @@ jobs:
   # Note: Unity 6 cells use 6000.4.5f1 (the latest patch with a GameCI image);
   # 6000.4.0f1 does not have a published GameCI Docker image.
   mobile-build:
-    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || (github.event_name == 'workflow_dispatch' && github.event.inputs.selfhosted_only != 'true')
+    if: github.event.pull_request.head.repo.fork == false || github.event_name == 'workflow_dispatch'
     name: ${{ matrix.target }} / IL2CPP / Unity ${{ matrix.unity }}
     runs-on: ubuntu-latest-8-cores
     strategy:
@@ -567,76 +562,3 @@ jobs:
           path: |
             examples/audience/Builds/Android/*.apk
             examples/audience/Logs/**
-
-  # workflow_dispatch only. Cross-checks the GameCI Docker outcome against
-  # the self-hosted Linux machine when there's reason to suspect divergence.
-  playmode-linux-selfhosted:
-    if: github.event_name == 'workflow_dispatch'
-    name: ${{ matrix.backend }} / Unity ${{ matrix.unity }} (self-hosted Linux)
-    runs-on: [self-hosted, X64, Linux]
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - backend: IL2CPP
-            unity: 2021.3.45f2
-          - backend: Mono2x
-            unity: 2021.3.45f2
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
-
-      - uses: actions/cache@v4
-        with:
-          path: examples/audience/Library
-          key: Library-selfhosted-${{ matrix.backend }}-StandaloneLinux64-${{ matrix.unity }}-${{ hashFiles('examples/audience/Assets/**', 'examples/audience/Packages/**', 'examples/audience/ProjectSettings/**', 'src/Packages/Audience/**') }}
-          restore-keys: |
-            Library-selfhosted-${{ matrix.backend }}-StandaloneLinux64-${{ matrix.unity }}-
-            Library-selfhosted-${{ matrix.backend }}-StandaloneLinux64-
-
-      - name: Resolve Unity
-        shell: bash
-        run: |
-          set -uo pipefail
-          UNITY="$HOME/Unity/Hub/Editor/${{ matrix.unity }}/Editor/Unity"
-          if [ ! -x "$UNITY" ]; then
-            echo "::error::Unity ${{ matrix.unity }} not found at $UNITY. Install via Unity Hub on the runner host."
-            exit 1
-          fi
-          echo "UNITY_PATH=$UNITY" >> "$GITHUB_ENV"
-
-      - name: Run PlayMode tests
-        shell: bash
-        env:
-          AUDIENCE_TEST_PUBLISHABLE_KEY: ${{ secrets.AUDIENCE_TEST_PUBLISHABLE_KEY }}
-          AUDIENCE_SCRIPTING_BACKEND: ${{ matrix.backend }}
-        run: |
-          set -euo pipefail
-          mkdir -p artifacts
-          "$UNITY_PATH" \
-            -batchmode -nographics \
-            -projectPath examples/audience \
-            -runTests \
-            -testPlatform StandaloneLinux64 \
-            -testResults "$(pwd)/artifacts/test-results.xml" \
-            -logFile - 2>&1 | tee "$(pwd)/artifacts/unity.log"
-
-      - name: Publish test report
-        uses: dorny/test-reporter@v3
-        if: always()
-        with:
-          name: Self-hosted Linux PlayMode (${{ matrix.backend }})
-          path: artifacts/test-results.xml
-          reporter: dotnet-nunit
-          fail-on-error: true
-
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: selfhosted-linux-${{ matrix.backend }}
-          path: |
-            artifacts/test-results.xml
-            artifacts/unity.log

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   playmode:
-    if: github.event.pull_request.head.repo.fork == false || (github.event_name == 'workflow_dispatch' && github.event.inputs.selfhosted_only != 'true')
+    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || (github.event_name == 'workflow_dispatch' && github.event.inputs.selfhosted_only != 'true')
     name: ${{ matrix.target }} / ${{ matrix.backend }} / Unity ${{ matrix.unity }}
     strategy:
       fail-fast: false
@@ -445,7 +445,7 @@ jobs:
   # Linux PlayMode runs on GitHub-hosted Ubuntu via GameCI Docker, not on the
   # self-hosted matrix above, to keep self-hosted machines free for Win/macOS.
   playmode-linux:
-    if: github.event.pull_request.head.repo.fork == false || (github.event_name == 'workflow_dispatch' && github.event.inputs.selfhosted_only != 'true')
+    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || (github.event_name == 'workflow_dispatch' && github.event.inputs.selfhosted_only != 'true')
     name: ${{ matrix.target }} / ${{ matrix.backend }} / Unity ${{ matrix.unity }}
     runs-on: ubuntu-latest-8-cores
     strategy:
@@ -509,7 +509,7 @@ jobs:
   # Note: Unity 6 cells use 6000.4.5f1 (the latest patch with a GameCI image);
   # 6000.4.0f1 does not have a published GameCI Docker image.
   mobile-build:
-    if: github.event.pull_request.head.repo.fork == false || (github.event_name == 'workflow_dispatch' && github.event.inputs.selfhosted_only != 'true')
+    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || (github.event_name == 'workflow_dispatch' && github.event.inputs.selfhosted_only != 'true')
     name: ${{ matrix.target }} / IL2CPP / Unity ${{ matrix.unity }}
     runs-on: ubuntu-latest-8-cores
     strategy:

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -562,3 +562,111 @@ jobs:
           path: |
             examples/audience/Builds/Android/*.apk
             examples/audience/Logs/**
+
+  # workflow_dispatch only. Cross-checks the GameCI Docker outcome against
+  # the self-hosted Linux machine when there's reason to suspect divergence.
+  playmode-linux-selfhosted:
+    if: github.event_name == 'workflow_dispatch'
+    name: ${{ matrix.backend }} / Unity ${{ matrix.unity }} (self-hosted Linux)
+    runs-on: [self-hosted, X64, Linux]
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - backend: IL2CPP
+            unity: 2021.3.45f2
+          - backend: Mono2x
+            unity: 2021.3.45f2
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - uses: actions/cache@v4
+        with:
+          path: examples/audience/Library
+          key: Library-selfhosted-${{ matrix.backend }}-StandaloneLinux64-${{ matrix.unity }}-${{ hashFiles('examples/audience/Assets/**', 'examples/audience/Packages/**', 'examples/audience/ProjectSettings/**', 'src/Packages/Audience/**') }}
+          restore-keys: |
+            Library-selfhosted-${{ matrix.backend }}-StandaloneLinux64-${{ matrix.unity }}-
+            Library-selfhosted-${{ matrix.backend }}-StandaloneLinux64-
+
+      - name: Resolve Unity
+        shell: bash
+        run: |
+          set -uo pipefail
+          UNITY="$HOME/Unity/Hub/Editor/${{ matrix.unity }}/Editor/Unity"
+          if [ ! -x "$UNITY" ]; then
+            echo "::error::Unity ${{ matrix.unity }} not found at $UNITY. Install via Unity Hub on the runner host."
+            exit 1
+          fi
+          echo "UNITY_PATH=$UNITY" >> "$GITHUB_ENV"
+
+      - name: Activate Unity license
+        shell: bash
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+        run: |
+          set -uo pipefail
+          LOG="$(mktemp)"
+          "$UNITY_PATH" -batchmode -nographics -quit \
+            -username "$UNITY_EMAIL" \
+            -password "$UNITY_PASSWORD" \
+            -serial   "$UNITY_SERIAL" \
+            -logFile - 2>&1 | tee "$LOG" || true
+
+          if grep -qE "(License activation has failed|\[Licensing::Client\] Error: Code [0-9]+)" "$LOG"; then
+            echo "::error::Unity activation failed."
+            exit 1
+          fi
+          if ! grep -qE "Successfully activated the entitlement license" "$LOG"; then
+            echo "::error::Unity activation: no success marker found."
+            exit 1
+          fi
+
+      - name: Run PlayMode tests
+        shell: bash
+        env:
+          AUDIENCE_TEST_PUBLISHABLE_KEY: ${{ secrets.AUDIENCE_TEST_PUBLISHABLE_KEY }}
+          AUDIENCE_SCRIPTING_BACKEND: ${{ matrix.backend }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          "$UNITY_PATH" \
+            -batchmode -nographics \
+            -projectPath examples/audience \
+            -runTests \
+            -testPlatform StandaloneLinux64 \
+            -testResults "$(pwd)/artifacts/test-results.xml" \
+            -logFile - 2>&1 | tee "$(pwd)/artifacts/unity.log"
+
+      - name: Return Unity license
+        if: always()
+        shell: bash
+        run: |
+          set -uo pipefail
+          # Releases the seat after every run so manual reruns do not exhaust
+          # the serial's activation pool.
+          if [ -n "${UNITY_PATH:-}" ] && [ -x "$UNITY_PATH" ]; then
+            "$UNITY_PATH" -returnlicense -batchmode -nographics -quit -logFile - 2>&1 || true
+          fi
+
+      - name: Publish test report
+        uses: dorny/test-reporter@v3
+        if: always()
+        with:
+          name: Self-hosted Linux PlayMode (${{ matrix.backend }})
+          path: artifacts/test-results.xml
+          reporter: dotnet-nunit
+          fail-on-error: true
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: selfhosted-linux-${{ matrix.backend }}
+          path: |
+            artifacts/test-results.xml
+            artifacts/unity.log

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -46,6 +46,16 @@ jobs:
             unity: 2021.3.45f2
             changeset: 88f88f591b2e
             runner: [self-hosted, macOS, ARM64]
+          - target: StandaloneLinux64
+            backend: IL2CPP
+            unity: 2021.3.45f2
+            changeset: 88f88f591b2e
+            runner: [self-hosted, X64, Linux]
+          - target: StandaloneLinux64
+            backend: Mono2x
+            unity: 2021.3.45f2
+            changeset: 88f88f591b2e
+            runner: [self-hosted, X64, Linux]
           - target: StandaloneWindows64
             backend: IL2CPP
             unity: 6000.4.0f1
@@ -188,6 +198,25 @@ jobs:
           Write-Host "Verified VC.Tools at: $($state.VcTools)"
           Write-Host "Verified Win10 SDK at: $($state.Win10Sdk)"
 
+      - name: Verify IL2CPP toolchain (Linux)
+        if: runner.os == 'Linux' && matrix.backend == 'IL2CPP'
+        shell: bash
+        run: |
+          # IL2CPP's C++ to native step links against gcc/g++ + glibc-dev (the
+          # build-essential package on Ubuntu). Without these, Unity fails late
+          # inside the IL2CPP build with a cryptic linker error. Fail fast here
+          # with a clear remediation message instead.
+          MISSING=""
+          for cmd in gcc g++; do
+            command -v "$cmd" >/dev/null 2>&1 || MISSING="${MISSING:+$MISSING+}$cmd"
+          done
+          if [ -n "$MISSING" ]; then
+            echo "::error::IL2CPP toolchain incomplete on runner: $MISSING. Run on the runner host: sudo apt install -y build-essential"
+            exit 1
+          fi
+          echo "gcc: $(gcc --version | head -1)"
+          echo "g++: $(g++ --version | head -1)"
+
       - name: Resolve Unity ${{ matrix.unity }} (macOS)
         if: runner.os == 'macOS'
         shell: bash
@@ -284,6 +313,89 @@ jobs:
           if ('${{ matrix.backend }}' -eq 'IL2CPP') { Write-Host "Found IL2CPP: $il2cpp" }
           "UNITY_PATH=$editor" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
+      - name: Resolve Unity ${{ matrix.unity }} (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        env:
+          UNITY_VER: ${{ matrix.unity }}
+          UNITY_CS: ${{ matrix.changeset }}
+        run: |
+          set -uo pipefail
+          HUB="unityhub"
+
+          echo "::group::install editor"
+          "$HUB" --headless install \
+            --version "$UNITY_VER" --changeset "$UNITY_CS" --architecture x86_64 \
+            || echo "(install non-zero, OK if 'Editor already installed in this location')"
+          echo "::endgroup::"
+
+          if [ "${{ matrix.backend }}" = "IL2CPP" ]; then
+            echo "::group::install linux-il2cpp module"
+            "$HUB" --headless install-modules \
+              --version "$UNITY_VER" --changeset "$UNITY_CS" --architecture x86_64 \
+              --module linux-il2cpp \
+              || echo "(install-modules non-zero, OK if 'No modules found to install')"
+            echo "::endgroup::"
+          fi
+
+          EDITOR_PATH="$HOME/Unity/Hub/Editor/$UNITY_VER/Editor/Unity"
+
+          IL2CPP_DIR=""
+          if [ "${{ matrix.backend }}" = "IL2CPP" ] && [ -x "$EDITOR_PATH" ]; then
+            IL2CPP_DIR="$HOME/Unity/Hub/Editor/$UNITY_VER/Editor/Data/PlaybackEngines/LinuxStandaloneSupport/Variations/linux64_player_nondevelopment_il2cpp"
+            [ -d "$IL2CPP_DIR" ] || IL2CPP_DIR=""
+          fi
+
+          MISSING=""
+          [ -x "$EDITOR_PATH" ] || MISSING="editor"
+          [ "${{ matrix.backend }}" = "IL2CPP" ] && [ -z "$IL2CPP_DIR" ] && MISSING="${MISSING:+$MISSING+}linux-il2cpp"
+          if [ -n "$MISSING" ]; then
+            echo "::error::Unity $UNITY_VER missing: $MISSING"
+            ls -la "$HOME/Unity/Hub/Editor/" 2>&1 || true
+            "$HUB" --headless editors --installed 2>&1 || true
+            exit 1
+          fi
+
+          echo "Found Unity:  $EDITOR_PATH"
+          [ -n "$IL2CPP_DIR" ] && echo "Found IL2CPP: $IL2CPP_DIR"
+          echo "UNITY_PATH=$EDITOR_PATH" >> "$GITHUB_ENV"
+
+      - name: Activate Unity license (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+        run: |
+          set -uo pipefail
+          # Activate-once-and-cache. Unity Pro/Plus seats are scarce; the license
+          # file persists in $HOME on the self-hosted runner so subsequent runs
+          # detect it and skip activation. Win/macOS runners are pre-activated
+          # manually outside the workflow; Linux activates here because the host
+          # was provisioned fresh.
+          LICENSE_FILE="$HOME/.local/share/unity3d/Unity/Unity_lic.ulf"
+          if [ -f "$LICENSE_FILE" ]; then
+            echo "Unity license already cached at $LICENSE_FILE; skipping activation"
+            exit 0
+          fi
+
+          echo "::group::Activate Unity"
+          # Unity exits non-zero on -quit even when activation succeeds, so the
+          # license-file existence check below is the real success gate.
+          "$UNITY_PATH" -batchmode -nographics -quit \
+            -username "$UNITY_EMAIL" \
+            -password "$UNITY_PASSWORD" \
+            -serial   "$UNITY_SERIAL" \
+            -logFile - 2>&1 || true
+          echo "::endgroup::"
+
+          if [ ! -f "$LICENSE_FILE" ]; then
+            echo "::error::Unity activation failed: no license file at $LICENSE_FILE. Check UNITY_EMAIL/UNITY_PASSWORD/UNITY_SERIAL secrets and seat-pool availability."
+            exit 1
+          fi
+          echo "Activated; license file at $LICENSE_FILE"
+
       - name: Run PlayMode tests (macOS)
         if: runner.os == 'macOS'
         shell: bash
@@ -333,6 +445,26 @@ jobs:
           Write-Host "Unity exited with code $exit"
           if ($exit -ne 0) { exit $exit }
 
+      - name: Run PlayMode tests (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        env:
+          AUDIENCE_TEST_PUBLISHABLE_KEY: ${{ secrets.AUDIENCE_TEST_PUBLISHABLE_KEY }}
+          AUDIENCE_SCRIPTING_BACKEND: ${{ matrix.backend }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          # Mirrors the macOS variant: tee Unity's stdout to artifacts/unity.log
+          # so the annotation step has a file to scan while progress streams to
+          # the job log. pipefail propagates Unity's exit code through tee.
+          "$UNITY_PATH" \
+            -batchmode -nographics \
+            -projectPath examples/audience \
+            -runTests \
+            -testPlatform ${{ matrix.target }} \
+            -testResults "$(pwd)/artifacts/test-results.xml" \
+            -logFile - 2>&1 | tee "$(pwd)/artifacts/unity.log"
+
       - name: Mark workspace safe for git (Windows)
         if: always() && runner.os == 'Windows'
         shell: pwsh
@@ -372,6 +504,21 @@ jobs:
                 Copy-Item -Path $_.FullName -Destination "artifacts/Player-$name.log" -ErrorAction SilentlyContinue
               }
           }
+
+      - name: Capture player log (Linux)
+        if: always() && runner.os == 'Linux'
+        shell: bash
+        run: |
+          # See macOS counterpart for rationale. Linux player log location:
+          # ~/.config/unity3d/<CompanyName>/<ProductName>/Player.log (Unity's
+          # standard persistent data path on Linux, matching $XDG_CONFIG_HOME).
+          mkdir -p artifacts
+          src="$HOME/.config/unity3d"
+          if [ -d "$src" ]; then
+            find "$src" -name "Player.log" 2>/dev/null | while IFS= read -r f; do
+              cp "$f" "artifacts/Player-$(basename "$(dirname "$f")").log" 2>/dev/null || true
+            done
+          fi
 
       - name: Surface Unity compile errors as annotations (macOS)
         if: always() && runner.os == 'macOS'
@@ -417,6 +564,23 @@ jobs:
               $sanitized = $_ -replace '::', '%3A%3A'
               Write-Host "::error::$sanitized"
             }
+
+      - name: Surface Unity compile errors as annotations (Linux)
+        if: always() && runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -uo pipefail
+          # See macOS counterpart for rationale.
+          LOG_FILE="artifacts/unity.log"
+          if [ ! -f "$LOG_FILE" ]; then
+            echo "::notice::No Unity log file at $LOG_FILE."
+            exit 0
+          fi
+          grep -E '(error CS[0-9]+:|Compilation failed:)' "$LOG_FILE" | sort -u | while IFS= read -r line; do
+            trimmed="${line#"${line%%[![:space:]]*}"}"
+            sanitized="${trimmed//::/%3A%3A}"
+            echo "::error::$sanitized"
+          done || true
 
       - name: Publish test report
         uses: dorny/test-reporter@v3

--- a/src/Packages/Audience/Runtime/Unity/com.immutable.audience.unity.asmdef
+++ b/src/Packages/Audience/Runtime/Unity/com.immutable.audience.unity.asmdef
@@ -2,7 +2,7 @@
     "name": "Immutable.Audience.Unity",
     "rootNamespace": "Immutable.Audience.Unity",
     "references": ["Immutable.Audience.Runtime"],
-    "includePlatforms": ["Android", "Editor", "iOS", "macOSStandalone", "WindowsStandalone64"],
+    "includePlatforms": ["Android", "Editor", "iOS", "LinuxStandalone64", "macOSStandalone", "WindowsStandalone64"],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/src/Packages/Audience/Runtime/com.immutable.audience.asmdef
+++ b/src/Packages/Audience/Runtime/com.immutable.audience.asmdef
@@ -2,7 +2,7 @@
     "name": "Immutable.Audience.Runtime",
     "rootNamespace": "Immutable.Audience",
     "references": [],
-    "includePlatforms": ["Android", "Editor", "iOS", "macOSStandalone", "WindowsStandalone64"],
+    "includePlatforms": ["Android", "Editor", "iOS", "LinuxStandalone64", "macOSStandalone", "WindowsStandalone64"],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
## Summary

Adds `StandaloneLinux64` cells to the audience PlayMode matrix in `test-audience-sample-app.yml` and the Linux-specific steps that resolve, license, and run Unity on the new self-hosted Linux runner.

**Matrix additions**
- `StandaloneLinux64 / IL2CPP / 2021.3.45f2` and `StandaloneLinux64 / Mono2x / 2021.3.45f2`, both targeting `runner: [self-hosted, X64, Linux]`. Wider-matrix expansion to Unity 2022.3 and 6000.x lives in SDK-316.

**Editor and module install**
- `Resolve Unity (Linux)` calls `unityhub --headless install` for the Editor and, for IL2CPP cells, `install-modules --module linux-il2cpp`. Idempotent: tolerates "Editor already installed" / "No modules found to install" non-zero exits, validates the Editor binary and IL2CPP variation directory after, and exports `UNITY_PATH` to `$GITHUB_ENV`.

**License activation**
- `Activate Unity license (Linux)` uses the existing `UNITY_EMAIL` / `UNITY_PASSWORD` / `UNITY_SERIAL` secrets to activate once and cache. Detects `~/.local/share/unity3d/Unity/Unity_lic.ulf` and skips activation if present. Win/macOS runners are activated manually outside the workflow; Linux activates inside the workflow because the runner host was provisioned fresh.

**Toolchain preflight**
- `Verify IL2CPP toolchain (Linux)`, gated on `matrix.backend == 'IL2CPP'`, confirms `gcc` and `g++` are on PATH and prints a remediation message if missing (`sudo apt install -y build-essential`).

**Test execution and diagnostics**
- `Run PlayMode tests (Linux)` mirrors the macOS bash variant (tee Unity log, propagate exit via `pipefail`).
- `Capture player log (Linux)` copies `Player.log` from `~/.config/unity3d/<Company>/<Product>/` into artifacts.
- `Surface Unity compile errors (Linux)` promotes `error CS####:` and `Compilation failed:` lines to `::error::` annotations, matching the macOS counterpart.

**Out of scope (separate tickets)**
- Audience runtime Linux portability (paths, permissions, locale, case-sensitivity): SDK-317.
- Sample app Linux build verification: SDK-318.
- Wider matrix expansion (Unity 2022.3 and 6000.x): SDK-316.

Linear: [SDK-255](https://linear.app/imtbl/issue/SDK-255/il2cpp-compatibility-testing-on-linux-standalonelinux64)