### PR TITLE
fix(audience): sync Constants.cs LibraryVersion in update-version workflow

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -121,6 +121,14 @@ jobs:
         sed -i -E "s/[0-9]+\.[0-9]+\.[0-9]+/$NEW_VERSION/g" $FILE
         echo "Updated SDK version in SdkVersionInfoHelpers.cs to $NEW_VERSION"
 
+    - name: Update LibraryVersion in Constants.cs
+      if: env.PACKAGE == 'audience'
+      run: |
+        FILE=./src/Packages/Audience/Runtime/Core/Constants.cs
+        NEW_VERSION="${{ steps.replace_version.outputs.version }}"
+        sed -i -E "s/LibraryVersion = \"[0-9]+\.[0-9]+\.[0-9]+\"/LibraryVersion = \"$NEW_VERSION\"/" $FILE
+        echo "Updated LibraryVersion in Constants.cs to $NEW_VERSION"
+
     - name: Ensure Samples~/SamplesScenesScripts directory exists and clear contents
       if: env.PACKAGE == 'passport'
       run: |


### PR DESCRIPTION
## Summary

- Adds a workflow step to update `Constants.LibraryVersion` in `Constants.cs` when bumping the audience package version
- Mirrors the existing passport step that updates `SdkVersionInfoHelpers.cs`
- Fixes the root cause of the `LibraryVersion_MatchesPackageJson` test failure (currently failing because `0.2.0` bump didn't update `Constants.cs`)

## Test plan

- [ ] After merging, run the **Update SDK version** workflow with `package=audience` to bump to `0.2.1` — verify the resulting PR updates both `package.json` and `Constants.cs`
- [ ] Confirm `LibraryVersion_MatchesPackageJson` passes in CI on the `0.2.1` bump PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)