### PR TITLE
ci(audience): align mobile-build Unity 6 cells with playmode at 6000.4.0f1

### DIFF
--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -467,8 +467,6 @@ jobs:
   # containers so self-hosted macOS/Windows machines are not occupied.
   # Scope: IL2CPP compile pipeline only. Runtime tests require a real device and
   # are out of scope until a device farm is available.
-  # Note: Unity 6 cells use 6000.4.5f1 (the latest patch with a GameCI image);
-  # 6000.4.0f1 does not have a published GameCI Docker image.
   mobile-build:
     if: github.event.pull_request.head.repo.fork == false || github.event_name == 'workflow_dispatch'
     name: ${{ matrix.target }} / IL2CPP / Unity ${{ matrix.unity }}
@@ -477,7 +475,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [Android, iOS]
-        unity: ['2021.3.45f2', '2022.3.62f2', '6000.4.5f1']
+        unity: ['2021.3.45f2', '2022.3.62f2', '6000.4.0f1']
         include:
           - target: Android
             method: AndroidBuilder.Build


### PR DESCRIPTION
## Summary

Aligns the audience mobile-build job's Unity 6 cells with the playmode (Win/macOS) and playmode-linux jobs at 6000.4.0f1. GameCI now publishes Docker images for 6000.4.0f1 (Android and Linux variants confirmed; iOS variant verified by CI in this PR), so the workaround that pinned mobile to 6000.4.5f1 is no longer needed.

Addresses Cursor Bugbot comment on PR #745:
https://github.com/immutable/unity-immutable-sdk/pull/745#discussion_r3198930803

No Linear ticket; small follow-up to the SDK-316 / SDK-327 work in PR #745.

## Changes

- Mobile-build matrix Unity 6 entry: 6000.4.5f1 -> 6000.4.0f1.
- Removed the stale comment claiming GameCI does not publish a 6000.4.0f1 Docker image.

## Test plan

- [ ] CI green on Android cells for 2021.3.45f2, 2022.3.62f2, 6000.4.0f1.
- [ ] CI green on iOS cells for 2021.3.45f2, 2022.3.62f2, 6000.4.0f1.
- [ ] If the iOS 6000.4.0f1 cell fails because GameCI lacks an ios-6000.4.0f1 image, revert just that cell to 6000.4.5f1.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adjusts the Unity version used in the mobile IL2CPP build matrix; main impact is potential CI breakage if GameCI images are missing/mismatched for that version.
> 
> **Overview**
> Aligns the `mobile-build` GitHub Actions job’s Unity 6 matrix entry from `6000.4.5f1` back to `6000.4.0f1` to match the PlayMode jobs.
> 
> Removes the stale workflow comment claiming a `6000.4.0f1` GameCI Docker image is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 463afe04ddef3564cfa433e9e044172472d4f69c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->