### PR TITLE
ci(audience): align mobile-build triggers with playmode (SDK-329)

### DIFF
--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -412,7 +412,10 @@ jobs:
   # Note: Unity 6 cells use 6000.4.5f1 (the latest patch with a GameCI image);
   # 6000.4.0f1 does not have a published GameCI Docker image.
   mobile-build:
-    if: github.event.pull_request.head.repo.fork == false || github.event_name == 'workflow_dispatch'
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+      || github.event_name == 'schedule'
+      || github.event_name == 'workflow_dispatch'
     name: ${{ matrix.target }} / IL2CPP / Unity ${{ matrix.unity }}
     runs-on: ubuntu-latest-8-cores
     strategy:


### PR DESCRIPTION
## Summary

- Replaces mobile-build's short-form `if` with explicit enumeration of `pull_request` (non-fork), `schedule`, and `workflow_dispatch`.
- Removes reliance on GitHub Actions coercing `null == false` to true; the previous form was already firing the job on schedule events by accident.
- Aligns the mobile-build trigger envelope with the playmode job above it, so the weekly cron exercises the full mobile build matrix the same way it exercises the full playmode matrix.
- mobile-build matrix and steps unchanged.

Linear: [SDK-329](https://linear.app/imtbl/issue/SDK-329)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that adjusts when `mobile-build` runs (no build matrix/steps modified). Main impact is CI coverage/cost by ensuring scheduled runs include the mobile matrix and avoiding accidental truthy comparisons on non-PR events.
> 
> **Overview**
> Updates the GitHub Actions `mobile-build` job condition to explicitly allow only **non-fork `pull_request`**, `schedule`, and `workflow_dispatch` events.
> 
> This removes reliance on implicit/null comparisons in the previous short-form `if` and aligns `mobile-build`’s trigger behavior with the `playmode` job so weekly scheduled runs exercise the full mobile IL2CPP build matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b691d4aeff922fa6e3c783e2cca7d0eb3876d57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->