### PR TITLE
ci(audience): add Linux desktop to PlayMode CI matrix via GameCI (SDK-255)

### DIFF
--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -405,6 +405,64 @@ jobs:
             artifacts/Player-*.log
             examples/audience/Logs/**
 
+  playmode-linux:
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+      || github.event_name == 'schedule'
+      || github.event_name == 'workflow_dispatch'
+    name: ${{ matrix.target }} / ${{ matrix.backend }} / Unity ${{ matrix.unity }}
+    runs-on: ubuntu-latest-8-cores
+    strategy:
+      fail-fast: false
+      matrix:
+        unity: ['2021.3.45f2', '6000.4.0f1', '2022.3.62f2']
+        target: [StandaloneLinux64]
+        backend: [IL2CPP, Mono2x]
+        exclude: ${{ fromJSON(github.event_name == 'pull_request' && '[{"unity":"2022.3.62f2"}]' || '[]') }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - uses: actions/cache@v4
+        with:
+          path: examples/audience/Library
+          key: Library-${{ matrix.backend }}-${{ matrix.target }}-${{ matrix.unity }}-${{ hashFiles('examples/audience/Assets/**', 'examples/audience/Packages/**', 'examples/audience/ProjectSettings/**', 'src/Packages/Audience/**') }}
+          restore-keys: |
+            Library-${{ matrix.backend }}-${{ matrix.target }}-${{ matrix.unity }}-
+            Library-${{ matrix.backend }}-${{ matrix.target }}-
+
+      - uses: game-ci/unity-test-runner@v4
+        id: playmode
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          AUDIENCE_TEST_PUBLISHABLE_KEY: ${{ secrets.AUDIENCE_TEST_PUBLISHABLE_KEY }}
+          AUDIENCE_SCRIPTING_BACKEND: ${{ matrix.backend }}
+        with:
+          unityVersion: ${{ matrix.unity }}
+          targetPlatform: ${{ matrix.target }}
+          projectPath: examples/audience
+          testMode: playmode
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish test report
+        uses: dorny/test-reporter@v3
+        if: always()
+        with:
+          name: PlayMode (${{ matrix.backend }} / ${{ matrix.target }})
+          path: ${{ steps.playmode.outputs.artifactsPath }}/playmode-results.xml
+          reporter: dotnet-nunit
+          fail-on-error: true
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playmode-${{ matrix.backend }}-${{ matrix.target }}-${{ matrix.unity }}
+          path: ${{ steps.playmode.outputs.artifactsPath }}
+
   # Mobile IL2CPP build validation — runs on GitHub-hosted Ubuntu via GameCI Docker
   # containers so self-hosted macOS/Windows machines are not occupied.
   # Scope: IL2CPP compile pipeline only. Runtime tests require a real device and

--- a/src/Packages/Audience/Runtime/Unity/com.immutable.audience.unity.asmdef
+++ b/src/Packages/Audience/Runtime/Unity/com.immutable.audience.unity.asmdef
@@ -2,7 +2,7 @@
     "name": "Immutable.Audience.Unity",
     "rootNamespace": "Immutable.Audience.Unity",
     "references": ["Immutable.Audience.Runtime"],
-    "includePlatforms": ["Android", "Editor", "iOS", "macOSStandalone", "WindowsStandalone64"],
+    "includePlatforms": ["Android", "Editor", "iOS", "LinuxStandalone64", "macOSStandalone", "WindowsStandalone64"],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/src/Packages/Audience/Runtime/com.immutable.audience.asmdef
+++ b/src/Packages/Audience/Runtime/com.immutable.audience.asmdef
@@ -2,7 +2,7 @@
     "name": "Immutable.Audience.Runtime",
     "rootNamespace": "Immutable.Audience",
     "references": [],
-    "includePlatforms": ["Android", "Editor", "iOS", "macOSStandalone", "WindowsStandalone64"],
+    "includePlatforms": ["Android", "Editor", "iOS", "LinuxStandalone64", "macOSStandalone", "WindowsStandalone64"],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
## Summary

Adds Linux desktop support to the audience CI matrix.

**SDK package**
- Adds `LinuxStandalone64` to `includePlatforms` in `src/Packages/Audience/Runtime/com.immutable.audience.asmdef` and `src/Packages/Audience/Runtime/Unity/com.immutable.audience.unity.asmdef`. Without these, the SDK does not compile when the build target is Linux and the sample app errors with `CS0246` for every audience type. The Tests asmdef already included Linux.

**CI**
- Adds a `playmode-linux` job in `.github/workflows/test-audience-sample-app.yml` that runs the audience PlayMode tests on `ubuntu-latest-8-cores` via `game-ci/unity-test-runner@v4`. Covers both scripting backends (IL2CPP and Mono2x).
- Mirrors the playmode (Win/macOS) job's PR-vs-schedule split from SDK-327: every PR runs Unity 2021 and 6000.4.0f1 (4 cells); the weekly cron and `workflow_dispatch` runs add Unity 2022.3.62f2 (6 cells total).
- Linux runs via GameCI on GitHub-hosted Ubuntu rather than a self-hosted machine, leaving self-hosted runners free for Win/macOS and avoiding Unity Pro seat-pool contention.

## Out of scope (separate tickets)

- Audience runtime Linux portability (paths, permissions, locale, case-sensitivity): SDK-317.
- Manual sample app verification on Linux: SDK-318.

Linear: [SDK-316](https://linear.app/imtbl/issue/SDK-316/add-linux-to-the-audience-sdks-ci-test-matrix)