### PR TITLE
chore(audience-sdk): remove em dashes from comments and trim verbose phrasing

### DIFF
--- a/src/Packages/Audience/Editor/AudienceMobileBuildSettings.cs
+++ b/src/Packages/Audience/Editor/AudienceMobileBuildSettings.cs
@@ -27,7 +27,7 @@ namespace Immutable.Audience.Editor
 
         [SerializeField]
         [Tooltip("Copy shown in the iOS App Tracking Transparency prompt. " +
-                 "Apple rejects empty or generic strings — describe what is " +
+                 "Apple rejects empty or generic strings. Describe what is " +
                  "collected and why.")]
         private string trackingUsageDescription = DefaultTrackingUsageDescription;
 
@@ -64,7 +64,7 @@ namespace Immutable.Audience.Editor
             if (guids.Length > 1)
             {
                 Debug.LogWarning(
-                    $"[ImmutableAudience] Multiple AudienceMobileBuildSettings assets found — " +
+                    $"[ImmutableAudience] Multiple AudienceMobileBuildSettings assets found - " +
                     $"using '{path}'. Remove the duplicates to avoid unexpected build behaviour.");
             }
             return AssetDatabase.LoadAssetAtPath<AudienceMobileBuildSettings>(path);

--- a/src/Packages/Audience/Editor/iOSFrameworkPostProcessor.cs
+++ b/src/Packages/Audience/Editor/iOSFrameworkPostProcessor.cs
@@ -19,7 +19,7 @@ namespace Immutable.Audience.Editor
     /// <c>AdSupport.framework</c> hosts <c>ASIdentifierManager</c> (the IDFA
     /// accessor). Without it linked, the runtime <c>NSClassFromString</c>
     /// lookup returns nil and the IDFA is silently dropped from
-    /// <c>game_launch</c> — the Info.plist key alone does not load this
+    /// <c>game_launch</c>. The Info.plist key alone does not load this
     /// framework. Linked as a required dep; the framework has shipped on
     /// every iOS release since 6.0.
     /// </para>
@@ -27,7 +27,7 @@ namespace Immutable.Audience.Editor
     /// <c>AppTrackingTransparency.framework</c> hosts <c>ATTrackingManager</c>.
     /// Unity often auto-links this when <c>NSUserTrackingUsageDescription</c>
     /// is present, but the auto-link heuristic is undocumented and
-    /// version-sensitive — an explicit weak link is immune to that drift and
+    /// version-sensitive. An explicit weak link is immune to that drift and
     /// keeps the binary loadable on iOS &lt; 14 (the runtime code already
     /// guards via <c>NSClassFromString</c>).
     /// </para>
@@ -40,7 +40,7 @@ namespace Immutable.Audience.Editor
     internal static class iOSFrameworkPostProcessor
     {
         // Runs just after the Info.plist post-processor (9050). Order is
-        // independent in practice — both edit different files — but keeping
+        // independent in practice (both edit different files), but keeping
         // them adjacent makes the build log obvious.
         internal const int CallbackOrder = 9051;
 
@@ -76,7 +76,7 @@ namespace Immutable.Audience.Editor
 #endif
         }
 
-        // Reads the iOS-target define list specifically — the post-processor
+        // Reads the iOS-target define list specifically. The post-processor
         // mutates iOS build output regardless of which target the editor is
         // currently focused on.
         private static bool AttributionDefineEnabled()

--- a/src/Packages/Audience/Editor/iOSInfoPlistPostProcessor.cs
+++ b/src/Packages/Audience/Editor/iOSInfoPlistPostProcessor.cs
@@ -18,7 +18,7 @@ namespace Immutable.Audience.Editor
     /// <remarks>
     /// Both keys are gated by the <c>AUDIENCE_MOBILE_ATTRIBUTION</c>
     /// scripting define so a studio that hasn't opted into attribution
-    /// ships a clean <c>Info.plist</c> — Apple flags apps that include
+    /// ships a clean <c>Info.plist</c>. Apple flags apps that include
     /// either key without the corresponding code paths.
     ///
     /// Values come from the <see cref="AudienceMobileBuildSettings"/>
