### PR TITLE
feat(audience-sdk): iOS SKAdNetwork registration on first launch (SDK-307)

### DIFF
--- a/examples/audience/Assets/SampleApp/Resources/AudienceSample.uxml
+++ b/examples/audience/Assets/SampleApp/Resources/AudienceSample.uxml
@@ -99,6 +99,12 @@
                                      text="Mirror SDK internal log output into the in-page event log below." />
                         </ui:VisualElement>
 
+                        <ui:VisualElement class="field">
+                            <ui:Toggle name="enable-mobile-attribution" label="MOBILE ATTRIBUTION" />
+                            <ui:Label class="helper-text below-field"
+                                     text="Enable iOS SKAdNetwork registration and mobile attribution signals." />
+                        </ui:VisualElement>
+
                         <ui:VisualElement class="field placeholder-host">
                             <ui:Label class="field-label" text="BASE URL OVERRIDE" />
                             <ui:TextField name="base-url" />

--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.UI.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.UI.cs
@@ -52,7 +52,7 @@ namespace Immutable.Audience.Samples.SampleApp
 
         private TextField _publishableKey, _baseUrl, _flushInterval, _flushSize;
         private DropdownField _initialConsent;
-        private Toggle _debug;
+        private Toggle _debug, _enableMobileAttribution;
         private Button _btnInit, _btnFlush, _btnReset, _btnShutdown, _btnDeleteData;
 
         // ---- UXML element fields (Consent tab) ----
@@ -180,7 +180,8 @@ namespace Immutable.Audience.Samples.SampleApp
             _publishableKey = Require<TextField>("publishable-key");
             _baseUrl        = Require<TextField>("base-url");
             _initialConsent = Require<DropdownField>("initial-consent");
-            _debug          = Require<Toggle>("debug");
+            _debug                    = Require<Toggle>("debug");
+            _enableMobileAttribution  = Require<Toggle>("enable-mobile-attribution");
             // Inject a tick Label — Unity 2021.3 runtime panels render the
             // checked state as a plain coloured square otherwise. USS hides
             // the tick when unchecked.
@@ -640,15 +641,17 @@ namespace Immutable.Audience.Samples.SampleApp
             public readonly string BaseUrl;
             public readonly ConsentLevel Consent;
             public readonly bool Debug;
+            public readonly bool EnableMobileAttribution;
             public readonly int? FlushIntervalMs;
             public readonly int? FlushSize;
 
-            public InitForm(string publishableKey, string baseUrl, ConsentLevel consent, bool debug, int? flushIntervalMs, int? flushSize)
+            public InitForm(string publishableKey, string baseUrl, ConsentLevel consent, bool debug, bool enableMobileAttribution, int? flushIntervalMs, int? flushSize)
             {
                 PublishableKey = publishableKey;
                 BaseUrl = baseUrl;
                 Consent = consent;
                 Debug = debug;
+                EnableMobileAttribution = enableMobileAttribution;
                 FlushIntervalMs = flushIntervalMs;
                 FlushSize = flushSize;
             }
@@ -660,12 +663,13 @@ namespace Immutable.Audience.Samples.SampleApp
             int? flushIntervalMs = int.TryParse((_flushInterval.value ?? "").Trim(), out var ms) && ms > 0 ? ms : (int?)null;
             int? flushSize = int.TryParse((_flushSize.value ?? "").Trim(), out var size) && size > 0 ? size : (int?)null;
             return new InitForm(
-                publishableKey:  (_publishableKey.value ?? "").Trim(),
-                baseUrl:         (_baseUrl.value ?? "").Trim(),
-                consent:         ConsentOrder[consentIdx],
-                debug:           _debug.value,
-                flushIntervalMs: flushIntervalMs,
-                flushSize:       flushSize);
+                publishableKey:          (_publishableKey.value ?? "").Trim(),
+                baseUrl:                 (_baseUrl.value ?? "").Trim(),
+                consent:                 ConsentOrder[consentIdx],
+                debug:                   _debug.value,
+                enableMobileAttribution: _enableMobileAttribution.value,
+                flushIntervalMs:         flushIntervalMs,
+                flushSize:               flushSize);
         }
 
         // Snapshot of the identify form on the Identity tab.

