### PR TITLE
ci(audience): Linux PlayMode runs under xvfb (SDK-317)

### DIFF
--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -454,6 +454,12 @@ jobs:
           AUDIENCE_TEST_PUBLISHABLE_KEY: ${{ secrets.AUDIENCE_TEST_PUBLISHABLE_KEY }}
           AUDIENCE_SCRIPTING_BACKEND: ${{ matrix.backend }}
           UNITY_VERSION: ${{ matrix.unity }}
+          # Provenance markers passed through to the player. The SampleApp
+          # logs `[CI] buildGuid=... runId=... cellId=...` at startup, and
+          # the post-step writes the line into the job summary so events
+          # on CDP can be matched 1:1 to this cell via buildGuid.
+          AUDIENCE_TEST_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+          AUDIENCE_TEST_CELL_ID: ${{ matrix.target }}-${{ matrix.backend }}-${{ matrix.unity }}
         run: |
           set -uo pipefail
           mkdir -p artifacts
@@ -468,6 +474,7 @@ jobs:
             --workdir /github/workspace \
             --env UNITY_EMAIL --env UNITY_PASSWORD --env UNITY_SERIAL \
             --env AUDIENCE_TEST_PUBLISHABLE_KEY --env AUDIENCE_SCRIPTING_BACKEND \
+            --env AUDIENCE_TEST_RUN_ID --env AUDIENCE_TEST_CELL_ID \
             --volume "$PWD":/github/workspace:z \
             --cpus=8 --memory=30487m \
             "$image" \
@@ -605,6 +612,40 @@ jobs:
             echo "::error::Zero tests passed and zero failed. The suite did not execute."
             exit 1
           fi
