### PR TITLE
fix: use GitHub API to create tags, supporting audience/vX.Y.Z format

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -50,7 +50,8 @@ jobs:
           SHA=$(git rev-parse HEAD)
           gh api /repos/${{ github.repository }}/git/refs \
             --method POST \
-            -f ref="refs/tags/${{ env.TAG }}" \
+            -f ref="refs/tags/${TAG}" \
             -f sha="$SHA"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ env.TAG }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -46,8 +46,11 @@ jobs:
           fi
 
       - name: Create Tag
-        uses: negz/create-tag@v1
-        with:
-          version: "${{ env.TAG }}"
-          message: "Version ${{ env.TAG }}"
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHA=$(git rev-parse HEAD)
+          gh api /repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/tags/${{ env.TAG }}" \
+            -f sha="$SHA"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Replaces `negz/create-tag@v1` with a direct GitHub API call to create release tags
- `negz/create-tag@v1` validates the version as strict semver and rejects `audience/v0.2.1` due to the slash — causing all audience release tags to fail silently
- Using `gh api` to POST to `/git/refs` works with any tag name format

## After merging

The missing `audience/v0.2.1` tag will need to be created manually (the `tag.yml` run for that PR already failed). Once created, the UPM git URL will be:

```
https://github.com/immutable/unity-immutable-sdk.git?path=src/Packages/Audience#audience/v0.2.1
```

Future audience release PRs will auto-tag correctly.

## Test plan

- [ ] Merge and trigger a new audience release bump — confirm `audience/vX.Y.Z` tag is created
- [ ] Confirm passport releases still tag correctly (`vX.Y.Z` format unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)