--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
@@ -301,11 +301,12 @@ namespace Immutable.Audience.Samples.SampleApp
         {
             var config = new AudienceConfig
             {
-                PublishableKey = form.PublishableKey,
-                BaseUrl        = string.IsNullOrEmpty(form.BaseUrl) ? null : form.BaseUrl,
-                Consent        = form.Consent,
-                Debug          = form.Debug,
-                OnError        = onError,
+                PublishableKey          = form.PublishableKey,
+                BaseUrl                 = string.IsNullOrEmpty(form.BaseUrl) ? null : form.BaseUrl,
+                Consent                 = form.Consent,
+                Debug                   = form.Debug,
+                EnableMobileAttribution = form.EnableMobileAttribution,
+                OnError                 = onError,
             };
             if (form.FlushIntervalMs is int flushMs && flushMs > 0)
             {
@@ -324,12 +325,13 @@ namespace Immutable.Audience.Samples.SampleApp
         {
             var echo = new Dictionary<string, object>
             {
-                ["consent"]                = config.Consent.ToString(),
-                ["debug"]                  = config.Debug,
-                ["flushIntervalSeconds"]   = config.FlushIntervalSeconds,
-                ["flushSize"]              = config.FlushSize,
-                ["packageVersion"]         = config.PackageVersion,
-                ["shutdownFlushTimeoutMs"] = config.ShutdownFlushTimeoutMs,
+                ["consent"]                  = config.Consent.ToString(),
+                ["debug"]                    = config.Debug,
+                ["enableMobileAttribution"]  = config.EnableMobileAttribution,
+                ["flushIntervalSeconds"]     = config.FlushIntervalSeconds,
+                ["flushSize"]                = config.FlushSize,
+                ["packageVersion"]           = config.PackageVersion,
+                ["shutdownFlushTimeoutMs"]   = config.ShutdownFlushTimeoutMs,
             };
             if (!string.IsNullOrEmpty(config.PublishableKey))
                 echo["publishableKey"] = RedactPublishableKey(config.PublishableKey);

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -48,6 +48,11 @@ namespace Immutable.Audience
         internal static volatile Func<IReadOnlyDictionary<string, object>>? LaunchContextProvider;
         internal static volatile Func<IReadOnlyDictionary<string, object>>? ContextProvider;
 
+        // Called during Init when config.EnableMobileAttribution is true.
+        // Returns true on first SKAN registration, null if already done or not applicable.
+        // Set by the Unity layer; null in pure-C# environments.
+        internal static volatile Func<bool?>? MobileAttributionProvider;
+
         // Active session. Created at Init (or on upgrade from None) and disposed
         // on Shutdown or SetConsent(None). Volatile so OnPause/OnResume see
         // assignments from SetConsent without taking _initLock.
@@ -204,7 +209,14 @@ namespace Immutable.Audience
             // shows the new sessionId ahead of the launch event.
             sessionToStart?.Start();
 
-            FireGameLaunch(config, consentAtInit);
+            bool? skanRegistered = null;
+            if (config.EnableMobileAttribution)
+            {
+                try { skanRegistered = MobileAttributionProvider?.Invoke(); }
+                catch (Exception ex) { Log.Warn(AudienceLogs.MobileAttributionProviderThrew(ex)); }
+            }
+
+            FireGameLaunch(config, consentAtInit, skanRegistered);
         }
 
         // Pause/Resume hooks for the Unity lifecycle bridge.
@@ -982,7 +994,7 @@ namespace Immutable.Audience
         }
 
         // consentAtInit only gates the launch; Track still checks live _state via CanTrack.
-        private static void FireGameLaunch(AudienceConfig config, ConsentLevel consentAtInit)
+        private static void FireGameLaunch(AudienceConfig config, ConsentLevel consentAtInit, bool? skanRegistered = null)
         {
             if (!consentAtInit.CanTrack()) return;
 
@@ -1010,6 +1022,10 @@ namespace Immutable.Audience
             // Config-supplied distributionPlatform overrides the provider value.
             if (config.DistributionPlatform != null)
                 properties["distributionPlatform"] = config.DistributionPlatform;
+
+            // Emitted only on the first launch where SKAN registration fires.
+            if (skanRegistered == true)
+                properties["skanRegistered"] = true;
 
             // No sessionId on game_launch per Event Reference. Pipeline correlates
             // via eventTimestamp with the session_start that fires just before.

--- a/src/Packages/Audience/Runtime/Plugins/iOS/AudienceMobileBridge.mm
+++ b/src/Packages/Audience/Runtime/Plugins/iOS/AudienceMobileBridge.mm
@@ -12,4 +12,15 @@ const char* _AudienceGetIDFV(void)
     return idfv ? strdup([idfv UTF8String]) : NULL;
 }
 
+void _AudienceRegisterSKAN(void)
+{
+    // Runtime dispatch avoids a hard link to StoreKit.framework, which would
+    // trigger Xcode's In-App Purchase capability check. StoreKit is always
+    // present on device; NSClassFromString finds it without a compile-time dep.
+    Class cls = NSClassFromString(@"SKAdNetwork");
+    if (cls) {
+        [cls performSelector:@selector(registerAppForAdNetworkAttribution)];
+    }
+}
+
 }

