### PR TITLE
feat(audience-sdk): iOS App Tracking Transparency + IDFA support (SDK-306)

### DIFF
--- a/examples/audience/Assets/SampleApp/Resources/AudienceSample.uxml
+++ b/examples/audience/Assets/SampleApp/Resources/AudienceSample.uxml
@@ -99,10 +99,20 @@
                                      text="Mirror SDK internal log output into the in-page event log below." />
                         </ui:VisualElement>
 
-                        <ui:VisualElement class="field">
+                        <ui:VisualElement name="mobile-attribution-field" class="field">
                             <ui:Toggle name="enable-mobile-attribution" label="MOBILE ATTRIBUTION" />
                             <ui:Label class="helper-text below-field"
                                      text="Enable iOS SKAdNetwork registration and mobile attribution signals." />
+                            <ui:VisualElement name="att-section">
+                                <ui:VisualElement class="actions last">
+                                    <ui:Button name="btn-request-att" class="with-sig">
+                                        <ui:Label class="btn-label" text="Request ATT" />
+                                        <ui:Label class="btn-sig" text="requestTrackingAuthorizationAsync()" />
+                                    </ui:Button>
+                                </ui:VisualElement>
+                                <ui:Label class="helper-text below-field"
+                                         text="iOS-only. Triggers the system ATT prompt on first call; subsequent calls return the cached status." />
+                            </ui:VisualElement>
                         </ui:VisualElement>
 
                         <ui:VisualElement class="field placeholder-host">

--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.UI.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.UI.cs
@@ -53,7 +53,7 @@ namespace Immutable.Audience.Samples.SampleApp
         private TextField _publishableKey, _baseUrl, _flushInterval, _flushSize;
         private DropdownField _initialConsent;
         private Toggle _debug, _enableMobileAttribution;
-        private Button _btnInit, _btnFlush, _btnReset, _btnShutdown, _btnDeleteData;
+        private Button _btnInit, _btnFlush, _btnReset, _btnShutdown, _btnDeleteData, _btnRequestAtt;
 
         // ---- UXML element fields (Consent tab) ----
 
@@ -197,10 +197,13 @@ namespace Immutable.Audience.Samples.SampleApp
             _flushSize     = Require<TextField>("flush-size");
             _btnInit       = Require<Button>("btn-init");
 
-            _btnFlush      = Require<Button>("btn-flush");
-            _btnReset      = Require<Button>("btn-reset");
-            _btnShutdown   = Require<Button>("btn-shutdown");
-            _btnDeleteData = Require<Button>("btn-delete-data");
+            _btnFlush       = Require<Button>("btn-flush");
+            _btnReset       = Require<Button>("btn-reset");
+            _btnShutdown    = Require<Button>("btn-shutdown");
+            _btnDeleteData  = Require<Button>("btn-delete-data");
+            _btnRequestAtt  = Require<Button>("btn-request-att");
+
+            ApplyMobilePlatformVisibility();
 
             _consentPills = new Dictionary<ConsentLevel, Button>
             {
@@ -245,6 +248,24 @@ namespace Immutable.Audience.Samples.SampleApp
             _logView.contentContainer.usageHints = UsageHints.GroupTransform;
 
             _logCount = Require<Label>("log-count");
+        }
+
+        // EnableMobileAttribution is a no-op on Standalone, so the toggle and
+        // ATT button only appear on iOS/Android. ATT is iOS-only — Android
+        // attribution uses a different signal — so the ATT subsection is
+        // hidden on Android even when the toggle remains visible.
+        // UNITY_IOS / UNITY_ANDROID also evaluate true in the Editor when the
+        // matching build target is active, which is the right behavior for
+        // testing.
+        private void ApplyMobilePlatformVisibility()
+        {
+#if !(UNITY_IOS || UNITY_ANDROID)
+            var mobileField = _root.Q<VisualElement>("mobile-attribution-field");
+            if (mobileField != null) mobileField.style.display = DisplayStyle.None;
+#elif !UNITY_IOS
+            var attSection = _root.Q<VisualElement>("att-section");
+            if (attSection != null) attSection.style.display = DisplayStyle.None;
+#endif
         }
 
         private void PopulateDropdowns()
@@ -300,9 +321,10 @@ namespace Immutable.Audience.Samples.SampleApp
                 _identifyId, _identifyTraits, _traitsUpdate,
             }) RegisterPlaceholder(field);
 
-            _publishableKey.RegisterValueChangedCallback(_ => { _btnInit.SetEnabled(!_initialised && !string.IsNullOrWhiteSpace(_publishableKey.value)); RefreshStatusBar(); });
+            _publishableKey.RegisterValueChangedCallback(_ => { _btnInit.SetEnabled(!_initialised && !string.IsNullOrWhiteSpace(_publishableKey.value)); UpdateAttButtonGate(); RefreshStatusBar(); });
             _initialConsent.RegisterValueChangedCallback(_ => RefreshStatusBar());
             _baseUrl.RegisterValueChangedCallback(_ => RefreshStatusBar());
+            _enableMobileAttribution.RegisterValueChangedCallback(_ => UpdateAttButtonGate());
 
             _btnInit.clicked += OnInit;
 
@@ -310,6 +332,7 @@ namespace Immutable.Audience.Samples.SampleApp
             _btnReset.clicked += OnReset;
             _btnShutdown.clicked += OnShutdown;
             _btnDeleteData.clicked += async () => await OnDeleteDataAsync();
+            _btnRequestAtt.clicked += async () => await OnRequestAttAsync();
             _btnIdentify.clicked += OnIdentify;
             _btnIdentifyTraits.clicked += OnIdentifyTraits;
             _btnAlias.clicked += OnAlias;
@@ -621,6 +644,18 @@ namespace Immutable.Audience.Samples.SampleApp
             foreach (var btn in _typedEventsHost.Query<Button>().ToList()) btn.SetEnabled(_initialised);
             _btnInit.SetEnabled(!_initialised && !string.IsNullOrWhiteSpace(_publishableKey.value));
             _btnAlias.SetEnabled(_initialised && IsAliasReady());
