### PR TITLE
ci(audience): trim playmode PR to 8 cells, add weekly 12-cell run (SDK-327)

### DIFF
--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -12,6 +12,13 @@ on:
       - 'examples/audience/Packages/**'
       - 'examples/audience/ProjectSettings/**'
       - '.github/workflows/test-audience-sample-app.yml'
+  schedule:
+    # Weekly full-matrix run on the default branch.
+    # Cron is UTC; cron has no DST awareness, so the local time shifts by one
+    # hour twice a year. Saturday 14:00 UTC maps to:
+    #   Sun 00:00 Sydney AEST / Sun 02:00 NZ NZST  (winter, Apr to Oct)
+    #   Sun 01:00 Sydney AEDT / Sun 03:00 NZ NZDT  (summer, Oct to Apr)
+    - cron: '0 14 * * 6'
   workflow_dispatch:
 
 concurrency:
@@ -19,73 +26,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Reduced matrix on pull_request, full matrix on schedule and
+  # workflow_dispatch. The self-hosted Windows runner pool is small, so
+  # trimming PR cells keeps PR feedback fast. `matrix.exclude` below is
+  # the source of truth for which cells are dropped on pull_request.
   playmode:
-    if: github.event.pull_request.head.repo.fork == false || github.event_name == 'workflow_dispatch'
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+      || github.event_name == 'schedule'
+      || github.event_name == 'workflow_dispatch'
     name: ${{ matrix.target }} / ${{ matrix.backend }} / Unity ${{ matrix.unity }}
     strategy:
       fail-fast: false
       matrix:
+        unity: ['2021.3.45f2', '6000.4.0f1', '2022.3.62f2']
+        target: [StandaloneWindows64, StandaloneOSX]
+        backend: [IL2CPP, Mono2x]
         include:
-          - target: StandaloneWindows64
-            backend: IL2CPP
-            unity: 2021.3.45f2
+          - unity: '2021.3.45f2'
             changeset: 88f88f591b2e
-            runner: [self-hosted, Windows, X64]
-          - target: StandaloneWindows64
-            backend: Mono2x
-            unity: 2021.3.45f2
-            changeset: 88f88f591b2e
-            runner: [self-hosted, Windows, X64]
-          - target: StandaloneOSX
-            backend: IL2CPP
-            unity: 2021.3.45f2
-            changeset: 88f88f591b2e
-            runner: [self-hosted, macOS, ARM64]
-          - target: StandaloneOSX
-            backend: Mono2x
-            unity: 2021.3.45f2
-            changeset: 88f88f591b2e
-            runner: [self-hosted, macOS, ARM64]
-          - target: StandaloneWindows64
-            backend: IL2CPP
-            unity: 6000.4.0f1
+          - unity: '6000.4.0f1'
             changeset: 8cf496087c8f
-            runner: [self-hosted, Windows, X64]
+          - unity: '2022.3.62f2'
+            changeset: 7670c08855a9
           - target: StandaloneWindows64
-            backend: Mono2x
-            unity: 6000.4.0f1
-            changeset: 8cf496087c8f
             runner: [self-hosted, Windows, X64]
           - target: StandaloneOSX
-            backend: IL2CPP
-            unity: 6000.4.0f1
-            changeset: 8cf496087c8f
             runner: [self-hosted, macOS, ARM64]
-          - target: StandaloneOSX
-            backend: Mono2x
-            unity: 6000.4.0f1
-            changeset: 8cf496087c8f
-            runner: [self-hosted, macOS, ARM64]
-          - target: StandaloneWindows64
-            backend: IL2CPP
-            unity: 2022.3.62f2
-            changeset: 7670c08855a9
-            runner: [self-hosted, Windows, X64]
-          - target: StandaloneWindows64
-            backend: Mono2x
-            unity: 2022.3.62f2
-            changeset: 7670c08855a9
-            runner: [self-hosted, Windows, X64]
-          - target: StandaloneOSX
-            backend: IL2CPP
-            unity: 2022.3.62f2
-            changeset: 7670c08855a9
-            runner: [self-hosted, macOS, ARM64]
-          - target: StandaloneOSX
-            backend: Mono2x
-            unity: 2022.3.62f2
-            changeset: 7670c08855a9
-            runner: [self-hosted, macOS, ARM64]
+        exclude: ${{ fromJSON(github.event_name == 'pull_request' && '[{"unity":"2022.3.62f2"}]' || '[]') }}
     runs-on: ${{ matrix.runner }}
     # Healthy cells finish in ~10 min. 30 min covers cold caches +
     # IL2CPP + Unity 6 startup; anything past that is a hang. Capping
@@ -450,24 +418,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        target: [Android, iOS]
+        unity: ['2021.3.45f2', '2022.3.62f2', '6000.4.5f1']
         include:
           - target: Android
-            unity: 2021.3.45f2
-            method: AndroidBuilder.Build
-          - target: Android
-            unity: 2022.3.62f2
-            method: AndroidBuilder.Build
-          - target: Android
-            unity: 6000.4.5f1
             method: AndroidBuilder.Build
           - target: iOS
-            unity: 2021.3.45f2
-            method: IosBuilder.Build
-          - target: iOS
-            unity: 2022.3.62f2
-            method: IosBuilder.Build
-          - target: iOS
-            unity: 6000.4.5f1
             method: IosBuilder.Build
 
     steps:


### PR DESCRIPTION
## Summary

- Trims playmode PR matrix from 12 to 8 cells; drops Unity 2022.3.62f2 from PR runs.
- Adds `on: schedule` (Sat 14:00 UTC = Sun 00:00 Sydney AEST in winter, Sun 01:00 AEDT in summer) so the full 12-cell matrix runs weekly on the default branch.
- `workflow_dispatch` continues to fire the full matrix on demand.
- Restructures the playmode matrix from a flat 12-entry include list to cross-product axes (unity x target x backend) plus include entries that supply changeset by unity and runner by target.
- `matrix.exclude` is set conditionally via `fromJSON`, so only PR runs drop the 2022 cells. Single job, no duplicated steps.
- Tidies the mobile-build matrix to the same cross-product shape (target x unity, method added by target via include). Same 6 cells, same behaviour.

Linear: [SDK-327](https://linear.app/imtbl/issue/SDK-327)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI matrix logic and trigger conditions, which could unintentionally reduce test coverage on PRs or misconfigure scheduled runs if the matrix/exclude expressions are wrong.
> 
> **Overview**
> Adds a weekly `schedule` trigger to run the full PlayMode test matrix on the default branch, while keeping `workflow_dispatch` for on-demand full runs.
> 
> Restructures the PlayMode matrix into cross-product axes (`unity`/`target`/`backend`) with `include` entries for `changeset` and per-target runners, and conditionally excludes Unity `2022.3.62f2` on `pull_request` to trim PR runs.
> 
> Simplifies the `mobile-build` job matrix to the same cross-product shape (target × unity) while preserving the same build methods and overall behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69a42d31e5a685fce8540dea4b9753f3a6923424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->