### PR TITLE
test(audience-sample): pin frame rate to 1 on Linux for llvmpipe fill rate

### DIFF
--- a/examples/audience/Assets/SampleApp/Tests/Runtime/LinuxRenderSuppression.cs
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/LinuxRenderSuppression.cs
@@ -1,0 +1,42 @@
+#nullable enable
+
+#if UNITY_STANDALONE_LINUX
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Immutable.Audience.Samples.SampleApp.Tests
+{
+    // Linux-only test suppression: clamp the player's frame rate to 1 fps
+    // and disable vsync. The SampleApp PlayMode tests assert on UI Toolkit
+    // visual-element state, which is layout-driven, not paint-driven.
+    // Painting fewer frames between coroutine yields removes llvmpipe
+    // fragment-fill cost without changing what tests observe.
+    //
+    // Scope: every test in the Tests assembly when the build target is
+    // StandaloneLinux64. UNITY_STANDALONE_LINUX is defined by Unity for
+    // PlayMode runs invoked with -testPlatform StandaloneLinux64.
+    [SetUpFixture]
+    public sealed class LinuxRenderSuppression
+    {
+        private int _priorTargetFrameRate;
+        private int _priorVSyncCount;
+
+        [OneTimeSetUp]
+        public void Suppress()
+        {
+            _priorTargetFrameRate = Application.targetFrameRate;
+            _priorVSyncCount = QualitySettings.vSyncCount;
+
+            Application.targetFrameRate = 1;
+            QualitySettings.vSyncCount = 0;
+        }
+
+        [OneTimeTearDown]
+        public void Restore()
+        {
+            Application.targetFrameRate = _priorTargetFrameRate;
+            QualitySettings.vSyncCount = _priorVSyncCount;
+        }
+    }
+}
+#endif

--- a/examples/audience/Assets/SampleApp/Tests/Runtime/LinuxRenderSuppression.cs.meta
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/LinuxRenderSuppression.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c2d9b1a8e4f3a4d8c1b2e3a4d5f6e7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

- Adds `LinuxRenderSuppression` `[SetUpFixture]` gated on `UNITY_STANDALONE_LINUX`.
- On Linux PlayMode runs only: `Application.targetFrameRate = 1` and `QualitySettings.vSyncCount = 0` for the duration of the suite, restored on teardown.
- Mac and Windows PlayMode runs unaffected.

## Why

Tests assert on UI Toolkit's visual-element tree (layout state), not on rasterised pixels. Painting more frames between assertions doesn't help the assertions; it just spends llvmpipe CPU cycles on fragment fill. Capping at 1 fps lets the player do logic work at full speed while skipping most paint cost.

## Experiment success criteria

- Unity 6 Linux Mono cell wall time **under 18 min** (currently around 27 min).
- Unity 2021.3 Linux cells stay at or below their current 4 min.
- All 4 Linux PR cells go green; no UI Toolkit state assertions regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)