### PR TITLE
ci(audience): swap llvmpipe -> lavapipe (Vulkan) for playmode-linux

### DIFF
--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -743,6 +743,7 @@ jobs:
           path: |
             artifacts/playmode-results.xml
             artifacts/playmode.log
+            artifacts/vulkaninfo.txt
             artifacts/activation.log
             artifacts/Player-*.log
             examples/audience/Logs/**

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -509,6 +509,22 @@ jobs:
                 exit 1
               fi
 
+              # Install Mesa software Vulkan (lavapipe) and vulkan-tools.
+              # The unityci/editor image is Debian-based; apt-get works as
+              # root inside the container.
+              echo "::group::install lavapipe"
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+                mesa-vulkan-drivers vulkan-tools
+              echo "::endgroup::"
+
+              # Force lavapipe selection if multiple Vulkan ICDs are present.
+              # MESA_VK_DEVICE_SELECT=lvp picks the LLVM-pipe Vulkan device.
+              export MESA_VK_DEVICE_SELECT=lvp
+
+              # Capture the Vulkan device list for post-run inspection.
+              vulkaninfo --summary > /github/workspace/artifacts/vulkaninfo.txt 2>&1 || true
+
               # xvfb-run gives Unity a virtual X display so PlayMode tests
               # that load scenes and exercise UI Toolkit can actually launch
               # the player. GLX + render are required for UIElements; the

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -563,15 +563,13 @@ jobs:
               # only on UI Toolkit log-row presence (queried via the
               # VisualElement tree, not via screen capture).
               #
-              # Why -force-glcore: Unity 6 prefers Vulkan on Linux and
-              # falls back to OpenGL when Vulkan init fails. Each frame
-              # carries the negotiation overhead. -force-glcore tells the
-              # player to skip Vulkan entirely and open a GLX context
-              # directly, the same path Unity 2021.3 takes by default.
+              # Vulkan via lavapipe is the experiment. We do not pass
+              # -force-glcore here so Unity 6 picks its native Vulkan
+              # path. Unity 2021.3 and 2022.3 still default to OpenGL on
+              # Linux; for them this is a no-op.
               xvfb-run -a --server-args="-screen 0 320x240x24 -ac +extension GLX +render -noreset" -- \
                 unity-editor \
                   -batchmode \
-                  -force-glcore \
                   -screen-fullscreen 0 \
                   -screen-width 320 \
                   -screen-height 240 \


### PR DESCRIPTION
## Summary

- Stacks on top of `chore/sdk-318-linux-playmode-xvfb`. Diff is lavapipe-only.
- Installs `mesa-vulkan-drivers` and `vulkan-tools` inside the `unityci/editor` container before the xvfb-driven Unity run.
- Sets `MESA_VK_DEVICE_SELECT=lvp` so multiple Vulkan ICDs do not race.
- Drops `-force-glcore` from the Unity command line so Unity 6 picks its native Vulkan path.
- Uploads `vulkaninfo.txt` as a CI artifact for post-run device confirmation.

## Experiment success criteria (from spec)

- Unity 6 Mono cell wall time **under 15 min**: declare win, propose merge into SDK-318 (and onward to main).
- Unity 6 Mono cell wall time **15 to 22 min**: marginal; close PR with measurements.
- Unity 6 Mono cell wall time **above 22 min** or any test failure not present on the SDK-318 baseline: regression; close PR with findings.
- Unity 2021.3 cells stay at or below their current 4 min on the SDK-318 baseline.

## Test plan

- [ ] All 6 `playmode-linux` cells run on this PR.
- [ ] `vulkaninfo.txt` artifact present on at least one cell and shows `llvmpipe (LLVM ...)` as the selected device.
- [ ] Compare cell wall times against the most recent SDK-318 same-day run; record numbers in PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)