+            UpdateAttButtonGate();
+        }
+
+        // ATT prompt is independent of SDK init, but in the demo flow it's
+        // only useful once a key is set (so events have somewhere to ship)
+        // and the toggle is on (so the chosen status actually appears on
+        // game_launch via MobileAttributionContextProvider).
+        private void UpdateAttButtonGate()
+        {
+            _btnRequestAtt.SetEnabled(
+                !string.IsNullOrWhiteSpace(_publishableKey.value) &&
+                _enableMobileAttribution.value);
         }
 
         private void RefreshIdentityPanel()

--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
@@ -101,6 +101,21 @@ namespace Immutable.Audience.Samples.SampleApp
             }
         }
 
+        private async Task OnRequestAttAsync()
+        {
+            AppendLog("requestTrackingAuthorizationAsync()", "ATT request dispatched", LogLevel.Info, LogSource.App);
+            try
+            {
+                var status = await ImmutableAudience.RequestTrackingAuthorizationAsync();
+                AppendLog("requestTrackingAuthorizationAsync()",
+                    $"status: {status}", LogLevel.Ok, LogSource.App);
+            }
+            catch (Exception ex)
+            {
+                AppendLog("requestTrackingAuthorizationAsync()", ex.Message, LogLevel.Err, LogSource.App);
+            }
+        }
+
         // ---- SDK action handlers: telemetry ----
 
         // Prefers the typed overload for the four events with public C#

--- a/examples/audience/ProjectSettings/ProjectSettings.asset
+++ b/examples/audience/ProjectSettings/ProjectSettings.asset
@@ -158,8 +158,8 @@ PlayerSettings:
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
-    iPhone: com.immutable.audience
     Android: com.immutable.audience
+    iPhone: com.immutable.audience
   buildNumber:
     Standalone: 0
     iPhone: 0
@@ -808,7 +808,8 @@ PlayerSettings:
   webGLThreadsSupport: 0
   webGLDecompressionFallback: 0
   webGLPowerPreference: 2
-  scriptingDefineSymbols: {}
+  scriptingDefineSymbols:
+    iPhone: AUDIENCE_MOBILE_ATTRIBUTION
   additionalCompilerArguments: {}
   platformArchitecture: {}
   scriptingBackend:
@@ -817,6 +818,7 @@ PlayerSettings:
     iPhone: 1
   il2cppCompilerConfiguration: {}
   managedStrippingLevel:
+    Android: 3
     EmbeddedLinux: 1
     GameCoreScarlett: 1
     GameCoreXboxOne: 1
@@ -829,7 +831,6 @@ PlayerSettings:
     WebGL: 1
     Windows Store Apps: 1
     XboxOne: 1
-    Android: 3
     iPhone: 3
     tvOS: 1
   incrementalIl2cppBuild: {}