--- a/src/Packages/Audience/Runtime/Unity/AudienceUnityHooks.cs
+++ b/src/Packages/Audience/Runtime/Unity/AudienceUnityHooks.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using Immutable.Audience.Unity.Mobile;
 using UnityEngine;
 
 namespace Immutable.Audience.Unity
@@ -26,6 +27,10 @@ namespace Immutable.Audience.Unity
                 new ReadOnlyDictionary<string, object>(DeviceCollector.CollectContext());
             ImmutableAudience.LaunchContextProvider = () => launchProps;
             ImmutableAudience.ContextProvider = () => contextProps;
+
+#if UNITY_IOS && !UNITY_EDITOR
+            ImmutableAudience.MobileAttributionProvider = () => SkanRegistration.RegisterIfFirstLaunch();
+#endif
 
             UnityLifecycleBridge.EnsureExists();
 

--- a/src/Packages/Audience/Runtime/Unity/Mobile/SKANBridge.cs
+++ b/src/Packages/Audience/Runtime/Unity/Mobile/SKANBridge.cs
@@ -1,0 +1,25 @@
+#nullable enable
+
+using System;
+#if UNITY_IOS
+using System.Runtime.InteropServices;
+#endif
+
+namespace Immutable.Audience.Unity.Mobile
+{
+    internal static class SKANBridge
+    {
+        internal static Action Impl = NativeImpl;
+
+        internal static void Register() => Impl();
+
+#if UNITY_IOS
+        [DllImport("__Internal")]
+        private static extern void _AudienceRegisterSKAN();
+
+        private static void NativeImpl() => _AudienceRegisterSKAN();
+#else
+        private static void NativeImpl() { }
+#endif
+    }
+}

--- a/src/Packages/Audience/Runtime/Unity/Mobile/SKANBridge.cs.meta
+++ b/src/Packages/Audience/Runtime/Unity/Mobile/SKANBridge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Runtime/Unity/Mobile/SkanRegistration.cs
+++ b/src/Packages/Audience/Runtime/Unity/Mobile/SkanRegistration.cs
@@ -1,0 +1,33 @@
+#nullable enable
+
+using System;
+using UnityEngine;
+
+namespace Immutable.Audience.Unity.Mobile
+{
+    internal static class SkanRegistration
+    {
+        private const string PrefsKey = "ImmutableAudience.skan_registered";
+
+        // Replaceable in tests.
+        internal static Func<bool> HasRegistered = DefaultHasRegistered;
+        internal static Action MarkRegistered = DefaultMarkRegistered;
+
+        // Returns true on first registration (SKAN was called), null if already done or N/A.
+        internal static bool? RegisterIfFirstLaunch()
+        {
+            if (HasRegistered()) return null;
+            SKANBridge.Register();
+            MarkRegistered();
+            return true;
+        }
+
+        private static bool DefaultHasRegistered() => PlayerPrefs.HasKey(PrefsKey);
+
+        private static void DefaultMarkRegistered()
+        {
+            PlayerPrefs.SetInt(PrefsKey, 1);
+            PlayerPrefs.Save();
+        }
+    }
+}