@@ -88,11 +88,11 @@ namespace Immutable.Audience.Editor
                 $"  NSUserTrackingUsageDescription: {description}\n" +
                 $"  SKAdNetworkItems: {ids.Length} id(s)\n" +
                 (ids.Length == 0
-                    ? "  (no SKAdNetwork ids configured — set them on the AudienceMobileBuildSettings asset)\n"
+                    ? "  (no SKAdNetwork ids configured - set them on the AudienceMobileBuildSettings asset)\n"
                     : string.Concat(System.Array.ConvertAll(ids, id => $"    - {id}\n"))));
         }
 
-        // Reads the iOS-target define list specifically — the post-processor
+        // Reads the iOS-target define list specifically. The post-processor
         // mutates iOS build output regardless of which target the editor is
         // currently focused on.
         private static bool AttributionDefineEnabled()
@@ -114,7 +114,7 @@ namespace Immutable.Audience.Editor
                 ? settings.TrackingUsageDescription
                 : AudienceMobileBuildSettings.DefaultTrackingUsageDescription;
 
-            // Always overwrite — the settings asset is the source of truth,
+            // Always overwrite. The settings asset is the source of truth,
             // beating any placeholder a lower-order post-processor wrote.
             root.SetString("NSUserTrackingUsageDescription", description);
         }

--- a/src/Packages/Audience/Editor/iOSPrivacyManifestPostProcessor.cs
+++ b/src/Packages/Audience/Editor/iOSPrivacyManifestPostProcessor.cs
@@ -62,7 +62,7 @@ namespace Immutable.Audience.Editor
         /// <summary>
         /// Adds the attribution-specific privacy declarations to an existing
         /// (already Unity-merged) <c>PrivacyInfo.xcprivacy</c> plist root.
-        /// Idempotent — safe to call on a manifest that already has these entries.
+        /// Idempotent. Safe to call on a manifest that already has these entries.
         /// </summary>
         internal static void ApplyAttributionPrivacyEntries(PlistElementDict root)
         {

--- a/src/Packages/Audience/Runtime/AudienceConfig.cs
+++ b/src/Packages/Audience/Runtime/AudienceConfig.cs
@@ -68,7 +68,7 @@ namespace Immutable.Audience
         ///    collected at runtime. Without the define, this setter is a
         ///    no-op.
         ///
-        /// Studios who set neither ship a clean binary — no AD_ID permission,
+        /// Studios who set neither ship a clean binary: no AD_ID permission,
         /// no native attribution code, <c>NSPrivacyTracking = false</c>.
         /// </remarks>
         public bool EnableMobileAttribution { get; set; } = false;

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -742,7 +742,7 @@ namespace Immutable.Audience
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Studios decide when to show the prompt — Apple's HIG requires it
+        /// Studios decide when to show the prompt. Apple's HIG requires it
         /// to fire at a moment that makes the value to the player obvious,
         /// not at SDK Init. The IDFA, when authorized, is collected
         /// automatically on the next <see cref="ImmutableAudience.Init"/> via
@@ -751,7 +751,7 @@ namespace Immutable.Audience
         /// </para>
         /// <para>
         /// Resolves to <see cref="TrackingAuthorizationStatus.NotDetermined"/>
-        /// in three distinct cases — callers who use this signal to decide
+        /// in three distinct cases. Callers who use this signal to decide
         /// whether to retry should consult the SDK log to disambiguate:
         /// </para>
         /// <list type="bullet">
@@ -1148,7 +1148,7 @@ namespace Immutable.Audience
             if (skanRegistered == true)
                 properties["skanRegistered"] = true;
 
-            // iOS ATT/IDFA snapshot — merged after Unity context so attribution
+            // iOS ATT/IDFA snapshot, merged after Unity context so attribution
             // keys are authoritative if both sources happen to set the same key.
             // idfa and gaid are cross-app device identifiers, same privacy class
             // as userId; gate them at Full-only. State-class keys (attStatus,
@@ -1170,7 +1170,7 @@ namespace Immutable.Audience
         }
 
         // Fires install_referrer_received exactly once per install. Cache