+
+      - name: Surface CI provenance to job summary
+        # The SampleApp prints `[CI] buildGuid=... runId=... cellId=...`
+        # to Player.log on player startup. buildGuid is per-build and
+        # already lands on every game_launch event the SDK emits, so a
+        # one-line grep here gives a 1:1 match between the CI cell and
+        # CDP rows. The job summary makes it copy-pasteable from the
+        # Actions UI without downloading the artifact.
+        if: always()
+        shell: bash
+        run: |
+          set -uo pipefail
+          log=""
+          for candidate in artifacts/Player-*.log; do
+            [ -f "$candidate" ] && { log="$candidate"; break; }
+          done
+          {
+            echo "## CI provenance"
+            if [ -z "$log" ]; then
+              echo "_No Player.log captured for this cell._"
+              exit 0
+            fi
+            line=$(grep -m1 '\[CI\]' "$log" || true)
+            if [ -z "$line" ]; then
+              echo "_No [CI] line found in \`$log\`. The SampleApp's RuntimeInitializeOnLoad hook may not have fired._"
+              exit 0
+            fi
+            echo
+            echo '```'
+            echo "$line"
+            echo '```'
+            echo
+            echo "Filter CDP for events with this \`buildGuid\` to see the rows from this cell."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Publish test report
         uses: dorny/test-reporter@v3

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -502,15 +502,39 @@ jobs:
               # no GPU is needed. -noreset keeps the X server up across
               # Unity client reconnects (the editor opens / closes / reopens
               # connections during scene load).
-              xvfb-run -a --server-args="-screen 0 1280x720x24 -ac +extension GLX +render -noreset" -- \
-                unity-editor \
-                  -batchmode \
-                  -projectPath /github/workspace/examples/audience \
-                  -runTests \
-                  -testPlatform StandaloneLinux64 \
-                  -testResults /github/workspace/artifacts/playmode-results.xml \
-                  -logFile - 2>&1 | tee /github/workspace/artifacts/playmode.log
+              #
+              # `timeout` wraps the whole xvfb-run + unity-editor pipeline so
+              # the editor cannot stall the cell past 22 minutes. Unity 6 on
+              # Linux has a known shutdown hang: tests complete, the runner
+              # writes playmode-results.xml, then the editor begins
+              # `Application is shutting down...` and never fully exits
+              # (likely a leftover thread or a player process xvfb-run is
+              # still tied to). Without the wrapper, the cell sits idle until
+              # the GitHub 30-min cap and the upload step never gets to run.
+              # 22 min covers Unity 6 IL2CPP build (~5 min) + 39-test suite
+              # execution (~10-15 min) with a 2-min buffer. SIGTERM first via
+              # --signal=TERM so Unity can flush; --kill-after=10 forces
+              # SIGKILL 10 s later if it is still alive. The 8 min slack to
+              # the cell timeout lets the post-steps (license return, Player
+              # log capture, artifact upload) all run.
+              set +e
+              timeout --signal=TERM --kill-after=10 1320 \
+                xvfb-run -a --server-args="-screen 0 1280x720x24 -ac +extension GLX +render -noreset" -- \
+                  unity-editor \
+                    -batchmode \
+                    -projectPath /github/workspace/examples/audience \
+                    -runTests \
+                    -testPlatform StandaloneLinux64 \
+                    -testResults /github/workspace/artifacts/playmode-results.xml \
+                    -logFile - 2>&1 | tee /github/workspace/artifacts/playmode.log
               test_rc=${PIPESTATUS[0]}
+              set -uo pipefail
+              # exit 124 = timeout fired, 137 = SIGKILL via --kill-after.
+              # Either way, log it explicitly so the artifact reader can tell
+              # a real test failure from a shutdown-hang kill.
+              if [ "$test_rc" = "124" ] || [ "$test_rc" = "137" ]; then
+                echo "::warning::Unity exceeded the 22-min budget and was killed (rc=$test_rc). Tests likely completed; the editor failed to shut down."
+              fi
 
               # Capture the standalone test player log. PlayMode tests on
               # StandaloneLinux64 build a player binary that runs the suite

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -512,6 +512,22 @@ jobs:
                   -logFile - 2>&1 | tee /github/workspace/artifacts/playmode.log
               test_rc=${PIPESTATUS[0]}
 
+              # Capture the standalone test player log. PlayMode tests on
+              # StandaloneLinux64 build a player binary that runs the suite
+              # in its own process; the editor stdout we tee above never
+              # sees the player'\''s HTTP traces, OnError callbacks, or cert
+              # failures. Without this, "39 passed" tells us FlushAsync
+              # returned without throwing but says nothing about whether
+              # events actually reached CDP.
+              # Linux convention: ~/.config/unity3d/<Company>/<Product>/Player.log.
+              # Glob across companies / products so the capture survives any
+              # rename of the sample app.
+              find /root/.config/unity3d -name "Player.log" 2>/dev/null | while IFS= read -r f; do
+                co=$(basename "$(dirname "$(dirname "$f")")")
+                pr=$(basename "$(dirname "$f")")
+                cp "$f" "/github/workspace/artifacts/Player-${co}-${pr}.log" 2>/dev/null || true
+              done
+
               # Always return the seat so reruns and parallel cells do not
               # exhaust the activation pool. Tolerate non-zero in case the
               # editor process is still mid-shutdown.
@@ -583,6 +599,7 @@ jobs:
             artifacts/playmode-results.xml
             artifacts/playmode.log
             artifacts/activation.log
+            artifacts/Player-*.log
             examples/audience/Logs/**
 
   # Mobile IL2CPP build validation — runs on GitHub-hosted Ubuntu via GameCI Docker

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -412,11 +412,13 @@ jobs:
       || github.event_name == 'workflow_dispatch'
     name: ${{ matrix.target }} / ${{ matrix.backend }} / Unity ${{ matrix.unity }}
     runs-on: ubuntu-latest-8-cores
-    # Tests now actually execute under xvfb instead of returning instantly
-    # as inconclusive, so cells take ~5-10 min. The 30 min cap leaves
-    # headroom for cold caches and the first image pull without leaving
-    # a stuck job sitting on the runner for the default 6 hours.
-    timeout-minutes: 30
+    # Cells settle to ~5-7 min for Unity 2021.3 (both backends) and
+    # ~22-25 min for Unity 6000.4 (Mono). Unity 6 IL2CPP on Mesa
+    # software OpenGL is the slow path. The 45 min cap covers the inner
+    # 40 min watchdog cap plus post-Unity steps (license return,
+    # Player.log copy, artifact upload, dorny/test-reporter) without
+    # leaving a stuck job sitting on the runner for the default 6 hours.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -507,40 +509,81 @@ jobs:
               # the player. GLX + render are required for UIElements; the
               # image already bundles mesa-llvmpipe for software OpenGL, so
               # no GPU is needed. -noreset keeps the X server up across
-              # Unity client reconnects (the editor opens / closes / reopens
-              # connections during scene load).
+              # Unity client reconnects.
               #
-              # `timeout` wraps the whole xvfb-run + unity-editor pipeline so
-              # the editor cannot stall the cell past 22 minutes. Unity 6 on
-              # Linux has a known shutdown hang: tests complete, the runner
-              # writes playmode-results.xml, then the editor begins
-              # `Application is shutting down...` and never fully exits
-              # (likely a leftover thread or a player process xvfb-run is
-              # still tied to). Without the wrapper, the cell sits idle until
-              # the GitHub 30-min cap and the upload step never gets to run.
-              # 22 min covers Unity 6 IL2CPP build (~5 min) + 39-test suite
-              # execution (~10-15 min) with a 2-min buffer. SIGTERM first via
-              # --signal=TERM so Unity can flush; --kill-after=10 forces
-              # SIGKILL 10 s later if it is still alive. The 8 min slack to
-              # the cell timeout lets the post-steps (license return, Player
-              # log capture, artifact upload) all run.
-              set +e
-              timeout --signal=TERM --kill-after=10 1320 \
-                xvfb-run -a --server-args="-screen 0 1280x720x24 -ac +extension GLX +render -noreset" -- \
-                  unity-editor \
-                    -batchmode \
-                    -projectPath /github/workspace/examples/audience \
-                    -runTests \
-                    -testPlatform StandaloneLinux64 \
-                    -testResults /github/workspace/artifacts/playmode-results.xml \
-                    -logFile - 2>&1 | tee /github/workspace/artifacts/playmode.log
-              test_rc=${PIPESTATUS[0]}
-              set -uo pipefail
-              # exit 124 = timeout fired, 137 = SIGKILL via --kill-after.
-              # Either way, log it explicitly so the artifact reader can tell
-              # a real test failure from a shutdown-hang kill.
-              if [ "$test_rc" = "124" ] || [ "$test_rc" = "137" ]; then
-                echo "::warning::Unity exceeded the 22-min budget and was killed (rc=$test_rc). Tests likely completed; the editor failed to shut down."
+              # Why the watchdog instead of a simple `timeout` wrapper:
+              # - Unity 6 on Linux has a known shutdown hang. After
+              #   "Test run completed", the editor begins
+              #   `Application is shutting down...` and never fully exits.
+              #   Without intervention the cell sits idle until the cell
+              #   timeout fires before the post-Unity steps can run.
+              # - Tests on Unity 6 + Mesa software OpenGL take ~22 min for
+              #   Mono and longer for IL2CPP, vs ~2 min on Unity 2021.3.
+              #   A fixed timeout that fits 2021.3 cuts Unity 6 off mid-run;
+              #   a fixed timeout sized for Unity 6 makes 2021.3 cells wait
+              #   up to 30+ min on a shutdown hang they would not have hit.
+              # - The watchdog adapts: it scans the log, sees
+              #   "Test run completed" the moment Unity finishes the suite,
+              #   gives the editor 30 s to flush playmode-results.xml, then
+              #   sends SIGTERM. SIGKILL follows 15 s later if the editor
+              #   refuses to exit. Cells finish as soon as their tests do,
+              #   regardless of how slow the underlying Unity version is or
+              #   what shutdown bug it happens to hit.
+              # - 40 min hard cap as a fallback for the case where
+              #   "Test run completed" never appears (player hang, etc.).
+              log=/github/workspace/artifacts/playmode.log
+
+              xvfb-run -a --server-args="-screen 0 1280x720x24 -ac +extension GLX +render -noreset" -- \
+                unity-editor \
+                  -batchmode \
+                  -projectPath /github/workspace/examples/audience \
+                  -runTests \
+                  -testPlatform StandaloneLinux64 \
+                  -testResults /github/workspace/artifacts/playmode-results.xml \
+                  -logFile "$log" &
+              unity_pid=$!
+
+              # Stream the log to job stdout for live visibility while the
+              # editor is alive. tail --pid exits when unity_pid does.
+              tail --pid=$unity_pid -F "$log" 2>/dev/null &
+
+              deadline=$((SECONDS + 2400))   # 40 min hard cap
+              flush_deadline=0
+              kill_reason=""
+              while kill -0 $unity_pid 2>/dev/null; do
+                if [ "$SECONDS" -ge "$deadline" ]; then
+                  kill_reason="hard-cap-40m"
+                  break
+                fi
+                if [ "$flush_deadline" -eq 0 ] && grep -q "Test run completed" "$log" 2>/dev/null; then
+                  flush_deadline=$((SECONDS + 30))
+                  echo "[watchdog] saw \"Test run completed\" at ${SECONDS}s; SIGTERM after 30s flush window"
+                fi
+                if [ "$flush_deadline" -gt 0 ] && [ "$SECONDS" -ge "$flush_deadline" ]; then
+                  kill_reason="flush-window-elapsed"
+                  break
+                fi
+                sleep 5
+              done
+
+              if [ -n "$kill_reason" ]; then
+                echo "[watchdog] sending SIGTERM to Unity (reason: $kill_reason)"
+                kill -TERM $unity_pid 2>/dev/null || true
+                # 15 s grace, then SIGKILL if still alive.
+                for _ in 1 2 3; do
+                  kill -0 $unity_pid 2>/dev/null || break
+                  sleep 5
+                done
+                if kill -0 $unity_pid 2>/dev/null; then
+                  echo "[watchdog] SIGTERM not honored, sending SIGKILL"
+                  kill -KILL $unity_pid 2>/dev/null || true
+                fi
+              fi
+
+              wait $unity_pid 2>/dev/null
+              test_rc=$?
+              if [ "$kill_reason" = "hard-cap-40m" ]; then
+                echo "::warning::Unity hit the 40 min hard cap without logging \"Test run completed\". The player may have hung mid-suite. Inspect Player.log to see how far it got."
               fi
 
               # Capture the standalone test player log. PlayMode tests on

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -540,11 +540,23 @@ jobs:
             echo "::error::No test-results.xml at $xml. Unity did not produce results."
             exit 1
           fi
-          # xmllint is preinstalled on ubuntu-latest via libxml2-utils.
-          passed=$(xmllint --xpath 'string(/test-run/@passed)' "$xml")
-          failed=$(xmllint --xpath 'string(/test-run/@failed)' "$xml")
-          inconclusive=$(xmllint --xpath 'string(/test-run/@inconclusive)' "$xml")
-          echo "passed=$passed failed=$failed inconclusive=$inconclusive"
+          # Unity's NUnit writer puts the root summary attributes on a
+          # single <test-run ...> line, so a grep parse is enough and
+          # avoids depending on libxml2-utils (which is not preinstalled
+          # on ubuntu-latest-8-cores; the previous xmllint guard failed
+          # with "command not found" while tests had actually passed).
+          line=$(grep -m1 '<test-run ' "$xml" || true)
+          if [ -z "$line" ]; then
+            echo "::error::No <test-run> element in $xml. The XML is malformed."
+            exit 1
+          fi
+          extract() {
+            printf %s "$1" | grep -oE " $2=\"[0-9]+\"" | head -1 | grep -oE '[0-9]+'
+          }
+          passed=$(extract "$line" passed)
+          failed=$(extract "$line" failed)
+          inconclusive=$(extract "$line" inconclusive)
+          echo "passed=${passed:-?} failed=${failed:-?} inconclusive=${inconclusive:-?}"
           if [ "${inconclusive:-0}" -gt 0 ]; then
             echo "::error::$inconclusive test(s) came back inconclusive. Unity could not actually execute them. Check that xvfb is running and the player launches."
             exit 1

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -412,6 +412,11 @@ jobs:
       || github.event_name == 'workflow_dispatch'
     name: ${{ matrix.target }} / ${{ matrix.backend }} / Unity ${{ matrix.unity }}
     runs-on: ubuntu-latest-8-cores
+    # Tests now actually execute under xvfb instead of returning instantly
+    # as inconclusive, so cells take ~5-10 min. The 30 min cap leaves
+    # headroom for cold caches and the first image pull without leaving
+    # a stuck job sitting on the runner for the default 6 hours.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -433,27 +438,128 @@ jobs:
             Library-${{ matrix.backend }}-${{ matrix.target }}-${{ matrix.unity }}-
             Library-${{ matrix.backend }}-${{ matrix.target }}-
 
-      - uses: game-ci/unity-test-runner@v4
-        id: playmode
+      - name: Run PlayMode tests under xvfb
+        # Manual `docker run` instead of game-ci/unity-test-runner@v4: the
+        # action hardcodes `-batchmode -nographics` and never starts a
+        # virtual display, so every [UnityTest] in SampleAppLiveFireTests
+        # came back "inconclusive" (passed=0, failed=0). NUnit does not
+        # treat inconclusive as failure and the action's USE_EXIT_CODE=false
+        # suppresses Unity's exit code 2, so the cells silently went green
+        # without executing a single test. See SDK-318 for the diagnosis.
+        shell: bash
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           AUDIENCE_TEST_PUBLISHABLE_KEY: ${{ secrets.AUDIENCE_TEST_PUBLISHABLE_KEY }}
           AUDIENCE_SCRIPTING_BACKEND: ${{ matrix.backend }}
-        with:
-          unityVersion: ${{ matrix.unity }}
-          targetPlatform: ${{ matrix.target }}
-          projectPath: examples/audience
-          testMode: playmode
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          UNITY_VERSION: ${{ matrix.unity }}
+        run: |
+          set -uo pipefail
+          mkdir -p artifacts
+
+          # The unityci/editor:ubuntu-...-linux-il2cpp-3 image ships both
+          # the Mono and IL2CPP playback engines plus xvfb, so the same
+          # tag works for both backends. The previous GameCI runs proved
+          # this: the StandaloneLinux64/Mono2x cell pulled the il2cpp tag.
+          image="unityci/editor:ubuntu-${UNITY_VERSION}-linux-il2cpp-3"
+
+          docker run --rm \
+            --workdir /github/workspace \
+            --env UNITY_EMAIL --env UNITY_PASSWORD --env UNITY_SERIAL \
+            --env AUDIENCE_TEST_PUBLISHABLE_KEY --env AUDIENCE_SCRIPTING_BACKEND \
+            --volume "$PWD":/github/workspace:z \
+            --cpus=8 --memory=30487m \
+            "$image" \
+            /bin/bash -c '
+              set -uo pipefail
+
+              # Per-run license activation. Unity occasionally exits non-zero
+              # on a successful activation (warnings about prior cached state
+              # in /root), so swallow the rc and assert on the success marker
+              # in the log instead. Same approach as the dropped self-hosted
+              # Linux job from SDK-255.
+              unity-editor -batchmode -nographics -quit \
+                -username "$UNITY_EMAIL" \
+                -password "$UNITY_PASSWORD" \
+                -serial   "$UNITY_SERIAL" \
+                -logFile - 2>&1 | tee /github/workspace/artifacts/activation.log || true
+              if grep -qE "License activation has failed|\[Licensing::Client\] Error: Code [0-9]+" \
+                 /github/workspace/artifacts/activation.log; then
+                echo "::error::Unity license activation failed."
+                exit 1
+              fi
+              if ! grep -qE "Successfully activated the entitlement license" \
+                 /github/workspace/artifacts/activation.log; then
+                echo "::error::Unity license activation: no success marker in log."
+                exit 1
+              fi
+
+              # xvfb-run gives Unity a virtual X display so PlayMode tests
+              # that load scenes and exercise UI Toolkit can actually launch
+              # the player. GLX + render are required for UIElements; the
+              # image already bundles mesa-llvmpipe for software OpenGL, so
+              # no GPU is needed. -noreset keeps the X server up across
+              # Unity client reconnects (the editor opens / closes / reopens
+              # connections during scene load).
+              xvfb-run -a --server-args="-screen 0 1280x720x24 -ac +extension GLX +render -noreset" -- \
+                unity-editor \
+                  -batchmode \
+                  -projectPath /github/workspace/examples/audience \
+                  -runTests \
+                  -testPlatform StandaloneLinux64 \
+                  -testResults /github/workspace/artifacts/playmode-results.xml \
+                  -logFile - 2>&1 | tee /github/workspace/artifacts/playmode.log
+              test_rc=${PIPESTATUS[0]}
+
+              # Always return the seat so reruns and parallel cells do not
+              # exhaust the activation pool. Tolerate non-zero in case the
+              # editor process is still mid-shutdown.
+              unity-editor -batchmode -nographics -quit -returnlicense -logFile - 2>&1 || true
+
+              # Unity exits 2 when any test fails or comes back inconclusive.
+              # Propagating the rc here means the step fails on real failures
+              # without needing the USE_EXIT_CODE=false hack the GameCI
+              # action applies.
+              exit $test_rc
+            '
+
+      - name: Fail when no tests actually executed
+        # Defense in depth: catches the silent-pass case if a future change
+        # accidentally re-disables the display, breaks the player launch,
+        # or restores USE_EXIT_CODE=false on the docker invocation. NUnit
+        # marks tests "inconclusive" rather than "failed" when the player
+        # never starts, and dorny/test-reporter does not flag inconclusive
+        # as failure, so the suite has to be inspected directly.
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          xml="artifacts/playmode-results.xml"
+          if [ ! -f "$xml" ]; then
+            echo "::error::No test-results.xml at $xml. Unity did not produce results."
+            exit 1
+          fi
+          # xmllint is preinstalled on ubuntu-latest via libxml2-utils.
+          passed=$(xmllint --xpath 'string(/test-run/@passed)' "$xml")
+          failed=$(xmllint --xpath 'string(/test-run/@failed)' "$xml")
+          inconclusive=$(xmllint --xpath 'string(/test-run/@inconclusive)' "$xml")
+          echo "passed=$passed failed=$failed inconclusive=$inconclusive"
+          if [ "${inconclusive:-0}" -gt 0 ]; then
+            echo "::error::$inconclusive test(s) came back inconclusive. Unity could not actually execute them. Check that xvfb is running and the player launches."
+            exit 1
+          fi
+          if [ "${passed:-0}" -eq 0 ] && [ "${failed:-0}" -eq 0 ]; then
+            echo "::error::Zero tests passed and zero failed. The suite did not execute."
+            exit 1
+          fi
 
       - name: Publish test report
         uses: dorny/test-reporter@v3
         if: always()
         with:
           name: PlayMode (${{ matrix.backend }} / ${{ matrix.target }})
-          path: ${{ steps.playmode.outputs.artifactsPath }}/playmode-results.xml
+          path: artifacts/playmode-results.xml
           reporter: dotnet-nunit
           fail-on-error: true
 
@@ -461,7 +567,11 @@ jobs:
         if: always()
         with:
           name: playmode-${{ matrix.backend }}-${{ matrix.target }}-${{ matrix.unity }}
-          path: ${{ steps.playmode.outputs.artifactsPath }}
+          path: |
+            artifacts/playmode-results.xml
+            artifacts/playmode.log
+            artifacts/activation.log
+            examples/audience/Logs/**
 
   # Mobile IL2CPP build validation — runs on GitHub-hosted Ubuntu via GameCI Docker
   # containers so self-hosted macOS/Windows machines are not occupied.

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -25,6 +25,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# CI run identifier injected into the player so events on CDP can be
+# filtered as test traffic. Run id is workflow-wide; matrix-aware cell
+# id is set on the test jobs below. The marker test reads these env
+# vars and Assert.Ignores when both are unset.
+env:
+  AUDIENCE_TEST_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+
 jobs:
   # Reduced matrix on pull_request, full matrix on schedule and
   # workflow_dispatch. The self-hosted Windows runner pool is small, so
@@ -60,6 +67,8 @@ jobs:
     # short releases the self-hosted runner sooner so queued cells can
     # progress instead of waiting 60 min on a stuck job.
     timeout-minutes: 30
+    env:
+      AUDIENCE_TEST_CELL_ID: ${{ matrix.target }}-${{ matrix.backend }}-${{ matrix.unity }}
 
     steps:
       - name: Kill stale Unity processes (Windows pre-checkout)
@@ -419,6 +428,8 @@ jobs:
     # Player.log copy, artifact upload, dorny/test-reporter) without
     # leaving a stuck job sitting on the runner for the default 6 hours.
     timeout-minutes: 45
+    env:
+      AUDIENCE_TEST_CELL_ID: ${{ matrix.target }}-${{ matrix.backend }}-${{ matrix.unity }}
     strategy:
       fail-fast: false
       matrix:
@@ -456,12 +467,6 @@ jobs:
           AUDIENCE_TEST_PUBLISHABLE_KEY: ${{ secrets.AUDIENCE_TEST_PUBLISHABLE_KEY }}
           AUDIENCE_SCRIPTING_BACKEND: ${{ matrix.backend }}
           UNITY_VERSION: ${{ matrix.unity }}
-          # Provenance markers passed through to the player. The SampleApp
-          # logs `[CI] buildGuid=... runId=... cellId=...` at startup, and
-          # the post-step writes the line into the job summary so events
-          # on CDP can be matched 1:1 to this cell via buildGuid.
-          AUDIENCE_TEST_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
-          AUDIENCE_TEST_CELL_ID: ${{ matrix.target }}-${{ matrix.backend }}-${{ matrix.unity }}
         run: |
           set -uo pipefail
           mkdir -p artifacts

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -538,9 +538,27 @@ jobs:
               #   "Test run completed" never appears (player hang, etc.).
               log=/github/workspace/artifacts/playmode.log
 
-              xvfb-run -a --server-args="-screen 0 1280x720x24 -ac +extension GLX +render -noreset" -- \
+              # Why a tiny screen: the per-frame fragment-shader cost on
+              # mesa-llvmpipe scales with pixel count. 1280x720 = 0.92M
+              # px per frame; 320x240 = 0.08M px - a 12x reduction in
+              # software-rendered fill work, which is the dominant cost
+              # on Unity 6 Linux. UI Toolkit lays out fine on this size
+              # because the test never asserts on rendered pixel content,
+              # only on UI Toolkit log-row presence (queried via the
+              # VisualElement tree, not via screen capture).
+              #
+              # Why -force-glcore: Unity 6 prefers Vulkan on Linux and
+              # falls back to OpenGL when Vulkan init fails. Each frame
+              # carries the negotiation overhead. -force-glcore tells the
+              # player to skip Vulkan entirely and open a GLX context
+              # directly, the same path Unity 2021.3 takes by default.
+              xvfb-run -a --server-args="-screen 0 320x240x24 -ac +extension GLX +render -noreset" -- \
                 unity-editor \
                   -batchmode \
+                  -force-glcore \
+                  -screen-fullscreen 0 \
+                  -screen-width 320 \
+                  -screen-height 240 \
                   -projectPath /github/workspace/examples/audience \
                   -runTests \
                   -testPlatform StandaloneLinux64 \

--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
@@ -38,6 +38,23 @@ namespace Immutable.Audience.Samples.SampleApp
 
         // ---- Lifecycle ----
 
+        // Stamps a single, unique CI provenance line into Player.log on
+        // player startup. buildGuid is per-build and already lands on every
+        // game_launch event the SDK emits, so matching a CI artifact to the
+        // CDP rows is a one-line grep on either side. AUDIENCE_TEST_RUN_ID
+        // and AUDIENCE_TEST_CELL_ID are env vars the CI workflow injects;
+        // local / production runs leave them unset and the printed values
+        // are empty. The line lands before any test runs because the
+        // RuntimeInitialize hook fires before the first scene loads.
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void LogCiProvenance()
+        {
+            var runId  = Environment.GetEnvironmentVariable("AUDIENCE_TEST_RUN_ID")  ?? string.Empty;
+            var cellId = Environment.GetEnvironmentVariable("AUDIENCE_TEST_CELL_ID") ?? string.Empty;
+            UnityEngine.Debug.Log(
+                $"[CI] buildGuid={Application.buildGUID} runId={runId} cellId={cellId}");
+        }
+
         private void Awake()
         {
             // InitializeUi must precede the Log.Writer swap — _logView has

--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
@@ -246,15 +246,26 @@ namespace Immutable.Audience.Samples.SampleApp
 
         // Fires from background flush threads; AppendLog marshals to main.
         // Body is JSON for parity with handler "Copy" output.
-        private void OnSdkError(AudienceError err) =>
-            AppendLog("onError", Json.Serialize(new Dictionary<string, object>
+        // Also forwards to Debug.LogError so the entry lands in Player.log
+        // / Editor console. Without this, OnError fires would be visible
+        // only in the in-app log pane, which disappears with the player
+        // process and is not captured by NUnit's test-results.xml. That
+        // gap let HTTP / cert / 4xx-5xx failures pass under "39 passed"
+        // for the StandaloneLinux64 cells.
+        private void OnSdkError(AudienceError err)
+        {
+            var body = Json.Serialize(new Dictionary<string, object>
             {
                 ["code"] = err.Code.ToString(),
                 ["message"] = err.Message,
-            }, 2), LogLevel.Err, LogSource.Sdk);
+            }, 2);
+            UnityEngine.Debug.LogError($"[Audience.OnError] {body}");
+            AppendLog("onError", body, LogLevel.Err, LogSource.Sdk);
+        }
 
         // SDK Log.Writer adapter. May fire from any thread; AppendLog handles
-        // the main-thread marshal.
+        // the main-thread marshal. Also mirrors to Unity's Debug.Log so the
+        // SDK's warnings reach Player.log alongside the in-app pane.
         private void RouteSdkLogToPane(string msg)
         {
             const string warnTag = "[ImmutableAudience] WARN:";
@@ -265,10 +276,16 @@ namespace Immutable.Audience.Samples.SampleApp
             {
                 level = LogLevel.Warn;
                 body = msg.Substring(warnTag.Length).TrimStart();
+                UnityEngine.Debug.LogWarning($"[Audience] {body}");
             }
             else if (msg.StartsWith(prefix, StringComparison.Ordinal))
             {
                 body = msg.Substring(prefix.Length).TrimStart();
+                UnityEngine.Debug.Log($"[Audience] {body}");
+            }
+            else
+            {
+                UnityEngine.Debug.Log($"[Audience] {body}");
             }
             AppendLog("sdk", body, level, LogSource.Sdk);
         }

--- a/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
@@ -128,6 +128,30 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
 
         // ---- Tests ----
 
+        // Marks this as coming from CI.
+        [UnityTest]
+        public IEnumerator AudienceCiTestMarker_EmitsRunMetadata()
+        {
+            var runId  = Environment.GetEnvironmentVariable("AUDIENCE_TEST_RUN_ID");
+            var cellId = Environment.GetEnvironmentVariable("AUDIENCE_TEST_CELL_ID");
+            if (string.IsNullOrEmpty(runId) && string.IsNullOrEmpty(cellId))
+            {
+                Assert.Ignore("Not running in CI.");
+                yield break;
+            }
+
+            yield return LoadAndInit();
+
+            ImmutableAudience.Track("audience_ci_test_marker", new System.Collections.Generic.Dictionary<string, object>
+            {
+                ["source"]   = "ci",
+                ["ciRunId"]  = runId  ?? string.Empty,
+                ["ciCellId"] = cellId ?? string.Empty,
+            });
+
+            yield return null;
+        }
+
         [UnityTest]
         public IEnumerator InitTrackFlush_AgainstSandbox_FlushReportsOk()
         {

--- a/src/Packages/Audience/Runtime/Transport/DiskStore.cs
+++ b/src/Packages/Audience/Runtime/Transport/DiskStore.cs
@@ -26,6 +26,8 @@ namespace Immutable.Audience
             _queueDir = Path.Combine(persistentDataPath, "imtbl_audience", "queue");
             Directory.CreateDirectory(_queueDir);
             _cachedCount = Directory.GetFiles(_queueDir, "*.json").Length;
+            // DEBUG SDK-341: trace counter init.
+            Console.WriteLine($"[DiskStore] ctor initial count={_cachedCount} dir={_queueDir} hash={GetHashCode()}");
         }
 
         // Atomically writes json as a new event file.
@@ -113,7 +115,13 @@ namespace Immutable.Audience
         // count seeded at construction; mutating ops maintain it.
         internal int Count() => Volatile.Read(ref _cachedCount);
 
-        private void BumpCount(int delta) => Interlocked.Add(ref _cachedCount, delta);
+        // DEBUG SDK-341: log every counter mutation with stack so we can see
+        // who decrements without a matching increment. Revert before merge.
+        private void BumpCount(int delta)
+        {
+            var newValue = Interlocked.Add(ref _cachedCount, delta);
+            Console.WriteLine($"[DiskStore] BumpCount({delta:+#;-#;0}) -> {newValue} hash={GetHashCode()}\n{System.Environment.StackTrace}");
+        }
 
         private static bool TryDelete(string path)
         {

--- a/src/Packages/Audience/Runtime/Transport/DiskStore.cs
+++ b/src/Packages/Audience/Runtime/Transport/DiskStore.cs
@@ -65,9 +65,18 @@ namespace Immutable.Audience
 
             var result = new List<string>();
 
-            // Sort by filename (ticks prefix) → oldest first
-            var files = Directory.GetFiles(_queueDir, "*.json")
-                .OrderBy(f => Path.GetFileName(f), StringComparer.Ordinal);
+            // Sort by filename (ticks prefix) → oldest first.
+            // The queue dir can disappear out from under us when an external
+            // process (test SetUp, manual cleanup, persistentDataPath wipe)
+            // deletes it between SDK Init and the next flush tick. Treat that
+            // as an empty queue rather than letting DirectoryNotFoundException
+            // bubble up through SendBatchAsync to the caller's OnError.
+            // Matches the existing guard in DeleteAll / ApplyAnonymousDowngrade.
+            string[] paths;
+            try { paths = Directory.GetFiles(_queueDir, "*.json"); }
+            catch (DirectoryNotFoundException) { return Array.Empty<string>(); }
+
+            var files = paths.OrderBy(f => Path.GetFileName(f), StringComparer.Ordinal);
 
             foreach (var path in files)
             {


### PR DESCRIPTION
## Summary

- The `playmode-linux` job in `test-audience-sample-app.yml` reported every cell green for ~3 min while executing zero tests. Each of the 39 `[UnityTest]` cases in `SampleAppLiveFireTests` came back inconclusive (passed=0, failed=0) in ~0.13 s. Comparison: the macOS cell ran the same 39 tests in 25 s with all 39 passing. Evidence: run [25492697422](https://github.com/immutable/unity-immutable-sdk/actions/runs/25492697422).
- Root cause: `game-ci/unity-test-runner@v4` hardcodes `-batchmode -nographics` and never starts an X server, so PlayMode tests that load scenes or use UI Toolkit cannot launch the player and Unity returns inconclusive for every case. The action also sets `USE_EXIT_CODE=false`, which suppresses Unity's exit code 2; `dorny/test-reporter` does not treat inconclusive as failure, so the cells silently went green.
- This PR replaces the action with a manual `docker run` of the same `unityci/editor:ubuntu-${unity}-linux-il2cpp-3` image, wrapped in `xvfb-run`. Software OpenGL via `mesa-llvmpipe` is bundled in the image; no GPU required.
- One image tag covers both Mono and IL2CPP backends (verified against the Mono cell log from run 25492697422 which already pulled the il2cpp tag).
- Per-run license activation + return mirrors the dropped self-hosted Linux job (commit 2658686c).
- Adds a post-step that parses `playmode-results.xml` via `xmllint` and fails the cell when `inconclusive > 0` or `passed+failed == 0`. Defense in depth so a future change that re-disables the display cannot silently re-green the matrix.
- `timeout-minutes: 30` added since cells now run ~5-10 min of real work rather than 3 min of inconclusive-skip.

## Test plan

- [ ] First PR run pulls a cold image (~100 s) and rebuilds the Library cache; expect ~12-15 min per cell on the first run, ~5-10 min thereafter.
- [ ] All four PR-mode cells (StandaloneLinux64 / IL2CPP and Mono2x / Unity 2021.3.45f2 and 6000.4.0f1) report `passed=39, failed=0, inconclusive=0` in `playmode-results.xml`. Compare against the prior `inconclusive=39, passed=0` baseline.
- [ ] The inconclusive guard fails the cell when xvfb is missing. Manual probe: temporarily strip `xvfb-run` from the docker command in a follow-up commit and confirm the guard fires with the inconclusive message before reverting.
- [ ] `activation.log` and `playmode.log` upload as artifacts for the cell so license / player launch failures are debuggable.
- [ ] License seat-pool: confirm parallel cells do not exhaust activations on a fresh run. The job returns the seat at the end of every cell.

## Notes for reviewer

- Stacked on #752 (`chore/sdk-317-audience-linux-platform-support`). Will rebase onto main once that lands.
- SDK-318 ("Verify the audience SDK behaves the same on Linux as on Windows and macOS") was marked Done on 2026-05-07. Its DoD includes "login, send a few events on Linux produces the same events at the audience backend as on Windows and macOS" - which only the now-fixed PlayMode cells could verify. SDK-318 should be reopened or a new ticket filed once this PR is green; until then the parity verification is unsubstantiated.