--- a/src/Packages/Audience/Runtime/Unity/Mobile/SkanRegistration.cs.meta
+++ b/src/Packages/Audience/Runtime/Unity/Mobile/SkanRegistration.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Runtime/Utility/Log.cs
+++ b/src/Packages/Audience/Runtime/Utility/Log.cs
@@ -136,5 +136,9 @@ namespace Immutable.Audience
         internal static string LaunchContextProviderThrew(Exception ex) =>
             $"LaunchContextProvider threw {ex.GetType().Name}: {ex.Message}. " +
             "game_launch will ship without auto-detected Unity context.";
+
+        internal static string MobileAttributionProviderThrew(Exception ex) =>
+            $"MobileAttributionProvider threw {ex.GetType().Name}: {ex.Message}. " +
+            "game_launch will ship without skanRegistered.";
     }
 }

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -29,6 +29,7 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.LaunchContextProvider = null;
             ImmutableAudience.ContextProvider = null;
             ImmutableAudience.DefaultPersistentDataPathProvider = null;
+            ImmutableAudience.MobileAttributionProvider = null;
             Identity.Reset(_testDir);
             if (Directory.Exists(_testDir))
                 Directory.Delete(_testDir, recursive: true);
@@ -1239,6 +1240,54 @@ namespace Immutable.Audience.Tests
                 .Select(File.ReadAllText).ToList();
             Assert.IsTrue(contents.Any(c => c.Contains("\"game_launch\"")),
                 "game_launch must still ship when the context provider throws");
+        }
+
+        [Test]
+        public void Init_GameLaunch_IncludesSkanRegistered_WhenProviderReturnsTrue()
+        {
+            ImmutableAudience.MobileAttributionProvider = () => true;
+            var config = MakeConfig();
+            config.EnableMobileAttribution = true;
+            ImmutableAudience.Init(config);
+            ImmutableAudience.Shutdown();
+
+            var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
+                .Select(File.ReadAllText)
+                .First(c => c.Contains("\"game_launch\""));
+            StringAssert.Contains("\"skanRegistered\":true", launchFile);
+        }
+
+        [Test]
+        public void Init_GameLaunch_OmitsSkanRegistered_WhenProviderReturnsNull()
+        {
+            ImmutableAudience.MobileAttributionProvider = () => null;
+            var config = MakeConfig();
+            config.EnableMobileAttribution = true;
+            ImmutableAudience.Init(config);
+            ImmutableAudience.Shutdown();
+
+            var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
+                .Select(File.ReadAllText)
+                .First(c => c.Contains("\"game_launch\""));
+            Assert.IsFalse(launchFile.Contains("skanRegistered"));
+        }
+
+        [Test]
+        public void Init_GameLaunch_OmitsSkanRegistered_WhenMobileAttributionDisabled()
+        {
+            var callCount = 0;
+            ImmutableAudience.MobileAttributionProvider = () => { callCount++; return true; };
+            var config = MakeConfig();
+            config.EnableMobileAttribution = false;
+            ImmutableAudience.Init(config);
+            ImmutableAudience.Shutdown();
+
+            Assert.AreEqual(0, callCount,
+                "MobileAttributionProvider must not be called when EnableMobileAttribution is false");
+            var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
+                .Select(File.ReadAllText)
+                .First(c => c.Contains("\"game_launch\""));
+            Assert.IsFalse(launchFile.Contains("skanRegistered"));
         }
 
         // -----------------------------------------------------------------