--- a/src/Packages/Audience/Editor/iOSFrameworkPostProcessor.cs
+++ b/src/Packages/Audience/Editor/iOSFrameworkPostProcessor.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+using System.IO;
+using UnityEditor;
+using UnityEditor.Callbacks;
+using UnityEngine;
+#if UNITY_IOS
+using UnityEditor.iOS.Xcode;
+#endif
+
+namespace Immutable.Audience.Editor
+{
+    /// <summary>
+    /// Links the Apple frameworks the runtime mobile-attribution code needs
+    /// into the generated iOS Xcode project.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>AdSupport.framework</c> hosts <c>ASIdentifierManager</c> (the IDFA
+    /// accessor). Without it linked, the runtime <c>NSClassFromString</c>
+    /// lookup returns nil and the IDFA is silently dropped from
+    /// <c>game_launch</c> — the Info.plist key alone does not load this
+    /// framework. Linked as a required dep; the framework has shipped on
+    /// every iOS release since 6.0.
+    /// </para>
+    /// <para>
+    /// <c>AppTrackingTransparency.framework</c> hosts <c>ATTrackingManager</c>.
+    /// Unity often auto-links this when <c>NSUserTrackingUsageDescription</c>
+    /// is present, but the auto-link heuristic is undocumented and
+    /// version-sensitive — an explicit weak link is immune to that drift and
+    /// keeps the binary loadable on iOS &lt; 14 (the runtime code already
+    /// guards via <c>NSClassFromString</c>).
+    /// </para>
+    /// <para>
+    /// Gated on the same <c>AUDIENCE_MOBILE_ATTRIBUTION</c> scripting define
+    /// as the Info.plist post-processor so studios who haven't opted into
+    /// attribution ship a clean Frameworks list.
+    /// </para>
+    /// </remarks>
+    internal static class iOSFrameworkPostProcessor
+    {
+        // Runs just after the Info.plist post-processor (9050). Order is
+        // independent in practice — both edit different files — but keeping
+        // them adjacent makes the build log obvious.
+        internal const int CallbackOrder = 9051;
+
+        [PostProcessBuild(CallbackOrder)]
+        internal static void OnPostProcessBuild(BuildTarget target, string pathToBuiltProject)
+        {
+            if (target != BuildTarget.iOS) return;
+
+#if UNITY_IOS
+            if (!AttributionDefineEnabled()) return;
+
+            var pbxPath = PBXProject.GetPBXProjectPath(pathToBuiltProject);
+            if (!File.Exists(pbxPath))
+            {
+                Debug.LogWarning(
+                    $"[ImmutableAudience] iOS framework post-processor: project.pbxproj not found at {pbxPath}. Skipping.");
+                return;
+            }
+
+            var pbx = new PBXProject();
+            pbx.ReadFromFile(pbxPath);
+
+            // Native plugin code under Runtime/Plugins/iOS compiles into the
+            // UnityFramework target on Unity 2019.3+. Linking against the
+            // main target instead leaves the symbols unresolved at runtime
+            // and the IDFA / ATT calls silently no-op.
+            var frameworkTarget = pbx.GetUnityFrameworkTargetGuid();
+
+            pbx.AddFrameworkToProject(frameworkTarget, "AdSupport.framework", weak: false);
+            pbx.AddFrameworkToProject(frameworkTarget, "AppTrackingTransparency.framework", weak: true);
+
+            pbx.WriteToFile(pbxPath);
+#endif
+        }
+
+        // Reads the iOS-target define list specifically — the post-processor
+        // mutates iOS build output regardless of which target the editor is
+        // currently focused on.
+        private static bool AttributionDefineEnabled()
+        {
+            var defines = PlayerSettings.GetScriptingDefineSymbolsForGroup(BuildTargetGroup.iOS) ?? string.Empty;
+            foreach (var define in defines.Split(';'))
+            {
+                if (define.Trim() == iOSInfoPlistPostProcessor.AttributionDefine) return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Packages/Audience/Editor/iOSFrameworkPostProcessor.cs.meta
+++ b/src/Packages/Audience/Editor/iOSFrameworkPostProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5f60718293a4b5c6d7e8f90a1b2c3d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -53,6 +53,16 @@ namespace Immutable.Audience
         // Set by the Unity layer; null in pure-C# environments.
         internal static volatile Func<bool?>? MobileAttributionProvider;
 
+        // Called during Init when config.EnableMobileAttribution is true.
+        // Returns iOS attribution context (attStatus, idfa) to merge into
+        // game_launch properties. Set by the Unity layer.
+        internal static volatile Func<IReadOnlyDictionary<string, object>?>? MobileAttributionContextProvider;
+
+        // Backs RequestTrackingAuthorizationAsync. Set by the Unity layer to
+        // ATTBridge.RequestAsync; null in pure-C# environments and on
+        // non-iOS platforms (the public API resolves to NotDetermined).
+        internal static volatile Func<Task<int>>? TrackingAuthorizationRequestProvider;
+
         // Active session. Created at Init (or on upgrade from None) and disposed
         // on Shutdown or SetConsent(None). Volatile so OnPause/OnResume see
         // assignments from SetConsent without taking _initLock.
@@ -209,14 +219,23 @@ namespace Immutable.Audience
             // shows the new sessionId ahead of the launch event.
             sessionToStart?.Start();
 
+            // Consent gate before invoking attribution providers: SKAN
+            // registration is a network side effect and IDFA / ATT status
+            // reads are privacy-sensitive. CanTrack() == false (consent
+            // None) means we have no licence to do either, regardless of
+            // whether EnableMobileAttribution is set in config.
             bool? skanRegistered = null;
-            if (config.EnableMobileAttribution)
+            IReadOnlyDictionary<string, object>? attributionContext = null;
+            if (config.EnableMobileAttribution && consentAtInit.CanTrack())
             {
                 try { skanRegistered = MobileAttributionProvider?.Invoke(); }
                 catch (Exception ex) { Log.Warn(AudienceLogs.MobileAttributionProviderThrew(ex)); }
+
+                try { attributionContext = MobileAttributionContextProvider?.Invoke(); }
+                catch (Exception ex) { Log.Warn(AudienceLogs.MobileAttributionContextProviderThrew(ex)); }
             }
 
-            FireGameLaunch(config, consentAtInit, skanRegistered);
+            FireGameLaunch(config, consentAtInit, skanRegistered, attributionContext);
         }
 
         // Pause/Resume hooks for the Unity lifecycle bridge.
@@ -678,6 +697,64 @@ namespace Immutable.Audience
         }
 
         // -----------------------------------------------------------------
+        // Mobile attribution
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Requests the iOS App Tracking Transparency authorization. Triggers
+        /// the system prompt on first call; returns the cached status on
+        /// subsequent calls.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Studios decide when to show the prompt — Apple's HIG requires it
+        /// to fire at a moment that makes the value to the player obvious,
+        /// not at SDK Init. The IDFA, when authorized, is collected
+        /// automatically on the next <see cref="ImmutableAudience.Init"/> via
+        /// the <c>game_launch</c> event when
+        /// <see cref="AudienceConfig.EnableMobileAttribution"/> is set.
+        /// </para>
+        /// <para>
+        /// Resolves to <see cref="TrackingAuthorizationStatus.NotDetermined"/>
+        /// in three distinct cases — callers who use this signal to decide
+        /// whether to retry should consult the SDK log to disambiguate:
+        /// </para>
+        /// <list type="bullet">
+        ///   <item>The user has not yet been prompted, or the prompt was dismissed without a choice.</item>
+        ///   <item>The platform is not iOS, or the iOS version is &lt; 14.</item>
+        ///   <item>The native call threw an unexpected exception (logged via <c>Log.Warn</c>).</item>
+        /// </list>
+        /// </remarks>
+        /// <returns>
+        /// A task that completes with the user's authorization decision.
+        /// </returns>
+        public static async Task<TrackingAuthorizationStatus> RequestTrackingAuthorizationAsync()
+        {
+            var provider = TrackingAuthorizationRequestProvider;
+            if (provider == null)
+                return TrackingAuthorizationStatus.NotDetermined;
+
+            int status;
+            try
+            {
+                status = await provider().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.Warn(AudienceLogs.TrackingAuthorizationRequestThrew(ex));
+                return TrackingAuthorizationStatus.NotDetermined;
+            }
+
+            // Defensively clamp: any value outside Apple's documented range
+            // (0..3) is surfaced as NotDetermined rather than as an invalid
+            // enum cast that callers can't pattern-match safely.
+            if (status < 0 || status > 3)
+                return TrackingAuthorizationStatus.NotDetermined;
+
+            return (TrackingAuthorizationStatus)status;
+        }
+
+        // -----------------------------------------------------------------
         // Flush / Shutdown
         // -----------------------------------------------------------------
 
@@ -994,7 +1071,11 @@ namespace Immutable.Audience
         }
 
         // consentAtInit only gates the launch; Track still checks live _state via CanTrack.
-        private static void FireGameLaunch(AudienceConfig config, ConsentLevel consentAtInit, bool? skanRegistered = null)
+        private static void FireGameLaunch(
+            AudienceConfig config,
+            ConsentLevel consentAtInit,
+            bool? skanRegistered = null,
+            IReadOnlyDictionary<string, object>? attributionContext = null)
         {
             if (!consentAtInit.CanTrack()) return;
 
@@ -1026,6 +1107,14 @@ namespace Immutable.Audience
             // Emitted only on the first launch where SKAN registration fires.
             if (skanRegistered == true)
                 properties["skanRegistered"] = true;
+
+            // iOS ATT/IDFA snapshot — merged after Unity context so attribution
+            // keys are authoritative if both sources happen to set the same key.
+            if (attributionContext != null)
+            {
+                foreach (var kvp in attributionContext)
+                    properties[kvp.Key] = kvp.Value;
+            }
 
             // No sessionId on game_launch per Event Reference. Pipeline correlates
             // via eventTimestamp with the session_start that fires just before.

--- a/src/Packages/Audience/Runtime/Plugins/iOS/AudienceMobileBridge.mm
+++ b/src/Packages/Audience/Runtime/Plugins/iOS/AudienceMobileBridge.mm
@@ -1,5 +1,13 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import <objc/message.h>
+
+// Runtime dispatch (NSClassFromString + IMP-cast) is used throughout. The
+// alternative — hard-importing AppTrackingTransparency.framework, AdSupport.framework,
+// and StoreKit.framework — would force the Xcode project to link them and, in
+// the case of StoreKit, trigger the In-App Purchase capability check on
+// personal teams. Runtime lookup keeps the binary clean for studios that don't
+// opt into attribution and avoids any compile-time framework dependency.
 
 extern "C" {
 
@@ -14,13 +22,79 @@ const char* _AudienceGetIDFV(void)
 
 void _AudienceRegisterSKAN(void)
 {
-    // Runtime dispatch avoids a hard link to StoreKit.framework, which would
-    // trigger Xcode's In-App Purchase capability check. StoreKit is always
-    // present on device; NSClassFromString finds it without a compile-time dep.
     Class cls = NSClassFromString(@"SKAdNetwork");
     if (cls) {
         [cls performSelector:@selector(registerAppForAdNetworkAttribution)];
     }
+}
+
+// Matches C# delegate ATTBridge.NativeStatusCallback(int).
+typedef void (*AudienceATTStatusCallback)(int status);
+
+void _AudienceRequestATT(AudienceATTStatusCallback callback)
+{
+    if (!callback) return;
+
+    Class cls = NSClassFromString(@"ATTrackingManager");
+    SEL sel = NSSelectorFromString(@"requestTrackingAuthorizationWithCompletionHandler:");
+    if (!cls || ![cls respondsToSelector:sel]) {
+        // ATT unavailable (iOS < 14). Surface as notDetermined so callers can
+        // proceed with a deterministic value rather than hanging.
+        callback(0);
+        return;
+    }
+
+    // Apple's completion handler may fire on a background thread. Cross back
+    // into managed code on whatever thread we're given — IL2CPP tolerates
+    // this and the C# side dispatches its own continuation.
+    void (^handler)(NSUInteger) = ^(NSUInteger status) {
+        callback((int)status);
+    };
+
+    // objc_msgSend with an explicit signature cast preserves block typing —
+    // performSelector:withObject: would erase the block to id, and ARC's
+    // retain rules for blocks-as-id are inconsistent across compilers.
+    typedef void (*RequestFn)(id, SEL, void (^)(NSUInteger));
+    RequestFn fn = (RequestFn)objc_msgSend;
+    fn(cls, sel, handler);
+}
+
+int _AudienceGetATTStatus(void)
+{
+    Class cls = NSClassFromString(@"ATTrackingManager");
+    SEL sel = NSSelectorFromString(@"trackingAuthorizationStatus");
+    if (!cls || ![cls respondsToSelector:sel]) {
+        return 0; // notDetermined fallback for iOS < 14.
+    }
+
+    // trackingAuthorizationStatus returns NSUInteger; performSelector returns
+    // id, which would mis-marshal. Cast the IMP to a typed function pointer
+    // so the value comes back without trip through NSInvocation.
+    IMP imp = [cls methodForSelector:sel];
+    NSUInteger (*fn)(id, SEL) = (NSUInteger (*)(id, SEL))imp;
+    return (int)fn(cls, sel);
+}
+
+const char* _AudienceGetIDFA(void)
+{
+    Class cls = NSClassFromString(@"ASIdentifierManager");
+    if (!cls) return NULL;
+
+    id manager = [cls performSelector:@selector(sharedManager)];
+    if (!manager) return NULL;
+
+    NSUUID *uuid = [manager performSelector:@selector(advertisingIdentifier)];
+    if (!uuid) return NULL;
+
+    NSString *str = [uuid UUIDString];
+    // Apple returns the all-zeros UUID when ATT is not authorized. Surfacing
+    // it would pollute the dataset; treat as no-IDFA so the C# side can omit
+    // the field entirely.
+    if ([str isEqualToString:@"00000000-0000-0000-0000-000000000000"]) {
+        return NULL;
+    }
+
+    return strdup([str UTF8String]);
 }
 
 }

--- a/src/Packages/Audience/Runtime/TrackingAuthorizationStatus.cs
+++ b/src/Packages/Audience/Runtime/TrackingAuthorizationStatus.cs
@@ -1,0 +1,28 @@
+#nullable enable
+
+namespace Immutable.Audience
+{
+    /// <summary>
+    /// Result of <see cref="ImmutableAudience.RequestTrackingAuthorizationAsync"/>.
+    /// </summary>
+    /// <remarks>
+    /// Maps directly to Apple's
+    /// <c>ATTrackingManagerAuthorizationStatus</c>. On platforms other than
+    /// iOS, or on iOS &lt; 14, the request resolves to
+    /// <see cref="NotDetermined"/>.
+    /// </remarks>
+    public enum TrackingAuthorizationStatus
+    {
+        /// <summary>The user has not yet been prompted, or the prompt was dismissed without a choice.</summary>
+        NotDetermined = 0,
+
+        /// <summary>Tracking is restricted by a profile or parental control. The system prompt is not shown.</summary>
+        Restricted = 1,
+
+        /// <summary>The user denied tracking. IDFA is unavailable.</summary>
+        Denied = 2,
+
+        /// <summary>The user authorized tracking. IDFA is available.</summary>
+        Authorized = 3,
+    }
+}

--- a/src/Packages/Audience/Runtime/TrackingAuthorizationStatus.cs.meta
+++ b/src/Packages/Audience/Runtime/TrackingAuthorizationStatus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c3d4e5f60718293a4b5c6d7e8f90a1b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Runtime/Unity/AudienceUnityHooks.cs
+++ b/src/Packages/Audience/Runtime/Unity/AudienceUnityHooks.cs
@@ -30,6 +30,8 @@ namespace Immutable.Audience.Unity
 
 #if UNITY_IOS && !UNITY_EDITOR
             ImmutableAudience.MobileAttributionProvider = () => SkanRegistration.RegisterIfFirstLaunch();
+            ImmutableAudience.MobileAttributionContextProvider = () => AttributionContext.Capture();
+            ImmutableAudience.TrackingAuthorizationRequestProvider = () => ATTBridge.RequestAsync();
 #endif
 
             UnityLifecycleBridge.EnsureExists();

--- a/src/Packages/Audience/Runtime/Unity/Mobile/ATTBridge.cs
+++ b/src/Packages/Audience/Runtime/Unity/Mobile/ATTBridge.cs
@@ -1,0 +1,117 @@
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+#if UNITY_IOS
+using System.Runtime.InteropServices;
+using AOT;
+using UnityEngine.Scripting;
+#endif
+
+namespace Immutable.Audience.Unity.Mobile
+{
+    // Thin wrapper around the iOS AppTrackingTransparency / AdSupport native
+    // calls in AudienceMobileBridge.mm. The async request bridges Apple's
+    // completion-handler callback into a Task; the synchronous getters mirror
+    // the IDFV / SKAN bridges.
+    //
+    // Status codes (matching ATTrackingManagerAuthorizationStatus):
+    //   0 = notDetermined, 1 = restricted, 2 = denied, 3 = authorized.
+    internal static class ATTBridge
+    {
+        // Test seams. Default to the native impls; tests substitute fakes so
+        // the editor playmode doesn't try to load __Internal.
+        internal static Func<Task<int>> RequestImpl = NativeRequestAsync;
+        internal static Func<int> GetStatusImpl = NativeGetStatus;
+        internal static Func<string?> GetIDFAImpl = NativeGetIDFA;
+
+        internal static Task<int> RequestAsync() => RequestImpl();
+        internal static int GetStatus() => GetStatusImpl();
+        internal static string? GetIDFA() => GetIDFAImpl();
+
+#if UNITY_IOS
+        // Marshalled as a function pointer to native code. The signature must
+        // exactly match the AudienceATTStatusCallback typedef in the .mm.
+        private delegate void NativeStatusCallback(int status);
+
+        [DllImport("__Internal")]
+        private static extern void _AudienceRequestATT(NativeStatusCallback callback);
+
+        [DllImport("__Internal")]
+        private static extern int _AudienceGetATTStatus();
+
+        [DllImport("__Internal")]
+        private static extern string _AudienceGetIDFA();
+
+        // Hold a single delegate instance for the lifetime of the process. If
+        // we passed a fresh delegate to each P/Invoke call, IL2CPP could GC
+        // the wrapper before Apple's completion handler fires (which can be
+        // seconds or minutes later — the user may swipe the prompt away or
+        // background the app).
+        private static readonly NativeStatusCallback _staticCallback = OnATTStatus;
+
+        // Single-flight: ATT prompts once per app lifetime. A second request
+        // while one is in flight returns the same task.
+        private static readonly object _requestLock = new object();
+        private static TaskCompletionSource<int>? _pendingTcs;
+
+        // Required:
+        // - MonoPInvokeCallback so IL2CPP emits the trampoline that lets
+        //   native code call back into managed code.
+        // - Preserve so managed-code stripping at High doesn't drop this
+        //   method (it has no managed callers — only the function pointer).
+        // Without both, the await in RequestAsync never completes on a
+        // shipping build with stripping enabled.
+        [MonoPInvokeCallback(typeof(NativeStatusCallback))]
+        [Preserve]
+        private static void OnATTStatus(int status)
+        {
+            TaskCompletionSource<int>? tcs;
+            lock (_requestLock)
+            {
+                tcs = _pendingTcs;
+                _pendingTcs = null;
+            }
+            // Apple may fire the handler on a background thread.
+            // RunContinuationsAsynchronously (set on construction) ensures
+            // awaiting code resumes on the thread pool, not Apple's thread.
+            tcs?.TrySetResult(status);
+        }
+
+        private static Task<int> NativeRequestAsync()
+        {
+            TaskCompletionSource<int> tcs;
+            lock (_requestLock)
+            {
+                if (_pendingTcs != null) return _pendingTcs.Task;
+                tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _pendingTcs = tcs;
+            }
+
+            try
+            {
+                _AudienceRequestATT(_staticCallback);
+            }
+            catch
+            {
+                lock (_requestLock)
+                {
+                    if (_pendingTcs == tcs) _pendingTcs = null;
+                }
+                throw;
+            }
+
+            return tcs.Task;
+        }
+
+        private static int NativeGetStatus() => _AudienceGetATTStatus();
+
+        private static string? NativeGetIDFA() => _AudienceGetIDFA();
+#else
+        private static Task<int> NativeRequestAsync() => Task.FromResult(0);
+        private static int NativeGetStatus() => 0;
+        private static string? NativeGetIDFA() => null;
+#endif
+    }
+}

--- a/src/Packages/Audience/Runtime/Unity/Mobile/ATTBridge.cs.meta
+++ b/src/Packages/Audience/Runtime/Unity/Mobile/ATTBridge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1b2c3d4e5f60718293a4b5c6d7e8f90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Runtime/Unity/Mobile/AttributionContext.cs
+++ b/src/Packages/Audience/Runtime/Unity/Mobile/AttributionContext.cs
@@ -1,0 +1,54 @@
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace Immutable.Audience.Unity.Mobile
+{
+    // Builds the iOS attribution snapshot that ships on game_launch when
+    // EnableMobileAttribution is true. ATT status is always read; IDFA is
+    // only included when status is authorized (Apple returns the all-zeros
+    // UUID otherwise, which the native bridge filters to null).
+    internal static class AttributionContext
+    {
+        // Maps Apple's ATTrackingManagerAuthorizationStatus to the wire
+        // strings the analytics pipeline expects. Stable values shared with
+        // backend dashboards.
+        internal static string AttStatusToString(int status)
+        {
+            switch (status)
+            {
+                case 0: return "notDetermined";
+                case 1: return "restricted";
+                case 2: return "denied";
+                case 3: return "authorized";
+                default: return "unknown";
+            }
+        }
+
+        // Always returns a non-null dictionary — at minimum
+        // { attStatus: "notDetermined" }. The provider field type is
+        // nullable for forward-compat with future implementations that may
+        // want to opt out, but this implementation never returns null.
+        internal static IReadOnlyDictionary<string, object> Capture()
+        {
+            var status = ATTBridge.GetStatus();
+            var props = new Dictionary<string, object>
+            {
+                ["attStatus"] = AttStatusToString(status),
+            };
+
+            // Only ship IDFA when the user has authorized tracking. The native
+            // bridge already returns null for the zero-UUID case, but gating
+            // here makes the contract explicit and survives a future native
+            // change.
+            if (status == 3)
+            {
+                var idfa = ATTBridge.GetIDFA();
+                if (!string.IsNullOrEmpty(idfa))
+                    props["idfa"] = idfa!;
+            }
+
+            return props;
+        }
+    }
+}

--- a/src/Packages/Audience/Runtime/Unity/Mobile/AttributionContext.cs.meta
+++ b/src/Packages/Audience/Runtime/Unity/Mobile/AttributionContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2c3d4e5f60718293a4b5c6d7e8f90a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Packages/Audience/Runtime/Utility/Log.cs
+++ b/src/Packages/Audience/Runtime/Utility/Log.cs
@@ -140,5 +140,13 @@ namespace Immutable.Audience
         internal static string MobileAttributionProviderThrew(Exception ex) =>
             $"MobileAttributionProvider threw {ex.GetType().Name}: {ex.Message}. " +
             "game_launch will ship without skanRegistered.";
+
+        internal static string MobileAttributionContextProviderThrew(Exception ex) =>
+            $"MobileAttributionContextProvider threw {ex.GetType().Name}: {ex.Message}. " +
+            "game_launch will ship without iOS attribution context.";
+
+        internal static string TrackingAuthorizationRequestThrew(Exception ex) =>
+            $"RequestTrackingAuthorizationAsync threw {ex.GetType().Name}: {ex.Message}. " +
+            "Returning NotDetermined.";
     }
 }

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -30,6 +30,8 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.ContextProvider = null;
             ImmutableAudience.DefaultPersistentDataPathProvider = null;
             ImmutableAudience.MobileAttributionProvider = null;
