### PR TITLE
chore(audience): SDK-317 PR #768 review follow-up

### DIFF
--- a/.github/scripts/audience/playmode-linux-container.sh
+++ b/.github/scripts/audience/playmode-linux-container.sh
@@ -6,7 +6,7 @@
 set -uo pipefail
 
 LOG=/github/workspace/artifacts/unity.log
-ACTIVATION_LOG=/github/workspace/artifacts/activation.log
+ACTIVATION_LOG=/tmp/audience-unity-activation.log
 RESULTS=/github/workspace/artifacts/test-results.xml
 PROJECT=/github/workspace/examples/audience
 

--- a/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
@@ -162,7 +162,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
                 ["ciJobId"]  = jobId  ?? string.Empty,
             });
 
-            yield return null;
+            yield return FlushAndAssertNoErrors("ci marker");
         }
 
         [UnityTest]

--- a/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
@@ -60,6 +60,13 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
             _root = null;
         }
 
+        [TearDown]
+        public void TearDown()
+        {
+            LogAssert.ignoreFailingMessages = false;
+            System.Net.ServicePointManager.ServerCertificateValidationCallback = null;
+        }
+
         // ---- Helpers shared by every test ----
 
         // Loads the SampleApp scene, types the env-var key into publishable-key,


### PR DESCRIPTION
## Summary

- Adds a TearDown to SampleAppLiveFireTests so the LogAssert filter and the cert validator SetUp mutates do not leak into other test fixtures sharing the same process.
- Flushes after AudienceCiTestMarker_EmitsRunMetadata's Track call so the marker actually leaves the player; the previous yield-null left it on the queue and the next test's SetUp wiped it.
- Moves the Unity license activation log from /github/workspace/artifacts/activation.log to /tmp/audience-unity-activation.log so it stays out of the artifact upload (the workflow ships everything under artifacts/**).

## Reviewer threads addressed on #768

- nattb8 inline (LiveFire SetUp line 29): TearDown reset.
- nattb8 inline (CI marker test line 137): added flush; kept the test name since the test now does what the name claims.
- cursor[bot] inline (playmode-linux-container.sh line 20, MEDIUM): activation log moved off the artifact path.

Linear: [SDK-317](https://linear.app/imtbl/issue/SDK-317)