--- a/src/Packages/Audience/Tests/Runtime/Unity/SkanRegistrationTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Unity/SkanRegistrationTests.cs
@@ -1,0 +1,78 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Immutable.Audience.Unity.Mobile;
+
+namespace Immutable.Audience.Tests
+{
+    [TestFixture]
+    internal class SkanRegistrationTests
+    {
+        private Action? _originalBridgeImpl;
+        private Func<bool>? _originalHasRegistered;
+        private Action? _originalMarkRegistered;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _originalBridgeImpl = SKANBridge.Impl;
+            _originalHasRegistered = SkanRegistration.HasRegistered;
+            _originalMarkRegistered = SkanRegistration.MarkRegistered;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            SKANBridge.Impl = _originalBridgeImpl!;
+            SkanRegistration.HasRegistered = _originalHasRegistered!;
+            SkanRegistration.MarkRegistered = _originalMarkRegistered!;
+        }
+
+        [Test]
+        public void RegisterIfFirstLaunch_FirstLaunch_CallsBridgeAndReturnsTrue()
+        {
+            var bridgeCalled = false;
+            var marked = false;
+            SKANBridge.Impl = () => { bridgeCalled = true; };
+            SkanRegistration.HasRegistered = () => false;
+            SkanRegistration.MarkRegistered = () => { marked = true; };
+
+            var result = SkanRegistration.RegisterIfFirstLaunch();
+
+            Assert.AreEqual(true, result, "first launch must return true");
+            Assert.IsTrue(bridgeCalled, "bridge must be called on first launch");
+            Assert.IsTrue(marked, "registered flag must be persisted");
+        }
+
+        [Test]
+        public void RegisterIfFirstLaunch_AlreadyRegistered_SkipsBridgeAndReturnsNull()
+        {
+            var bridgeCalled = false;
+            SKANBridge.Impl = () => { bridgeCalled = true; };
+            SkanRegistration.HasRegistered = () => true;
+
+            var result = SkanRegistration.RegisterIfFirstLaunch();
+
+            Assert.IsNull(result, "subsequent launches must return null");
+            Assert.IsFalse(bridgeCalled, "bridge must not be called if already registered");
+        }
+
+        [Test]
+        public void RegisterIfFirstLaunch_PersistsAfterBridgeCall()
+        {
+            // Bridge must fire before MarkRegistered so the flag isn't set if the
+            // native call throws (a future crash here won't block re-registration).
+            var order = new List<string>();
+            SKANBridge.Impl = () => order.Add("bridge");
+            SkanRegistration.HasRegistered = () => false;
+            SkanRegistration.MarkRegistered = () => order.Add("mark");
+
+            SkanRegistration.RegisterIfFirstLaunch();
+
+            Assert.AreEqual(new[] { "bridge", "mark" }, order,
+                "bridge must fire before the registered flag is persisted");
+        }
+    }
+}

--- a/src/Packages/Audience/Tests/Runtime/Unity/SkanRegistrationTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/Unity/SkanRegistrationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

- Adds `_AudienceRegisterSKAN()` to the Obj-C++ bridge using runtime dispatch (`NSClassFromString`) to avoid a hard StoreKit link (which would trigger the In-App Purchase capability and block personal team builds)
- Calls registration on first launch when `config.EnableMobileAttribution = true`, skipping on subsequent launches via a PlayerPrefs flag
- Emits `skanRegistered: true` on `game_launch` only when registration fires (per-install signal — reappears after reinstall, not after `Reset()`)
- Sample app gets a **Mobile Attribution** toggle on the Setup tab to drive `EnableMobileAttribution`

## Depends on

PR #744 (SDK-308 — iOS Info.plist post-processor). Targets that branch so the diff is clean.

## Test plan

- [ ] First launch with Mobile Attribution toggled on → `game_launch` contains `skanRegistered: true`
- [ ] Quit and relaunch → `game_launch` fires, `skanRegistered` absent
- [ ] `SkanRegistrationTests` — first launch calls bridge + persists, subsequent launch skips
- [ ] `ImmutableAudienceTests` — three new cases covering provider returns true/null and disabled flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds iOS native/Unity bridging and new `game_launch` telemetry fields gated by `EnableMobileAttribution`; risk centers on platform-conditional native interop and ensuring the new provider is only invoked when intended.
> 
> **Overview**
> Adds opt-in iOS SKAdNetwork registration on first launch when `AudienceConfig.EnableMobileAttribution` is set, wiring a new Unity-installed `MobileAttributionProvider` into `ImmutableAudience.Init` and emitting `skanRegistered: true` on `game_launch` only when registration fires.
> 
> Introduces a runtime-dispatched Obj-C++ bridge (`_AudienceRegisterSKAN`) to avoid a hard StoreKit link, plus Unity-side `SKANBridge`/`SkanRegistration` (PlayerPrefs-backed “first launch” flag). Updates the sample app UI to expose a **Mobile Attribution** toggle and expands tests to cover provider behavior and first-launch persistence/ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6274d79e7d23edc13bc08ec08e7a8583d1d869c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->