+            ImmutableAudience.MobileAttributionContextProvider = null;
+            ImmutableAudience.TrackingAuthorizationRequestProvider = null;
             Identity.Reset(_testDir);
             if (Directory.Exists(_testDir))
                 Directory.Delete(_testDir, recursive: true);
@@ -1288,6 +1290,159 @@ namespace Immutable.Audience.Tests
                 .Select(File.ReadAllText)
                 .First(c => c.Contains("\"game_launch\""));
             Assert.IsFalse(launchFile.Contains("skanRegistered"));
+        }
+
+        [Test]
+        public void Init_GameLaunch_IncludesAttStatusAndIdfa_WhenContextProviderReturns()
+        {
+            ImmutableAudience.MobileAttributionContextProvider = () =>
+                new Dictionary<string, object>
+                {
+                    ["attStatus"] = "authorized",
+                    ["idfa"] = "11111111-2222-3333-4444-555555555555",
+                };
+            var config = MakeConfig();
+            config.EnableMobileAttribution = true;
+            ImmutableAudience.Init(config);
+            ImmutableAudience.Shutdown();
+
+            var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
+                .Select(File.ReadAllText)
+                .First(c => c.Contains("\"game_launch\""));
+            StringAssert.Contains("\"attStatus\":\"authorized\"", launchFile);
+            StringAssert.Contains("\"idfa\":\"11111111-2222-3333-4444-555555555555\"", launchFile);
+        }
+
+        [Test]
+        public void Init_GameLaunch_IncludesAttStatusOnly_WhenIdfaUnauthorized()
+        {
+            ImmutableAudience.MobileAttributionContextProvider = () =>
+                new Dictionary<string, object>
+                {
+                    ["attStatus"] = "denied",
+                };
+            var config = MakeConfig();
+            config.EnableMobileAttribution = true;
+            ImmutableAudience.Init(config);
+            ImmutableAudience.Shutdown();
+
+            var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
+                .Select(File.ReadAllText)
+                .First(c => c.Contains("\"game_launch\""));
+            StringAssert.Contains("\"attStatus\":\"denied\"", launchFile);
+            Assert.IsFalse(launchFile.Contains("\"idfa\""),
+                "idfa must not appear when ATT status is denied");
+        }
+
+        [Test]
+        public void Init_GameLaunch_OmitsAttributionContext_WhenMobileAttributionDisabled()
+        {
+            var callCount = 0;
+            ImmutableAudience.MobileAttributionContextProvider = () =>
+            {
+                callCount++;
+                return new Dictionary<string, object> { ["attStatus"] = "authorized" };
+            };
+            var config = MakeConfig();
+            config.EnableMobileAttribution = false;
+            ImmutableAudience.Init(config);
+            ImmutableAudience.Shutdown();
+
+            Assert.AreEqual(0, callCount,
+                "MobileAttributionContextProvider must not be called when EnableMobileAttribution is false");
+            var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
+                .Select(File.ReadAllText)
+                .First(c => c.Contains("\"game_launch\""));
+            Assert.IsFalse(launchFile.Contains("attStatus"));
+            Assert.IsFalse(launchFile.Contains("idfa"));
+        }
+
+        [Test]
+        public void Init_AttributionProviders_NotCalled_WhenConsentNone()
+        {
+            // Consent gate must precede attribution side effects: SKAN
+            // registration (network call) and IDFA/ATT reads must not fire
+            // when the user hasn't authorized any tracking.
+            var skanCallCount = 0;
+            var contextCallCount = 0;
+            ImmutableAudience.MobileAttributionProvider = () => { skanCallCount++; return true; };
+            ImmutableAudience.MobileAttributionContextProvider = () =>
+            {
+                contextCallCount++;
+                return new Dictionary<string, object> { ["attStatus"] = "authorized" };
+            };
+
+            var config = MakeConfig(ConsentLevel.None);
+            config.EnableMobileAttribution = true;
+            ImmutableAudience.Init(config);
+            ImmutableAudience.Shutdown();
+
+            Assert.AreEqual(0, skanCallCount,
+                "MobileAttributionProvider must not run when consent is None");
+            Assert.AreEqual(0, contextCallCount,
+                "MobileAttributionContextProvider must not run when consent is None");
+        }
+
+        [Test]
+        public void Init_GameLaunch_AttributionContextProviderThrows_DoesNotPreventEvent()
+        {
+            ImmutableAudience.MobileAttributionContextProvider = () =>
+                throw new InvalidOperationException("provider exploded");
+            var config = MakeConfig();
+            config.EnableMobileAttribution = true;
+
+            Assert.DoesNotThrow(() => ImmutableAudience.Init(config));
+            ImmutableAudience.Shutdown();
+
+            var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
+                .Select(File.ReadAllText)
+                .First(c => c.Contains("\"game_launch\""));
+            Assert.IsFalse(launchFile.Contains("attStatus"));
+        }
+
+        // -----------------------------------------------------------------
+        // RequestTrackingAuthorizationAsync
+        // -----------------------------------------------------------------
+
+        [Test]
+        public async Task RequestTrackingAuthorization_NoProvider_ReturnsNotDetermined()
+        {
+            // No provider set — non-iOS environment.
+            var status = await ImmutableAudience.RequestTrackingAuthorizationAsync();
+            Assert.AreEqual(TrackingAuthorizationStatus.NotDetermined, status);
+        }
+
+        [Test]
+        public async Task RequestTrackingAuthorization_ProviderReturnsAuthorized_MapsToEnum()
+        {
+            ImmutableAudience.TrackingAuthorizationRequestProvider = () => Task.FromResult(3);
+            var status = await ImmutableAudience.RequestTrackingAuthorizationAsync();
+            Assert.AreEqual(TrackingAuthorizationStatus.Authorized, status);
+        }
+
+        [Test]
+        public async Task RequestTrackingAuthorization_ProviderReturnsDenied_MapsToEnum()
+        {
+            ImmutableAudience.TrackingAuthorizationRequestProvider = () => Task.FromResult(2);
+            var status = await ImmutableAudience.RequestTrackingAuthorizationAsync();
+            Assert.AreEqual(TrackingAuthorizationStatus.Denied, status);
+        }
+
+        [Test]
+        public async Task RequestTrackingAuthorization_ProviderThrows_ReturnsNotDetermined()
+        {
+            ImmutableAudience.TrackingAuthorizationRequestProvider = () =>
+                throw new InvalidOperationException("provider exploded");
+            var status = await ImmutableAudience.RequestTrackingAuthorizationAsync();
+            Assert.AreEqual(TrackingAuthorizationStatus.NotDetermined, status);
+        }
+
+        [Test]
+        public async Task RequestTrackingAuthorization_OutOfRangeStatus_ReturnsNotDetermined()
+        {
+            ImmutableAudience.TrackingAuthorizationRequestProvider = () => Task.FromResult(99);
+            var status = await ImmutableAudience.RequestTrackingAuthorizationAsync();
+            Assert.AreEqual(TrackingAuthorizationStatus.NotDetermined, status);
         }
 
         // -----------------------------------------------------------------

