### PR TITLE
ci(audience): shrink xvfb screen to 160x120 for llvmpipe fill rate

### DIFF
--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -540,7 +540,7 @@ jobs:
 
               # Why a tiny screen: the per-frame fragment-shader cost on
               # mesa-llvmpipe scales with pixel count. 1280x720 = 0.92M
-              # px per frame; 320x240 = 0.08M px - a 12x reduction in
+              # px per frame; 160x120 = 0.02M px - a 48x reduction in
               # software-rendered fill work, which is the dominant cost
               # on Unity 6 Linux. UI Toolkit lays out fine on this size
               # because the test never asserts on rendered pixel content,
@@ -552,13 +552,13 @@ jobs:
               # carries the negotiation overhead. -force-glcore tells the
               # player to skip Vulkan entirely and open a GLX context
               # directly, the same path Unity 2021.3 takes by default.
-              xvfb-run -a --server-args="-screen 0 320x240x24 -ac +extension GLX +render -noreset" -- \
+              xvfb-run -a --server-args="-screen 0 160x120x24 -ac +extension GLX +render -noreset" -- \
                 unity-editor \
                   -batchmode \
                   -force-glcore \
                   -screen-fullscreen 0 \
-                  -screen-width 320 \
-                  -screen-height 240 \
+                  -screen-width 160 \
+                  -screen-height 120 \
                   -projectPath /github/workspace/examples/audience \
                   -runTests \
                   -testPlatform StandaloneLinux64 \


### PR DESCRIPTION
## Summary

- xvfb virtual screen drops from 320x240x24 (76 800 px) to 160x120x24 (19 200 px). 4x fewer pixels per frame.
- Unity `-screen-width` and `-screen-height` track the new size.

## Why

llvmpipe fragment-fill cost scales linearly with pixel count. The previous reduction (1280x720 to 320x240) cut fill 12x. Going to 160x120 cuts another 4x.

## Risk

UI Toolkit may fail to lay out below some threshold. The SampleApp tests assert on the visual element tree, not on rendered pixels, so layout only needs to be valid; visible quality is irrelevant. If tests come back inconclusive on this PR's CI run, that means the floor is between 320x240 and 160x120 and we step back.

## Experiment success criteria

- Unity 6 Linux Mono cell wall time **under 18 min** (currently around 27 min).
- All 4 Linux PR cells go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)