-        // file presence alone isn't enough — on first launch the bridge may
+        // file presence alone isn't enough. On first launch the bridge may
         // write the cache after Init has already run, so the event must be
         // dispatched at the next Init that observes a cache hit. The on-disk
         // "sent" marker provides idempotency across that boundary.
@@ -1193,7 +1193,7 @@ namespace Immutable.Audience
             }
             catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
             {
-                // Marker write failed — the event will re-fire on the next
+                // Marker write failed. The event will re-fire on the next
                 // launch. Pipeline-side dedup or the cost of one duplicate is
                 // less bad than never sending the event at all.
                 Log.Warn(AudienceLogs.InstallReferrerSentMarkerWriteFailed(ex));
@@ -1220,7 +1220,7 @@ namespace Immutable.Audience
         // RequestTrackingAuthorizationAsync resolves).
         //
         // First observation (no file): persists the baseline and returns without
-        // firing — game_launch already captures the initial state on that Init.
+        // firing. game_launch already captures the initial state on that Init.
         private static void CheckAndFireAttStatusChanged(
             AudienceConfig config,
             ConsentLevel consent,

--- a/src/Packages/Audience/Runtime/Plugins/Android/proguard-user.txt
+++ b/src/Packages/Audience/Runtime/Plugins/Android/proguard-user.txt
@@ -13,7 +13,7 @@
 # Keep Google Play Services AdvertisingIdClient symbols (GAID).
 #
 # AdvertisingIdClient and its inner Info class are reflected via JNI from
-# GAIDBridge — they have no managed-side reference for R8 to follow, so
+# GAIDBridge - they have no managed-side reference for R8 to follow, so
 # fullMode in studio projects can drop them. Defensive rules ensure the
 # getAdvertisingIdInfo / getId / isLimitAdTrackingEnabled surface survives.
 -keep class com.google.android.gms.ads.identifier.** { *; }

--- a/src/Packages/Audience/Runtime/Unity/Mobile/ATTBridge.cs
+++ b/src/Packages/Audience/Runtime/Unity/Mobile/ATTBridge.cs
@@ -47,7 +47,7 @@ namespace Immutable.Audience.Unity.Mobile
         // Hold a single delegate instance for the lifetime of the process. If
         // we passed a fresh delegate to each P/Invoke call, IL2CPP could GC
         // the wrapper before Apple's completion handler fires (which can be
-        // seconds or minutes later — the user may swipe the prompt away or
+        // seconds or minutes later. The user may swipe the prompt away or
         // background the app).
         private static readonly NativeStatusCallback _staticCallback = OnATTStatus;
 
@@ -60,7 +60,7 @@ namespace Immutable.Audience.Unity.Mobile
         // - MonoPInvokeCallback so IL2CPP emits the trampoline that lets
         //   native code call back into managed code.
         // - Preserve so managed-code stripping at High doesn't drop this
-        //   method (it has no managed callers — only the function pointer).
+        //   method (no managed callers; only the function pointer).
         // Without both, the await in RequestAsync never completes on a
         // shipping build with stripping enabled.
         [MonoPInvokeCallback(typeof(NativeStatusCallback))]

--- a/src/Packages/Audience/Runtime/Unity/Mobile/AttributionContext.cs
+++ b/src/Packages/Audience/Runtime/Unity/Mobile/AttributionContext.cs
@@ -14,7 +14,7 @@ namespace Immutable.Audience.Unity.Mobile
     // Android: gaid + gaidLimitAdTracking are read from the GAIDBridge disk
     // cache populated by the previous launch's background fetch (Google's
     // AdvertisingIdClient is sync + must run off main thread, so first launch
-    // ships nothing — gaidLimitAdTracking shows up on launch #2 onwards).
+    // ships nothing; gaidLimitAdTracking shows up on launch #2 onwards).
     internal static class AttributionContext
     {
         // Maps Apple's ATTrackingManagerAuthorizationStatus to the wire
@@ -33,7 +33,7 @@ namespace Immutable.Audience.Unity.Mobile
         }
 
         // persistentDataPath is required for Android (GAID disk cache); iOS
-        // ignores it. Returns a possibly-empty dict — never null — so callers
+        // ignores it. Returns a possibly-empty dict (never null) so callers
         // can merge unconditionally.
         internal static IReadOnlyDictionary<string, object> Capture(string? persistentDataPath = null)
         {

--- a/src/Packages/Audience/Runtime/Unity/Mobile/GAIDBridge.cs
+++ b/src/Packages/Audience/Runtime/Unity/Mobile/GAIDBridge.cs
@@ -14,7 +14,7 @@ namespace Immutable.Audience.Unity.Mobile
     /// Reads gaid + limitAdTracking via AdvertisingIdClient. Google requires
     /// the call run off the main thread, so we dispatch on a dedicated worker
     /// and cache the result to disk for the next launch. GAID can change
-    /// (user reset), so we refresh every launch — first launch ships nothing,
+    /// (user reset), so we refresh every launch. First launch ships nothing;
     /// launch #2+ ships the previously-cached value.
     /// </summary>
     internal static class GAIDBridge
@@ -101,7 +101,7 @@ namespace Immutable.Audience.Unity.Mobile
         private static void StartFetchNative(string persistentDataPath)
         {
             // Dedicated Thread (not ThreadPool) so Attach/Detach pair on the
-            // same one-shot worker — ThreadPool reuse strands JVM state.
+            // same one-shot worker. ThreadPool reuse strands JVM state.
             var thread = new Thread(() => FetchOnWorkerThread(persistentDataPath))
             {
                 IsBackground = true,

--- a/src/Packages/Audience/Runtime/Unity/Mobile/IDFVBridge.cs
+++ b/src/Packages/Audience/Runtime/Unity/Mobile/IDFVBridge.cs
@@ -9,7 +9,7 @@ namespace Immutable.Audience.Unity.Mobile
 {
     internal static class IDFVBridge
     {
-        // Replaceable in tests — captures NativeImpl by default.
+        // Replaceable in tests; captures NativeImpl by default.
         internal static Func<string?> Impl = NativeImpl;
 
         internal static string? GetIDFV() => Impl();

--- a/src/Packages/Audience/Runtime/Unity/Mobile/InstallReferrerBridge.cs
+++ b/src/Packages/Audience/Runtime/Unity/Mobile/InstallReferrerBridge.cs
@@ -135,7 +135,7 @@ namespace Immutable.Audience.Unity.Mobile
             //
             // Each AndroidJavaClass / AndroidJavaObject holds a JNI global
             // reference; leaking them stranded a JNI handle every Init.
-            // `client` is the exception — ownership transfers to the
+            // `client` is the exception: ownership transfers to the
             // listener which disposes it in its endConnection finally.
             using (var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
             using (var activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity"))

--- a/src/Packages/Audience/Tests/Editor/iOSInfoPlistPostProcessorTests.cs
+++ b/src/Packages/Audience/Tests/Editor/iOSInfoPlistPostProcessorTests.cs
@@ -45,7 +45,7 @@ namespace Immutable.Audience.Editor.Tests
         [Test]
         public void ApplyTrackingUsageDescription_WithEmptyCopy_FallsBackToDefault()
         {
-            // Whitespace falls through to the default — Apple rejects empty.
+            // Whitespace falls through to the default. Apple rejects empty.
             var settings = ScriptableObject.CreateInstance<AudienceMobileBuildSettings>();
             SetPrivate(settings, "trackingUsageDescription", "   ");
 
@@ -61,7 +61,7 @@ namespace Immutable.Audience.Editor.Tests
         [Test]
         public void ApplyTrackingUsageDescription_OverwritesExistingValue()
         {
-            // Settings asset is the source of truth — beat any placeholder
+            // Settings asset is the source of truth. Beat any placeholder
             // a lower-order post-processor wrote.
             var root = new PlistDocument().root;
             root.SetString("NSUserTrackingUsageDescription", "stale placeholder");

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -1524,7 +1524,7 @@ namespace Immutable.Audience.Tests
         //
         // Dedicated event (not a game_launch property): install attribution
         // is install-level state, decoupled from launch / session lifecycles.
-        // Fires once per install — cache landing late on first launch is
+        // Fires once per install. Cache landing late on first launch is
         // recovered by the next Init via the on-disk "sent" marker.
         // -----------------------------------------------------------------
 
@@ -1561,7 +1561,7 @@ namespace Immutable.Audience.Tests
                 .Select(File.ReadAllText)
                 .First(c => c.Contains("\"game_launch\""));
             Assert.IsFalse(launchFile.Contains("installReferrer"),
-                "game_launch must never carry installReferrer — it ships on its own event");
+                "game_launch must never carry installReferrer; it ships on its own event");
         }
 
         [Test]
@@ -1585,7 +1585,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Init_DoesNotFireInstallReferrerReceived_WhenProviderReturnsEmpty()
         {
-            // Empty cache file marks "fetched, no referrer" — bridge maps
+            // Empty cache file marks "fetched, no referrer". Bridge maps
             // that to null on read, but defend the contract here too.
             ImmutableAudience.MobileInstallReferrerProvider = () => string.Empty;
             var config = MakeConfig();
@@ -1766,7 +1766,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public async Task RequestTrackingAuthorization_NoProvider_ReturnsNotDetermined()
         {
-            // No provider set — non-iOS environment.
+            // No provider set (non-iOS environment).
             var status = await ImmutableAudience.RequestTrackingAuthorizationAsync();
             Assert.AreEqual(TrackingAuthorizationStatus.NotDetermined, status);
         }

--- a/src/Packages/Audience/Tests/Runtime/Unity/GAIDBridgeTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Unity/GAIDBridgeTests.cs
@@ -124,7 +124,7 @@ namespace Immutable.Audience.Tests
         public void EnsureFetchStarted_TerminalCacheExists_StillFetches()
         {
             // Unlike the install referrer (terminal once written), GAID can
-            // change (user reset) — we always refresh the cache for the next
+            // change (user reset), so we always refresh the cache for the next
             // launch even when a value already exists.
             GAIDBridge.WriteCacheEntry(_testDir, "stale-gaid", limitAdTracking: false);
 

--- a/src/Packages/Audience/Tests/Runtime/Unity/InstallReferrerBridgeTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Unity/InstallReferrerBridgeTests.cs
@@ -58,7 +58,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void GetCachedInstallReferrer_EmptyFile_ReturnsNull()
         {
-            // Empty file marks "fetched, no referrer" — caller treats it as
+            // Empty file marks "fetched, no referrer". Caller treats it as
             // "nothing to emit" but EnsureFetchStarted treats it as terminal.
             InstallReferrerBridge.WriteCacheEntry(_testDir, string.Empty);
 
@@ -104,7 +104,7 @@ namespace Immutable.Audience.Tests
         public void EnsureFetchStarted_TerminalCacheExists_SkipsFetch()
         {
             // Simulate a previous launch that wrote a cache entry. The fetch
-            // must NOT run again — Google's referrer is stable per install.
+            // must NOT run again. Google's referrer is stable per install.
             InstallReferrerBridge.WriteCacheEntry(_testDir, "utm_source=test");
 
             var fetchCalls = 0;
@@ -118,7 +118,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void EnsureFetchStarted_EmptyCacheExists_SkipsFetch()
         {
-            // Empty cache = "fetched, no referrer" — terminal state, no retry.
+            // Empty cache = "fetched, no referrer": terminal state, no retry.
             InstallReferrerBridge.WriteCacheEntry(_testDir, string.Empty);
 
             var fetchCalls = 0;

--- a/src/Packages/Audience/Tests/Runtime/Utility/TimerDisposalTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Utility/TimerDisposalTests.cs
@@ -39,7 +39,7 @@ namespace Immutable.Audience.Tests
             // Mono player builds (Unity Standalone Mono targets) signal
             // Timer.Dispose's wait handle ahead of in-flight callbacks
             // completing, which breaks this unit test's premise. Production
-            // code is unaffected — DrainHeartbeatTimer is exercised
+            // code is unaffected. DrainHeartbeatTimer is exercised
             // end-to-end by the SampleApp PlayMode tests on the same Mono
             // builds and works correctly. This unit test asserts a
             // lower-level WaitHandle invariant that doesn't hold under Mono.


### PR DESCRIPTION
Replaces em dashes across comments and XML docs in the Audience package with standard punctuation (periods, semicolons, colons). Trims a small number of wordy phrases while preserving all information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)