--- a/src/Packages/Audience/Tests/Runtime/Unity/ATTBridgeTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Unity/ATTBridgeTests.cs
@@ -1,0 +1,171 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Immutable.Audience.Unity.Mobile;
+
+namespace Immutable.Audience.Tests
+{
+    [TestFixture]
+    internal class ATTBridgeTests
+    {
+        private Func<Task<int>>? _originalRequest;
+        private Func<int>? _originalGetStatus;
+        private Func<string?>? _originalGetIDFA;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _originalRequest = ATTBridge.RequestImpl;
+            _originalGetStatus = ATTBridge.GetStatusImpl;
+            _originalGetIDFA = ATTBridge.GetIDFAImpl;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            ATTBridge.RequestImpl = _originalRequest!;
+            ATTBridge.GetStatusImpl = _originalGetStatus!;
+            ATTBridge.GetIDFAImpl = _originalGetIDFA!;
+        }
+
+        [Test]
+        public async Task RequestAsync_DelegatesToImpl()
+        {
+            ATTBridge.RequestImpl = () => Task.FromResult(3);
+
+            var status = await ATTBridge.RequestAsync();
+
+            Assert.AreEqual(3, status, "must surface the value the impl resolves to");
+        }
+
+        [Test]
+        public void GetStatus_DelegatesToImpl()
+        {
+            ATTBridge.GetStatusImpl = () => 2;
+            Assert.AreEqual(2, ATTBridge.GetStatus());
+        }
+
+        [Test]
+        public void GetIDFA_DelegatesToImpl()
+        {
+            ATTBridge.GetIDFAImpl = () => "deadbeef-0000-0000-0000-000000000000";
+            Assert.AreEqual("deadbeef-0000-0000-0000-000000000000", ATTBridge.GetIDFA());
+        }
+
+        [Test]
+        public void GetIDFA_ImplCanReturnNull()
+        {
+            ATTBridge.GetIDFAImpl = () => null;
+            Assert.IsNull(ATTBridge.GetIDFA(),
+                "null surfaces to callers when ATT denied / IDFA unavailable");
+        }
+    }
+
+    [TestFixture]
+    internal class AttributionContextTests
+    {
+        private Func<int>? _originalGetStatus;
+        private Func<string?>? _originalGetIDFA;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _originalGetStatus = ATTBridge.GetStatusImpl;
+            _originalGetIDFA = ATTBridge.GetIDFAImpl;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            ATTBridge.GetStatusImpl = _originalGetStatus!;
+            ATTBridge.GetIDFAImpl = _originalGetIDFA!;
+        }
+
+        [Test]
+        public void Capture_StatusAuthorized_IncludesIdfa()
+        {
+            ATTBridge.GetStatusImpl = () => 3;
+            ATTBridge.GetIDFAImpl = () => "11111111-2222-3333-4444-555555555555";
+
+            var ctx = AttributionContext.Capture();
+
+            Assert.AreEqual("authorized", ctx["attStatus"]);
+            Assert.AreEqual("11111111-2222-3333-4444-555555555555", ctx["idfa"]);
+        }
+
+        [Test]
+        public void Capture_StatusDenied_OmitsIdfa()
+        {
+            ATTBridge.GetStatusImpl = () => 2;
+            // Real native bridge returns null for the all-zeros UUID; we still
+            // gate on status to make the contract explicit.
+            ATTBridge.GetIDFAImpl = () =>
+                throw new InvalidOperationException("must not be called");
+
+            var ctx = AttributionContext.Capture();
+
+            Assert.AreEqual("denied", ctx["attStatus"]);
+            Assert.IsFalse(ctx.ContainsKey("idfa"),
+                "idfa must be omitted when ATT is not authorized");
+        }
+
+        [Test]
+        public void Capture_StatusNotDetermined_OmitsIdfa()
+        {
+            ATTBridge.GetStatusImpl = () => 0;
+            ATTBridge.GetIDFAImpl = () =>
+                throw new InvalidOperationException("must not be called");
+
+            var ctx = AttributionContext.Capture();
+
+            Assert.AreEqual("notDetermined", ctx["attStatus"]);
+            Assert.IsFalse(ctx.ContainsKey("idfa"));
+        }
+
+        [Test]
+        public void Capture_StatusRestricted_OmitsIdfa()
+        {
+            ATTBridge.GetStatusImpl = () => 1;
+            ATTBridge.GetIDFAImpl = () =>
+                throw new InvalidOperationException("must not be called");
+
+            var ctx = AttributionContext.Capture();
+
+            Assert.AreEqual("restricted", ctx["attStatus"]);
+            Assert.IsFalse(ctx.ContainsKey("idfa"));
+        }
+
+        [Test]
+        public void Capture_StatusAuthorizedButIdfaNull_OmitsIdfa()
+        {
+            // Defensive: Apple has been known to return nil under some
+            // configurations even when status reports authorized.
+            ATTBridge.GetStatusImpl = () => 3;
+            ATTBridge.GetIDFAImpl = () => null;
+
+            var ctx = AttributionContext.Capture();
+
+            Assert.AreEqual("authorized", ctx["attStatus"]);
+            Assert.IsFalse(ctx.ContainsKey("idfa"));
+        }
+
+        [Test]
+        public void AttStatusToString_UnknownValue_ReturnsUnknown()
+        {
+            Assert.AreEqual("unknown", AttributionContext.AttStatusToString(99));
+            Assert.AreEqual("unknown", AttributionContext.AttStatusToString(-1));
+        }
+
+        [Test]
+        public void AttStatusToString_KnownValues()
+        {
+            Assert.AreEqual("notDetermined", AttributionContext.AttStatusToString(0));
+            Assert.AreEqual("restricted", AttributionContext.AttStatusToString(1));
+            Assert.AreEqual("denied", AttributionContext.AttStatusToString(2));
+            Assert.AreEqual("authorized", AttributionContext.AttStatusToString(3));
+        }
+    }
+}

