### PR TITLE
chore: add audience release workflow support, remove marketplace

### DIFF
--- a/.github/scripts/check_team_membership.sh
+++ b/.github/scripts/check_team_membership.sh
@@ -4,18 +4,27 @@ set -x
 
 USER=$1
 
-response=$(gh api \
-  -H "Accept: application/vnd.github+json" \
-  -H "X-GitHub-Api-Version: 2022-11-28" \
-  "/orgs/immutable/teams/passport/memberships/${USER}")
+TEAMS=(
+  "ped-stream-sdk-integrations-list"
+  "ped-stream-blockchain-services-list"
+)
 
-echo "$response"
+IS_MEMBER=false
 
-if echo "$response" | grep -q '"state":"active"'; then
-  IS_MEMBER=true
-else
-  IS_MEMBER=false
-fi
+for TEAM in "${TEAMS[@]}"; do
+  response=$(gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/orgs/immutable/teams/${TEAM}/memberships/${USER}")
+
+  echo "$response"
+
+  if echo "$response" | grep -q '"state":"active"'; then
+    IS_MEMBER=true
+    break
+  fi
+done
+
 echo "$IS_MEMBER"
 
 # Set the environment variable for the GitHub workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,18 @@ jobs:
       - name: Get the latest tag
         run: |
           git fetch --tags
-          LATEST_TAG="$(git describe --tags "$(git rev-list --tags --max-count=1)")"
+          LATEST_TAG="$(git tag --sort=-creatordate | head -n 1)"
           echo "LATEST_TAG=${LATEST_TAG}" >> "$GITHUB_ENV"
+          if [[ "$LATEST_TAG" == audience/* ]]; then
+            echo "IS_AUDIENCE=true" >> "$GITHUB_ENV"
+          else
+            echo "IS_AUDIENCE=false" >> "$GITHUB_ENV"
+          fi
+          if [[ "$LATEST_TAG" == *alpha* ]]; then
+            echo "IS_PRERELEASE=true" >> "$GITHUB_ENV"
+          else
+            echo "IS_PRERELEASE=false" >> "$GITHUB_ENV"
+          fi
 
       - name: Pull LFS
         run: git lfs pull
@@ -62,6 +72,7 @@ jobs:
             }
 
       - name: Extract TS SDK version from index.html
+        if: env.IS_AUDIENCE != 'true'
         id: extract_ts_sdk_version
         run: |
           version=$(grep -oP '"x-sdk-version":"ts-immutable-sdk-\K[0-9]+\.[0-9]+\.[0-9]+' ./src/Packages/Passport/Runtime/Resources/index.html | head -n 1)
@@ -73,7 +84,15 @@ jobs:
 
           version=$(echo "$version" | tr -d '\r\n')
 
-          echo "VERSION=${version}" >> "$GITHUB_ENV"
+          echo "TS_SDK_VERSION=${version}" >> "$GITHUB_ENV"
+
+      - name: Build release body suffix
+        run: |
+          if [[ "$IS_AUDIENCE" != "true" && -n "$TS_SDK_VERSION" ]]; then
+            echo "RELEASE_BODY_SUFFIX=Game bridge built from Immutable Typescript SDK version $TS_SDK_VERSION" >> "$GITHUB_ENV"
+          else
+            echo "RELEASE_BODY_SUFFIX=" >> "$GITHUB_ENV"
+          fi
 
       - name: Create Release
         id: create_release
@@ -86,6 +105,6 @@ jobs:
           body: |
             ${{steps.github_release.outputs.changelog}}
 
-            Game bridge built from Immutable Typescript SDK version ${{ env.VERSION }}
+            ${{ env.RELEASE_BODY_SUFFIX }}
           draft: false
-          prerelease: false
+          prerelease: ${{ env.IS_PRERELEASE }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   create-tag:
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'passport-release') || contains(github.event.pull_request.labels.*.name, 'audience-release'))
     runs-on: ubuntu-latest
 
     steps:
@@ -22,13 +22,20 @@ jobs:
       - name: Install jq
         run: sudo apt-get install -y jq
 
-      - name: Extract version from package.json
+      - name: Extract version and set tag
         id: extract_version
         run: |
-          VERSION=$(jq -r .version ./src/Packages/Passport/package.json)
-          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          IS_AUDIENCE="${{ contains(github.event.pull_request.labels.*.name, 'audience-release') }}"
+          if [[ "$IS_AUDIENCE" == "true" ]]; then
+            VERSION=$(jq -r .version ./src/Packages/Audience/package.json)
+            echo "TAG=audience/v$VERSION" >> "$GITHUB_ENV"
+          else
+            VERSION=$(jq -r .version ./src/Packages/Passport/package.json)
+            echo "TAG=v$VERSION" >> "$GITHUB_ENV"
+          fi
 
       - name: Check TS SDK version exists in index.html
+        if: contains(github.event.pull_request.labels.*.name, 'passport-release')
         id: check_ts_sdk_version
         run: |
           version=$(grep -oP '"x-sdk-version":"ts-immutable-sdk-\K[0-9]+\.[0-9]+\.[0-9]+' ./src/Packages/Passport/Runtime/Resources/index.html | head -n 1)
@@ -41,6 +48,6 @@ jobs:
       - name: Create Tag
         uses: negz/create-tag@v1
         with:
-          version: "v${{ env.VERSION }}"
-          message: "Version ${{ env.VERSION }}"
+          version: "${{ env.TAG }}"
+          message: "Version ${{ env.TAG }}"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -2,16 +2,6 @@ name: Audience SDK PlayMode (IL2CPP + Mono)
 
 on:
   pull_request:
-    paths:
-      - 'src/Packages/Audience/Runtime/**'
-      - 'src/Packages/Audience/Tests/**'
-      - 'src/Packages/Audience/package.json'
-      - 'src/Packages/Audience/Directory.Build.props'
-      - 'src/Packages/Audience/link.xml'
-      - 'examples/audience/Assets/**'
-      - 'examples/audience/Packages/**'
-      - 'examples/audience/ProjectSettings/**'
-      - '.github/workflows/test-audience-sample-app.yml'
   schedule:
     # Weekly full-matrix run on the default branch. Saturday 14:00 UTC.
     - cron: '0 14 * * 6'
@@ -26,6 +16,30 @@ env:
   AUDIENCE_TEST_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
+  # Detects whether any Audience-relevant paths changed in this PR.
+  # schedule/workflow_dispatch always returns true to run the full matrix.
+  paths-changed:
+    runs-on: ubuntu-latest
+    outputs:
+      audience: ${{ steps.check.outputs.audience }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: check
+        run: |
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "audience=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch origin ${{ github.base_ref }} --depth=1
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD \
+              | grep -qE '^(src/Packages/Audience/|examples/audience/|\.github/workflows/test-audience-sample-app\.yml)'; then
+            echo "audience=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "audience=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # SSOT for the unity matrix and PR-only excludes. Both playmode and
   # mobile-build consume these outputs via fromJSON. Source data lives
   # in .github/scripts/audience/matrix-shared.json.
@@ -36,8 +50,11 @@ jobs:
   # data into the literal exclude objects GitHub Actions matrix.exclude
   # expects, and asserts each rule matched exactly one cell descriptor.
   setup:
+    needs: paths-changed
     if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+      (github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.fork == false
+        && needs.paths-changed.outputs.audience == 'true')
       || github.event_name == 'schedule'
       || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -250,3 +267,22 @@ jobs:
           path: |
             examples/audience/Builds/Android/*.apk
             examples/audience/Logs/**
+
+  # Required check. Passes immediately when no Audience paths changed;
+  # fails if playmode or mobile-build tests failed or were cancelled.
+  ci-gate:
+    needs: [playmode, mobile-build]
+    if: always() && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          PLAYMODE="${{ needs.playmode.result }}"
+          MOBILE="${{ needs.mobile-build.result }}"
+          if [[ "$PLAYMODE" == "failure" || "$PLAYMODE" == "cancelled" ]]; then
+            echo "::error::playmode tests $PLAYMODE" && exit 1
+          fi
+          if [[ "$MOBILE" == "failure" || "$MOBILE" == "cancelled" ]]; then
+            echo "::error::mobile-build $MOBILE" && exit 1
+          fi
+          echo "Gate passed (playmode=$PLAYMODE, mobile-build=$MOBILE)"

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -3,22 +3,30 @@ name: "Update SDK version"
 on:
   workflow_dispatch:
     inputs:
+      package:
+        type: choice
+        description: Package to release
+        options:
+          - passport
+          - audience
+        required: true
+        default: passport
       upgrade_type:
         type: choice
         description: Upgrade Type
         options:
           - patch
           - minor
-          # - major
         required: true
         default: patch
       mark_as_alpha:
         type: boolean
-        description: Mark as alpha release
+        description: Mark as alpha release (Passport only)
         required: false
         default: false
 
 env:
+  PACKAGE: ${{ github.event.inputs.package || 'passport' }}
   UPGRADE_TYPE: ${{ github.event.inputs.upgrade_type || 'patch' }}
   MARK_AS_ALPHA: ${{ github.event.inputs.mark_as_alpha || false }}
 
@@ -53,25 +61,42 @@ jobs:
     - name: Update Version in package.json
       id: replace_version
       run: |
-        PASSPORT_FILE=./src/Packages/Passport/package.json
-        MARKETPLACE_FILE=./src/Packages/Marketplace/package.json
-        
-        CURRENT_VERSION=$(jq -r '.version' $PASSPORT_FILE)
+        if [[ "$PACKAGE" == "audience" ]]; then
+          FILE=./src/Packages/Audience/package.json
+        else
+          FILE=./src/Packages/Passport/package.json
+        fi
+
+        CURRENT_VERSION=$(jq -r '.version' $FILE)
         echo "CURRENT_VERSION: $CURRENT_VERSION"
         IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
 
-        HAS_ALPHA=$(echo "$CURRENT_VERSION" | grep -q "\.alpha" && echo "true" || echo "false")
-        echo "HAS_ALPHA: $HAS_ALPHA"
         NEW_VERSION=""
 
-        if [[ "$HAS_ALPHA" == "true" ]]; then
-          # If version is alpha and upgrade type is patch, don't increment patch
-          if [ "$UPGRADE_TYPE" == "patch" ]; then
+        if [[ "$PACKAGE" == "passport" ]]; then
+          HAS_ALPHA=$(echo "$CURRENT_VERSION" | grep -q "\.alpha" && echo "true" || echo "false")
+          echo "HAS_ALPHA: $HAS_ALPHA"
+
+          if [[ "$HAS_ALPHA" == "true" ]]; then
+            if [ "$UPGRADE_TYPE" == "patch" ]; then
+              NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+            elif [ "$UPGRADE_TYPE" == "minor" ]; then
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+            fi
+          else
+            if [ "$UPGRADE_TYPE" == "patch" ]; then
+              PATCH=$((PATCH + 1))
+            elif [ "$UPGRADE_TYPE" == "minor" ]; then
+              MINOR=$((MINOR + 1))
+              PATCH=0
+            fi
             NEW_VERSION="$MAJOR.$MINOR.$PATCH"
-          elif [ "$UPGRADE_TYPE" == "minor" ]; then
-            MINOR=$((MINOR + 1))
-            PATCH=0
-            NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+          fi
+
+          if [[ "$MARK_AS_ALPHA" == "true" && "$HAS_ALPHA" == "false" ]]; then
+            NEW_VERSION="$NEW_VERSION.alpha"
           fi
         else
           if [ "$UPGRADE_TYPE" == "patch" ]; then
@@ -83,20 +108,12 @@ jobs:
           NEW_VERSION="$MAJOR.$MINOR.$PATCH"
         fi
 
-        if [[ "$MARK_AS_ALPHA" == "true" && "$HAS_ALPHA" == "false" ]]; then
-          NEW_VERSION="$NEW_VERSION.alpha"
-        fi
-
-        # Update Passport package.json
-        jq --arg version "$NEW_VERSION" '.version = $version' $PASSPORT_FILE > tmp.$$.json && mv tmp.$$.json $PASSPORT_FILE
-        echo "Updated version in Passport package.json from $CURRENT_VERSION to $NEW_VERSION"
-
-        # Update Marketplace package.json
-        jq --arg version "$NEW_VERSION" '.version = $version' $MARKETPLACE_FILE > tmp.$$.json && mv tmp.$$.json $MARKETPLACE_FILE
-        echo "Updated version in Marketplace package.json from $CURRENT_VERSION to $NEW_VERSION"
+        jq --arg version "$NEW_VERSION" '.version = $version' $FILE > tmp.$$.json && mv tmp.$$.json $FILE
+        echo "Updated version in $FILE from $CURRENT_VERSION to $NEW_VERSION"
         echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Update SDK Version in SdkVersionInfoHelpers.cs
+      if: env.PACKAGE == 'passport'
       id: replace_engine_sdk_version
       run: |
         FILE=./src/Packages/Passport/Runtime/Scripts/Private/Helpers/SdkVersionInfoHelpers.cs
@@ -105,31 +122,37 @@ jobs:
         echo "Updated SDK version in SdkVersionInfoHelpers.cs to $NEW_VERSION"
 
     - name: Ensure Samples~/SamplesScenesScripts directory exists and clear contents
+      if: env.PACKAGE == 'passport'
       run: |
         mkdir -p ./src/Packages/Passport/Samples~/SamplesScenesScripts
         rm -rf ./src/Packages/Passport/Samples~/SamplesScenesScripts/*
 
-        mkdir -p ./src/Packages/Marketplace/Samples~/SamplesScenesScripts
-        rm -rf ./src/Packages/Marketplace/Samples~/SamplesScenesScripts/*
-
     - name: Install rsync
+      if: env.PACKAGE == 'passport'
       run: sudo apt-get install -y rsync
 
     - name: Copy sample scenes and scripts to Passport package Samples~
+      if: env.PACKAGE == 'passport'
       id: copy_sample_scenes_and_scripts
       run: |
         rsync -av --exclude='*.meta' ./examples/passport/Assets/Scenes/Passport ./src/Packages/Passport/Samples~/SamplesScenesScripts/Scenes/
         rsync -av --exclude='*.meta' --exclude='features.json' --exclude='_prompts~/' --exclude='_tutorials~/' ./examples/passport/Assets/Scripts/Passport ./src/Packages/Passport/Samples~/SamplesScenesScripts/Scripts/
 
-        rsync -av --exclude='*.meta' ./examples/passport/Assets/Scenes/Marketplace ./src/Packages/Marketplace/Samples~/SamplesScenesScripts/Scenes/
-        rsync -av --exclude='*.meta' ./examples/passport/Assets/Scripts/Marketplace ./src/Packages/Marketplace/Samples~/SamplesScenesScripts/Scripts/
+    - name: Set release label
+      id: set_label
+      run: |
+        if [[ "$PACKAGE" == "audience" ]]; then
+          echo "label=audience-release" >> "$GITHUB_OUTPUT"
+        else
+          echo "label=passport-release" >> "$GITHUB_OUTPUT"
+        fi
 
     - uses: gr2m/create-or-update-pull-request-action@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        title: "chore: update version"
-        body: "Update version in package.json"
-        branch: "chore/update-version-${{ steps.replace_version.outputs.version }}"
-        commit-message: "chore: update version"
-        labels: release
+        title: "chore: bump ${{ github.event.inputs.package }} to ${{ steps.replace_version.outputs.version }}"
+        body: "Bump ${{ github.event.inputs.package }} package version to ${{ steps.replace_version.outputs.version }}."
+        branch: "chore/bump-${{ github.event.inputs.package }}-${{ steps.replace_version.outputs.version }}"
+        commit-message: "chore: bump ${{ github.event.inputs.package }} to ${{ steps.replace_version.outputs.version }}"
+        labels: ${{ steps.set_label.outputs.label }}


### PR DESCRIPTION
Extends the release workflow to support independent Passport and Audience releases, removes dead Marketplace references, and adds a smart CI gate to unblock workflow-only PRs.

- `update-version.yml`: adds a `package` dropdown (passport/audience), removes Marketplace, gates Passport-only steps (samples copy, SdkVersionInfoHelpers) behind the selection, sets `passport-release` or `audience-release` label accordingly
- `tag.yml`: handles both labels — creates `v{VERSION}` for Passport, `audience/v{VERSION}` for Audience; TS SDK index.html check only runs for Passport
- `release.yml`: detects Audience tags (`audience/` prefix) and skips the Passport-specific TS SDK version line; marks releases with `alpha` in the tag name as prereleases
- `check_team_membership.sh`: checks membership across both `ped-stream-sdk-integrations-list` and `ped-stream-blockchain-services-list`
- `test-audience-sample-app.yml`: replaces the top-level path filter with a `paths-changed` detection job; `ci-gate` (the required check) passes immediately when no Audience paths changed, and fails only if tests actually fail or are cancelled
- Audience `package.json` left at `0.1.0` so the workflow can be tested end-to-end

Closes SDK-304.