### PR TITLE
fix(audience-sdk): gate iOS attribution providers behind AUDIENCE_MOBILE_ATTRIBUTION (SDK-347)

### DIFF
--- a/src/Packages/Audience/Runtime/Unity/AudienceUnityHooks.cs
+++ b/src/Packages/Audience/Runtime/Unity/AudienceUnityHooks.cs
@@ -35,7 +35,7 @@ namespace Immutable.Audience.Unity
             ImmutableAudience.LaunchContextProvider = () => launchProps;
             ImmutableAudience.ContextProvider = () => contextProps;
 
-#if UNITY_IOS && !UNITY_EDITOR
+#if UNITY_IOS && !UNITY_EDITOR && AUDIENCE_MOBILE_ATTRIBUTION
             ImmutableAudience.MobileAttributionProvider = () => SkanRegistration.RegisterIfFirstLaunch();
             ImmutableAudience.MobileAttributionContextProvider = () => AttributionContext.Capture();
             ImmutableAudience.TrackingAuthorizationRequestProvider = () => ATTBridge.RequestAsync();


### PR DESCRIPTION
## Summary

- Adds `AUDIENCE_MOBILE_ATTRIBUTION` to the iOS provider registration guard in `AudienceUnityHooks.cs`
- Without this fix, iOS builds could collect ATT status and IDFA at runtime when `AUDIENCE_MOBILE_ATTRIBUTION` was not set, while the privacy manifest still declared `NSPrivacyTracking = false` — an App Store rejection risk
- Both platforms now require the define before any attribution provider is registered, making iOS and Android symmetric and matching the documented two-gate model

## Test plan

- [x] Build an iOS project **without** `AUDIENCE_MOBILE_ATTRIBUTION` set — verify `attStatus`, `idfa`, and `skanRegistered` are absent from `game_launch`
- [x] Build an iOS project **with** `AUDIENCE_MOBILE_ATTRIBUTION` + `EnableMobileAttribution = true` — verify attribution signals are present as before
- [x] Existing unit tests pass (they drive providers via test seams, not through `AudienceUnityHooks`)

Closes SDK-347

🤖 Generated with [Claude Code](https://claude.com/claude-code)