### PR TITLE
feat(audience): normalize platform wire values, add isEditor (SDK-343)

### DIFF
--- a/src/Packages/Audience/Runtime/Unity/DeviceCollector.cs
+++ b/src/Packages/Audience/Runtime/Unity/DeviceCollector.cs
@@ -47,12 +47,15 @@ namespace Immutable.Audience.Unity
         }
 
         internal static Dictionary<string, object> CollectGameLaunchProperties(
-            RuntimePlatform? platformOverride = null)
+            RuntimePlatform? platformOverride = null,
+            bool? isEditorOverride = null)
         {
             var platform = platformOverride ?? Application.platform;
+            var isEditor = isEditorOverride ?? Application.isEditor;
             var props = new Dictionary<string, object>
             {
                 ["platform"] = PlatformName(platform),
+                ["isEditor"] = isEditor,
                 ["version"] = Truncate(Application.version, 256),
                 ["buildGuid"] = Truncate(Application.buildGUID, 256),
                 ["unityVersion"] = Truncate(Application.unityVersion, 256),
@@ -106,7 +109,11 @@ namespace Immutable.Audience.Unity
 
         private static string PlatformName(RuntimePlatform platform) => platform switch
         {
+            RuntimePlatform.WindowsPlayer or RuntimePlatform.WindowsEditor => "Windows",
+            RuntimePlatform.OSXPlayer or RuntimePlatform.OSXEditor => "macOS",
+            RuntimePlatform.LinuxPlayer or RuntimePlatform.LinuxEditor => "Linux",
             RuntimePlatform.IPhonePlayer => "iOS",
+            RuntimePlatform.Android => "Android",
             _ => platform.ToString(),
         };
 

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -1189,7 +1189,7 @@ namespace Immutable.Audience.Tests
         {
             ImmutableAudience.LaunchContextProvider = () => new Dictionary<string, object>
             {
-                ["platform"] = "WindowsPlayer",
+                ["platform"] = "Windows",
                 ["version"] = "1.2.3",
                 ["buildGuid"] = "a1b2c3d4e5f6",
                 ["unityVersion"] = "2022.3.20f1",
@@ -1203,7 +1203,7 @@ namespace Immutable.Audience.Tests
                 .Select(File.ReadAllText)
                 .FirstOrDefault(c => c.Contains("\"game_launch\""));
             Assert.IsNotNull(launchFile, "game_launch should have been enqueued");
-            StringAssert.Contains("\"platform\":\"WindowsPlayer\"", launchFile);
+            StringAssert.Contains("\"platform\":\"Windows\"", launchFile);
             StringAssert.Contains("\"version\":\"1.2.3\"", launchFile);
             StringAssert.Contains("\"buildGuid\":\"a1b2c3d4e5f6\"", launchFile);
             StringAssert.Contains("\"unityVersion\":\"2022.3.20f1\"", launchFile);

--- a/src/Packages/Audience/Tests/Runtime/Unity/DeviceCollectorTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Unity/DeviceCollectorTests.cs
@@ -52,7 +52,7 @@ namespace Immutable.Audience.Tests
         {
             var props = DeviceCollector.CollectGameLaunchProperties();
             foreach (var key in new[] {
-                "platform", "version", "buildGuid", "unityVersion",
+                "platform", "isEditor", "version", "buildGuid", "unityVersion",
                 "osFamily", "deviceModel", "gpu", "gpuVendor",
                 "cpu", "cpuCores", "ramMb" })
             {
@@ -134,11 +134,51 @@ namespace Immutable.Audience.Tests
         }
 
         [Test]
-        public void CollectGameLaunchProperties_iOS_ContainsPlatformIPhonePlayer()
+        public void CollectGameLaunchProperties_iOS_PlatformIsIOS()
         {
             IDFVBridge.Impl = () => null;
             var props = DeviceCollector.CollectGameLaunchProperties(RuntimePlatform.IPhonePlayer);
             Assert.AreEqual("iOS", props["platform"]);
+        }
+
+        // -----------------------------------------------------------------
+        // PlatformName mapping: collapse Player/Editor variants to OS name
+        // -----------------------------------------------------------------
+
+        [TestCase(RuntimePlatform.WindowsPlayer, "Windows")]
+        [TestCase(RuntimePlatform.WindowsEditor, "Windows")]
+        [TestCase(RuntimePlatform.OSXPlayer, "macOS")]
+        [TestCase(RuntimePlatform.OSXEditor, "macOS")]
+        [TestCase(RuntimePlatform.LinuxPlayer, "Linux")]
+        [TestCase(RuntimePlatform.LinuxEditor, "Linux")]
+        [TestCase(RuntimePlatform.IPhonePlayer, "iOS")]
+        [TestCase(RuntimePlatform.Android, "Android")]
+        public void CollectGameLaunchProperties_Platform_MapsToLaymanName(
+            RuntimePlatform input, string expected)
+        {
+            var props = DeviceCollector.CollectGameLaunchProperties(input);
+            Assert.AreEqual(expected, props["platform"]);
+        }
+
+        [Test]
+        public void CollectGameLaunchProperties_Platform_UnmappedFallsBackToEnumName()
+        {
+            // Console / unsupported targets must not be silently dropped.
+            var props = DeviceCollector.CollectGameLaunchProperties(RuntimePlatform.WebGLPlayer);
+            Assert.AreEqual("WebGLPlayer", props["platform"]);
+        }
+
+        // -----------------------------------------------------------------
+        // isEditor: distinguishes dev runs from production player traffic
+        // -----------------------------------------------------------------
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void CollectGameLaunchProperties_IsEditor_ReflectsOverride(bool isEditor)
+        {
+            var props = DeviceCollector.CollectGameLaunchProperties(
+                isEditorOverride: isEditor);
+            Assert.AreEqual(isEditor, props["isEditor"]);
         }
     }
 }


### PR DESCRIPTION
## Summary

Normalizes the `platform` wire value for the audience SDK's auto-emitted `game_launch` event so the public schema speaks layman OS names instead of Unity's `RuntimePlatform` enum strings, and adds an `isEditor` boolean so studios can filter dev runs cleanly.

- `DeviceCollector.PlatformName` maps `RuntimePlatform` to `Windows`, `macOS`, `Linux`, `iOS`, `Android`. The Windows / OSX / Linux Player and Editor variants collapse to a single OS string each.
- Console, WebGL, server, and other unmapped `RuntimePlatform` values fall through to `platform.ToString()`, so traffic from those targets is not silently dropped.
- Adds an `isEditor` boolean to `game_launch`, sourced from `Application.isEditor`. Replaces the Player-vs-Editor distinction previously embedded in `platform`, so studios can filter dev runs out of production analytics on a dedicated field.
- `osFamily` is intentionally left as the raw `SystemInfo.operatingSystemFamily.ToString()` value (`Windows`, `MacOSX`, `Linux`, `Other`). `platform` is the curated public field; `osFamily` stays as a passthrough so power users still have direct access to Unity's view.
- `CollectGameLaunchProperties` gains an `isEditorOverride` parameter alongside the existing `platformOverride`, so the new mappings are deterministically testable.
- `DeviceCollectorTests` covers the new platform mappings for Windows / macOS / Linux in both Player and Editor variants, iOS, Android, unmapped fallback, and `isEditor` true and false.
- `ImmutableAudienceTests.Init_GameLaunch_IncludesLaunchContextProviderFields` example value updated from `"WindowsPlayer"` to `"Windows"` for consistency with the new convention.

Breaking wire-format change for `platform`. Any downstream consumer that filters on `WindowsPlayer` / `OSXPlayer` / `LinuxPlayer` will need updating. The public data dictionary in `immutable/documentation` is updated in parallel by [#83](https://github.com/immutable/documentation/pull/83).

Linear: [SDK-343](https://linear.app/imtbl/issue/SDK-343/normalize-audience-platformosfamily-wire-values-to-layman-strings)