--- a/src/Packages/Audience/Tests/Runtime/Unity/ATTBridgeTests.cs.meta
+++ b/src/Packages/Audience/Tests/Runtime/Unity/ATTBridgeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d4e5f60718293a4b5c6d7e8f90a1b2c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
Closes [SDK-306](https://linear.app/imtbl/issue/SDK-306). Stretch goal on top of SDK-307: ATT prompt + IDFA on iOS.

## SDK changes

- New public API: `ImmutableAudience.RequestTrackingAuthorizationAsync()` returning `TrackingAuthorizationStatus` (NotDetermined / Restricted / Denied / Authorized). Studios decide when to call it. Returns NotDetermined off iOS or on iOS<14.
- `game_launch` now ships `attStatus` (always) and `idfa` (only when authorized) when `EnableMobileAttribution = true`.
- Native bridge adds `_AudienceRequestATT` / `_AudienceGetATTStatus` / `_AudienceGetIDFA` using runtime dispatch (`NSClassFromString`) — no hard framework imports in the .mm.
- `ATTBridge.cs` marks the status callback `[MonoPInvokeCallback]` + `[Preserve]` so the await survives managed stripping = High.
- New iOS post-processor links `AdSupport.framework` (required) and `AppTrackingTransparency.framework` (weak) to the UnityFramework target when `AUDIENCE_MOBILE_ATTRIBUTION` is set. Without `AdSupport` explicitly linked, the IDFA lookup silently fails — caught during testing.

## Sample app changes

- Mobile Attribution toggle: hidden on Standalone, visible on iOS + Android.
- New "Request ATT" button beneath the toggle: iOS-only, hidden on Android and Standalone. Disabled until an API key is entered AND the toggle is on, so the result actually lands in `game_launch`.
- `AUDIENCE_MOBILE_ATTRIBUTION` scripting define added to the iOS player target so the post-processors run.

## Tests

- 5 new tests in `ImmutableAudienceTests`: ATT/IDFA emission on `game_launch` + `RequestTrackingAuthorizationAsync` enum mapping and error paths.
- 12 new tests in `ATTBridgeTests` / `AttributionContextTests`: delegate plumbing and IDFA-omission rules per ATT status.

## Test plan

Verified on a real iOS device with managed stripping = High:

- [x] Allow → `attStatus: "authorized"` + real IDFA
- [x] Deny → `attStatus: "denied"`, no IDFA
- [x] Init before tapping Request ATT → `attStatus: "notDetermined"`
- [x] Await completes on a stripped build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds privacy-sensitive iOS ATT/IDFA collection and new native/build post-processing (Xcode framework linking), which can impact compliance and iOS build/runtime behavior if misconfigured.
> 
> **Overview**
> Adds iOS App Tracking Transparency support end-to-end: a new public `ImmutableAudience.RequestTrackingAuthorizationAsync()` API (with `TrackingAuthorizationStatus`) plus Unity/iOS native bridging to request ATT, read ATT status, and fetch IDFA.
> 
> When `EnableMobileAttribution` is enabled *and consent allows tracking*, `game_launch` now merges an iOS attribution snapshot (`attStatus` and `idfa` only when authorized). iOS builds gain a new post-process step that links `AdSupport.framework` (required) and weak-links `AppTrackingTransparency.framework`, gated by the `AUDIENCE_MOBILE_ATTRIBUTION` define.
> 
> The sample app UI adds an iOS-only “Request ATT” action under the mobile attribution toggle with platform-aware visibility/gating, and tests are expanded to cover attribution context emission, consent gating, and ATT request/status mapping/error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0992db56bbc5aa4e466d051b4b79c87b3a487ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->