### PR TITLE
chore(audience-sample): drop Standalone default quality to Very Low

### DIFF
--- a/examples/audience/ProjectSettings/QualitySettings.asset
+++ b/examples/audience/ProjectSettings/QualitySettings.asset
@@ -226,7 +226,7 @@ QualitySettings:
     PS4: 5
     PS5: 5
     Stadia: 5
-    Standalone: 5
+    Standalone: 0
     WebGL: 3
     Windows Store Apps: 5
     XboxOne: 5


### PR DESCRIPTION
## Summary

- One-line change to `QualitySettings.asset`: `m_PerPlatformDefaultQuality.Standalone: 5 -> 0`.
- Standalone Linux CI cells boot at quality level 0 (Very Low): no shadows, no anisotropic, no antialiasing, no realtime reflection probes, no soft particles or vegetation.
- Standalone Windows and macOS cells also drop to Very Low. Their CI cells are GPU-accelerated and already finish in 2 to 4 min, so no regression expected.

## Experiment success criteria

- Unity 6 Linux Mono cell wall time **under 22 min** (currently around 27 min on baseline).
- Unity 2021.3 Linux cells stay at or below their current 4 min.
- All 4 Linux PR cells go green (no test failures introduced by the quality drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)