### PR TITLE
feat(audience): rename event property keys to snake_case [SDK-413]

### DIFF
--- a/src/Packages/Audience/Runtime/Core/Session.cs
+++ b/src/Packages/Audience/Runtime/Core/Session.cs
@@ -97,7 +97,7 @@ namespace Immutable.Audience
 
             SafeTrack("session_start", new Dictionary<string, object>
             {
-                ["sessionId"] = sessionId
+                ["session_id"] = sessionId
             });
         }
 
@@ -173,8 +173,8 @@ namespace Immutable.Audience
             // wall-clock; dashboards should not assume parity.
             SafeTrack("session_end", new Dictionary<string, object>
             {
-                ["sessionId"] = sessionId,
-                ["durationSec"] = duration
+                ["session_id"] = sessionId,
+                ["duration_sec"] = duration
             });
         }
 
@@ -198,8 +198,8 @@ namespace Immutable.Audience
 
             SafeTrack("session_end", new Dictionary<string, object>
             {
-                ["sessionId"] = sessionId,
-                ["durationSec"] = duration
+                ["session_id"] = sessionId,
+                ["duration_sec"] = duration
             });
         }
 
@@ -240,8 +240,8 @@ namespace Immutable.Audience
             // Build outside _lock so track doesn't re-enter.
             var properties = new Dictionary<string, object>
             {
-                ["sessionId"] = sessionId,
-                ["durationSec"] = duration
+                ["session_id"] = sessionId,
+                ["duration_sec"] = duration
             };
 
             SafeTrack("session_heartbeat", properties);

--- a/src/Packages/Audience/Runtime/Events/TypedEvents.cs
+++ b/src/Packages/Audience/Runtime/Events/TypedEvents.cs
@@ -95,7 +95,7 @@ namespace Immutable.Audience
             if (Level != null) props["level"] = Level;
             if (Stage != null) props["stage"] = Stage;
             if (Score.HasValue) props["score"] = Score.Value;
-            if (DurationSec.HasValue) props["durationSec"] = DurationSec.Value;
+            if (DurationSec.HasValue) props["duration_sec"] = DurationSec.Value;
 
             return props;
         }
@@ -182,8 +182,8 @@ namespace Immutable.Audience
                 ["amount"] = Amount.Value
             };
 
-            if (ItemType != null) props["itemType"] = ItemType;
-            if (ItemId != null) props["itemId"] = ItemId;
+            if (ItemType != null) props["item_type"] = ItemType;
+            if (ItemId != null) props["item_id"] = ItemId;
 
             return props;
         }
@@ -256,10 +256,10 @@ namespace Immutable.Audience
                 ["value"] = Value.Value
             };
 
-            if (ItemId != null) props["itemId"] = ItemId;
-            if (ItemName != null) props["itemName"] = ItemName;
+            if (ItemId != null) props["item_id"] = ItemId;
+            if (ItemName != null) props["item_name"] = ItemName;
             if (Quantity.HasValue) props["quantity"] = Quantity.Value;
-            if (TransactionId != null) props["transactionId"] = TransactionId;
+            if (TransactionId != null) props["transaction_id"] = TransactionId;
 
             return props;
         }

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -1121,17 +1121,17 @@ namespace Immutable.Audience
 
             // Config-supplied distributionPlatform overrides the provider value.
             if (config.DistributionPlatform != null)
-                properties["distributionPlatform"] = config.DistributionPlatform;
+                properties["distribution_platform"] = config.DistributionPlatform;
 
             // Emitted only on the first launch where SKAN registration fires.
             if (skanRegistered == true)
-                properties["skanRegistered"] = true;
+                properties["skan_registered"] = true;
 
             // iOS ATT/IDFA snapshot, merged after Unity context so attribution
             // keys are authoritative if both sources happen to set the same key.
             // idfa and gaid are cross-app device identifiers, same privacy class
-            // as userId; gate them at Full-only. State-class keys (attStatus,
-            // gaidLimitAdTracking) are non-identifying and ship at Anon+Full.
+            // as userId; gate them at Full-only. State-class keys (att_status,
+            // gaid_limit_ad_tracking) are non-identifying and ship at Anon+Full.
             if (attributionContext != null)
             {
                 var canIdentify = consentAtInit.CanIdentify();
@@ -1160,7 +1160,7 @@ namespace Immutable.Audience
 
             Track("install_referrer_received", new Dictionary<string, object>
             {
-                ["installReferrer"] = installReferrer,
+                ["install_referrer"] = installReferrer,
             });
 
             try
@@ -1235,8 +1235,8 @@ namespace Immutable.Audience
 
             var props = new Dictionary<string, object>
             {
-                ["previousStatus"] = AttStatusToString(previous.Value),
-                ["newStatus"] = AttStatusToString(currentStatus),
+                ["previous_status"] = AttStatusToString(previous.Value),
+                ["new_status"] = AttStatusToString(currentStatus),
             };
 
             if (currentStatus == 3 && consent.CanIdentify())

--- a/src/Packages/Audience/Runtime/Unity/DeviceCollector.cs
+++ b/src/Packages/Audience/Runtime/Unity/DeviceCollector.cs
@@ -55,25 +55,25 @@ namespace Immutable.Audience.Unity
             var props = new Dictionary<string, object>
             {
                 ["platform"] = PlatformName(platform),
-                ["isEditor"] = isEditor,
+                ["is_editor"] = isEditor,
                 ["version"] = Truncate(Application.version, 256),
-                ["buildGuid"] = Truncate(Application.buildGUID, 256),
-                ["unityVersion"] = Truncate(Application.unityVersion, 256),
-                ["osFamily"] = SystemInfo.operatingSystemFamily.ToString(),
-                ["deviceModel"] = Truncate(SystemInfo.deviceModel, 256),
+                ["build_guid"] = Truncate(Application.buildGUID, 256),
+                ["unity_version"] = Truncate(Application.unityVersion, 256),
+                ["os_family"] = SystemInfo.operatingSystemFamily.ToString(),
+                ["device_model"] = Truncate(SystemInfo.deviceModel, 256),
                 ["gpu"] = Truncate(SystemInfo.graphicsDeviceName, 256),
-                ["gpuVendor"] = Truncate(SystemInfo.graphicsDeviceVendor, 256),
+                ["gpu_vendor"] = Truncate(SystemInfo.graphicsDeviceVendor, 256),
                 ["cpu"] = Truncate(SystemInfo.processorType, 256),
-                ["cpuCores"] = SystemInfo.processorCount,
-                ["ramMb"] = SystemInfo.systemMemorySize,
+                ["cpu_cores"] = SystemInfo.processorCount,
+                ["ram_mb"] = SystemInfo.systemMemorySize,
             };
 
             // Screen.dpi can be 0 on some Linux WMs.
             var dpi = (int)Screen.dpi;
-            if (dpi > 0) props["screenDpi"] = dpi;
+            if (dpi > 0) props["screen_dpi"] = dpi;
 
             if (platform == RuntimePlatform.Android)
-                props["androidId"] = Truncate(SystemInfo.deviceUniqueIdentifier, 256);
+                props["android_id"] = Truncate(SystemInfo.deviceUniqueIdentifier, 256);
 
             if (platform == RuntimePlatform.IPhonePlayer)
             {
@@ -81,7 +81,7 @@ namespace Immutable.Audience.Unity
                 if (idfv != null) props["idfv"] = Truncate(idfv, 256);
 
                 // iOS baseline is 163 DPI (1×); 326 → 2×, 401-460 → 3×.
-                if (dpi > 0) props["screenScale"] = (int)Math.Round(dpi / 163.0);
+                if (dpi > 0) props["screen_scale"] = (int)Math.Round(dpi / 163.0);
             }
 
             return props;

--- a/src/Packages/Audience/Runtime/Unity/Mobile/AttributionContext.cs
+++ b/src/Packages/Audience/Runtime/Unity/Mobile/AttributionContext.cs
@@ -46,7 +46,7 @@ namespace Immutable.Audience.Unity.Mobile
             // never ships there. Native ATTBridge calls are themselves gated
             // by #if UNITY_IOS, so non-iOS editor targets get the safe stubs.
             var status = ATTBridge.GetStatus();
-            props["attStatus"] = AttStatusToString(status);
+            props["att_status"] = AttStatusToString(status);
 
             // Only ship IDFA when the user has authorized tracking. The native
             // bridge already returns null for the zero-UUID case, but gating
@@ -84,7 +84,7 @@ namespace Immutable.Audience.Unity.Mobile
         {
             if (!info.LimitAdTracking && !string.IsNullOrEmpty(info.Gaid))
                 props["gaid"] = info.Gaid;
-            props["gaidLimitAdTracking"] = info.LimitAdTracking;
+            props["gaid_limit_ad_tracking"] = info.LimitAdTracking;
         }
     }
 }

--- a/src/Packages/Audience/Tests/Runtime/Core/SessionTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Core/SessionTests.cs
@@ -35,8 +35,8 @@ namespace Immutable.Audience.Tests
 
             Assert.AreEqual(1, _events.Count);
             Assert.AreEqual("session_start", _events[0].name);
-            Assert.IsTrue(_events[0].props.ContainsKey("sessionId"));
-            Assert.IsNotEmpty((string)_events[0].props["sessionId"]);
+            Assert.IsTrue(_events[0].props.ContainsKey("session_id"));
+            Assert.IsNotEmpty((string)_events[0].props["session_id"]);
         }
 
         [Test]
@@ -64,9 +64,9 @@ namespace Immutable.Audience.Tests
 
             var endEvent = _events.FirstOrDefault(e => e.name == "session_end");
             Assert.IsNotNull(endEvent.props);
-            Assert.IsTrue(endEvent.props.ContainsKey("sessionId"));
-            Assert.IsTrue(endEvent.props.ContainsKey("durationSec"));
-            Assert.AreEqual(2L, (long)endEvent.props["durationSec"]);
+            Assert.IsTrue(endEvent.props.ContainsKey("session_id"));
+            Assert.IsTrue(endEvent.props.ContainsKey("duration_sec"));
+            Assert.AreEqual(2L, (long)endEvent.props["duration_sec"]);
         }
 
         [Test]
@@ -121,8 +121,8 @@ namespace Immutable.Audience.Tests
             {
                 var beat = events.FirstOrDefault(e => e.name == "session_heartbeat");
                 Assert.IsNotNull(beat.props, "heartbeat event should carry a properties dictionary");
-                Assert.IsTrue(beat.props.ContainsKey("sessionId"));
-                Assert.IsTrue(beat.props.ContainsKey("durationSec"));
+                Assert.IsTrue(beat.props.ContainsKey("session_id"));
+                Assert.IsTrue(beat.props.ContainsKey("duration_sec"));
             }
         }
 
@@ -198,7 +198,7 @@ namespace Immutable.Audience.Tests
             session.End();
 
             var sessionEnd = _events.Last(e => e.name == "session_end");
-            var duration = (long)sessionEnd.props["durationSec"];
+            var duration = (long)sessionEnd.props["duration_sec"];
             // Wall-clock Start→End = 13s, paused from T=5 to T=10 = 5s, engaged = 8s.
             Assert.AreEqual(8L, duration,
                 "double Pause must preserve the first Pause timestamp so engagement arithmetic covers the full pause window");
@@ -246,7 +246,7 @@ namespace Immutable.Audience.Tests
             session.End();
 
             var sessionEnd = _events.Last(e => e.name == "session_end");
-            var duration = (long)sessionEnd.props["durationSec"];
+            var duration = (long)sessionEnd.props["duration_sec"];
             // Wall-clock from Start to End is 10 + (-5) + 2 = 7 s. The
             // pause duration was clamped to 0, so engaged seconds = 7 - 0 = 7.
             // Without the clamp, _accumulatedPause would be -5, the
@@ -277,7 +277,7 @@ namespace Immutable.Audience.Tests
             session.End();
 
             var sessionEnd = _events.Last(e => e.name == "session_end");
-            var duration = (long)sessionEnd.props["durationSec"];
+            var duration = (long)sessionEnd.props["duration_sec"];
             Assert.AreEqual(0L, duration,
                 "negative engaged time from a wall-clock rewind must clamp to zero");
         }
@@ -306,7 +306,7 @@ namespace Immutable.Audience.Tests
             session.End();
 
             var sessionEnd = _events.Last(e => e.name == "session_end");
-            var duration = (long)sessionEnd.props["durationSec"];
+            var duration = (long)sessionEnd.props["duration_sec"];
             Assert.LessOrEqual(duration, 5L,
                 "clock rewind while paused must not over-credit engagement past the wall-clock window");
         }
@@ -331,7 +331,7 @@ namespace Immutable.Audience.Tests
             session.End();
 
             var sessionEnd = _events.Last(e => e.name == "session_end");
-            var duration = (long)sessionEnd.props["durationSec"];
+            var duration = (long)sessionEnd.props["duration_sec"];
             Assert.AreEqual(7L, duration,
                 "session_end duration should exclude the 3s paused interval");
         }
@@ -353,7 +353,7 @@ namespace Immutable.Audience.Tests
             session.End(); // ends while paused
 
             var sessionEnd = _events.Last(e => e.name == "session_end");
-            var duration = (long)sessionEnd.props["durationSec"];
+            var duration = (long)sessionEnd.props["duration_sec"];
             Assert.AreEqual(5L, duration,
                 "session_end fired while paused should count only pre-pause engaged time");
         }
@@ -381,7 +381,7 @@ namespace Immutable.Audience.Tests
             session.Resume();
 
             var sessionEnd = _events.First(e => e.name == "session_end");
-            var duration = (long)sessionEnd.props["durationSec"];
+            var duration = (long)sessionEnd.props["duration_sec"];
             Assert.AreEqual(10L, duration,
                 "session_end on extended-pause rollover should report pre-pause engaged time, not wall-clock");
         }
@@ -406,7 +406,7 @@ namespace Immutable.Audience.Tests
             session.OnHeartbeat();
 
             var heartbeat = _events.Last(e => e.name == "session_heartbeat");
-            var duration = (long)heartbeat.props["durationSec"];
+            var duration = (long)heartbeat.props["duration_sec"];
             Assert.AreEqual(6L, duration,
                 "heartbeat duration should exclude the 2s paused interval");
         }

--- a/src/Packages/Audience/Tests/Runtime/Events/TypedEventTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Events/TypedEventTests.cs
@@ -39,7 +39,7 @@ namespace Immutable.Audience.Tests
             Assert.AreEqual("tutorial", props["world"]);
             Assert.AreEqual("1", props["level"]);
             Assert.AreEqual(1500, props["score"]);
-            Assert.AreEqual(120.5f, props["durationSec"]);
+            Assert.AreEqual(120.5f, props["duration_sec"]);
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace Immutable.Audience.Tests
             Assert.IsFalse(props.ContainsKey("level"));
             Assert.IsFalse(props.ContainsKey("stage"));
             Assert.IsFalse(props.ContainsKey("score"));
-            Assert.IsFalse(props.ContainsKey("durationSec"));
+            Assert.IsFalse(props.ContainsKey("duration_sec"));
         }
 
         [Test]
@@ -72,8 +72,8 @@ namespace Immutable.Audience.Tests
             Assert.AreEqual("source", props["flow"]);
             Assert.AreEqual("gold", props["currency"]);
             Assert.AreEqual(100m, props["amount"]);
-            Assert.AreEqual("quest_reward", props["itemType"]);
-            Assert.AreEqual("main_quest_01", props["itemId"]);
+            Assert.AreEqual("quest_reward", props["item_type"]);
+            Assert.AreEqual("main_quest_01", props["item_id"]);
         }
 
         [Test]
@@ -126,10 +126,10 @@ namespace Immutable.Audience.Tests
 
             Assert.AreEqual("USD", props["currency"]);
             Assert.AreEqual(9.99m, props["value"]);
-            Assert.AreEqual("gem_pack_01", props["itemId"]);
-            Assert.AreEqual("Starter Gem Pack", props["itemName"]);
+            Assert.AreEqual("gem_pack_01", props["item_id"]);
+            Assert.AreEqual("Starter Gem Pack", props["item_name"]);
             Assert.AreEqual(1, props["quantity"]);
-            Assert.AreEqual("txn_abc123", props["transactionId"]);
+            Assert.AreEqual("txn_abc123", props["transaction_id"]);
         }
 
         [Test]
@@ -139,10 +139,10 @@ namespace Immutable.Audience.Tests
 
             Assert.IsTrue(props.ContainsKey("currency"));
             Assert.IsTrue(props.ContainsKey("value"));
-            Assert.IsFalse(props.ContainsKey("itemId"));
-            Assert.IsFalse(props.ContainsKey("itemName"));
+            Assert.IsFalse(props.ContainsKey("item_id"));
+            Assert.IsFalse(props.ContainsKey("item_name"));
             Assert.IsFalse(props.ContainsKey("quantity"));
-            Assert.IsFalse(props.ContainsKey("transactionId"));
+            Assert.IsFalse(props.ContainsKey("transaction_id"));
         }
 
         [Test]

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -1191,8 +1191,8 @@ namespace Immutable.Audience.Tests
             {
                 ["platform"] = "Windows",
                 ["version"] = "1.2.3",
-                ["buildGuid"] = "a1b2c3d4e5f6",
-                ["unityVersion"] = "2022.3.20f1",
+                ["build_guid"] = "a1b2c3d4e5f6",
+                ["unity_version"] = "2022.3.20f1",
             };
 
             ImmutableAudience.Init(MakeConfig());
@@ -1205,8 +1205,8 @@ namespace Immutable.Audience.Tests
             Assert.IsNotNull(launchFile, "game_launch should have been enqueued");
             StringAssert.Contains("\"platform\":\"Windows\"", launchFile);
             StringAssert.Contains("\"version\":\"1.2.3\"", launchFile);
-            StringAssert.Contains("\"buildGuid\":\"a1b2c3d4e5f6\"", launchFile);
-            StringAssert.Contains("\"unityVersion\":\"2022.3.20f1\"", launchFile);
+            StringAssert.Contains("\"build_guid\":\"a1b2c3d4e5f6\"", launchFile);
+            StringAssert.Contains("\"unity_version\":\"2022.3.20f1\"", launchFile);
         }
 
         [Test]
@@ -1214,7 +1214,7 @@ namespace Immutable.Audience.Tests
         {
             ImmutableAudience.LaunchContextProvider = () => new Dictionary<string, object>
             {
-                ["distributionPlatform"] = "provider_value",
+                ["distribution_platform"] = "provider_value",
             };
 
             var config = MakeConfig();
@@ -1226,7 +1226,7 @@ namespace Immutable.Audience.Tests
             var launchFile = Directory.GetFiles(queueDir, "*.json")
                 .Select(File.ReadAllText)
                 .First(c => c.Contains("\"game_launch\""));
-            StringAssert.Contains("\"distributionPlatform\":\"steam\"", launchFile);
+            StringAssert.Contains("\"distribution_platform\":\"steam\"", launchFile);
             Assert.IsFalse(launchFile.Contains("provider_value"),
                 "config.DistributionPlatform should win over the provider's value");
         }
@@ -1259,7 +1259,7 @@ namespace Immutable.Audience.Tests
             var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
                 .Select(File.ReadAllText)
                 .First(c => c.Contains("\"game_launch\""));
-            StringAssert.Contains("\"skanRegistered\":true", launchFile);
+            StringAssert.Contains("\"skan_registered\":true", launchFile);
         }
 
         [Test]
@@ -1274,7 +1274,7 @@ namespace Immutable.Audience.Tests
             var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
                 .Select(File.ReadAllText)
                 .First(c => c.Contains("\"game_launch\""));
-            Assert.IsFalse(launchFile.Contains("skanRegistered"));
+            Assert.IsFalse(launchFile.Contains("skan_registered"));
         }
 
         [Test]
@@ -1292,7 +1292,7 @@ namespace Immutable.Audience.Tests
             var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
                 .Select(File.ReadAllText)
                 .First(c => c.Contains("\"game_launch\""));
-            Assert.IsFalse(launchFile.Contains("skanRegistered"));
+            Assert.IsFalse(launchFile.Contains("skan_registered"));
         }
 
         [Test]
@@ -1301,7 +1301,7 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.MobileAttributionContextProvider = () =>
                 new Dictionary<string, object>
                 {
-                    ["attStatus"] = "authorized",
+                    ["att_status"] = "authorized",
                     ["idfa"] = "11111111-2222-3333-4444-555555555555",
                 };
             var config = MakeConfig(ConsentLevel.Full);
@@ -1312,7 +1312,7 @@ namespace Immutable.Audience.Tests
             var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
                 .Select(File.ReadAllText)
                 .First(c => c.Contains("\"game_launch\""));
-            StringAssert.Contains("\"attStatus\":\"authorized\"", launchFile);
+            StringAssert.Contains("\"att_status\":\"authorized\"", launchFile);
             StringAssert.Contains("\"idfa\":\"11111111-2222-3333-4444-555555555555\"", launchFile);
         }
 
@@ -1322,7 +1322,7 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.MobileAttributionContextProvider = () =>
                 new Dictionary<string, object>
                 {
-                    ["attStatus"] = "denied",
+                    ["att_status"] = "denied",
                 };
             var config = MakeConfig();
             config.EnableMobileAttribution = true;
@@ -1332,7 +1332,7 @@ namespace Immutable.Audience.Tests
             var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
                 .Select(File.ReadAllText)
                 .First(c => c.Contains("\"game_launch\""));
-            StringAssert.Contains("\"attStatus\":\"denied\"", launchFile);
+            StringAssert.Contains("\"att_status\":\"denied\"", launchFile);
             Assert.IsFalse(launchFile.Contains("\"idfa\""),
                 "idfa must not appear when ATT status is denied");
         }
@@ -1344,7 +1344,7 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.MobileAttributionContextProvider = () =>
             {
                 callCount++;
-                return new Dictionary<string, object> { ["attStatus"] = "authorized" };
+                return new Dictionary<string, object> { ["att_status"] = "authorized" };
             };
             var config = MakeConfig();
             config.EnableMobileAttribution = false;
@@ -1356,7 +1356,7 @@ namespace Immutable.Audience.Tests
             var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
                 .Select(File.ReadAllText)
                 .First(c => c.Contains("\"game_launch\""));
-            Assert.IsFalse(launchFile.Contains("attStatus"));
+            Assert.IsFalse(launchFile.Contains("att_status"));
             Assert.IsFalse(launchFile.Contains("idfa"));
         }
 
@@ -1374,7 +1374,7 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.MobileAttributionContextProvider = () =>
             {
                 contextCallCount++;
-                return new Dictionary<string, object> { ["attStatus"] = "authorized" };
+                return new Dictionary<string, object> { ["att_status"] = "authorized" };
             };
             ImmutableAudience.MobileInstallReferrerProvider = () =>
             {
@@ -1409,7 +1409,7 @@ namespace Immutable.Audience.Tests
             var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
                 .Select(File.ReadAllText)
                 .First(c => c.Contains("\"game_launch\""));
-            Assert.IsFalse(launchFile.Contains("attStatus"));
+            Assert.IsFalse(launchFile.Contains("att_status"));
         }
 
         [Test]
@@ -1423,7 +1423,7 @@ namespace Immutable.Audience.Tests
                 new Dictionary<string, object>
                 {
                     ["gaid"] = "abcdef01-2345-6789-abcd-ef0123456789",
-                    ["gaidLimitAdTracking"] = false,
+                    ["gaid_limit_ad_tracking"] = false,
                 };
             var config = MakeConfig(ConsentLevel.Full);
             config.EnableMobileAttribution = true;
@@ -1434,7 +1434,7 @@ namespace Immutable.Audience.Tests
                 .Select(File.ReadAllText)
                 .First(c => c.Contains("\"game_launch\""));
             StringAssert.Contains("\"gaid\":\"abcdef01-2345-6789-abcd-ef0123456789\"", launchFile);
-            StringAssert.Contains("\"gaidLimitAdTracking\":false", launchFile);
+            StringAssert.Contains("\"gaid_limit_ad_tracking\":false", launchFile);
         }
 
         [Test]
@@ -1446,7 +1446,7 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.MobileAttributionContextProvider = () =>
                 new Dictionary<string, object>
                 {
-                    ["gaidLimitAdTracking"] = true,
+                    ["gaid_limit_ad_tracking"] = true,
                 };
             var config = MakeConfig();
             config.EnableMobileAttribution = true;
@@ -1456,7 +1456,7 @@ namespace Immutable.Audience.Tests
             var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
                 .Select(File.ReadAllText)
                 .First(c => c.Contains("\"game_launch\""));
-            StringAssert.Contains("\"gaidLimitAdTracking\":true", launchFile);
+            StringAssert.Contains("\"gaid_limit_ad_tracking\":true", launchFile);
             Assert.IsFalse(launchFile.Contains("\"gaid\""),
                 "gaid must not appear when the user has opted out");
         }
@@ -1466,7 +1466,7 @@ namespace Immutable.Audience.Tests
         //
         // idfa and gaid are cross-app device identifiers, same privacy class
         // as userId. They ship only when consent is Full. State-class keys
-        // (attStatus, gaidLimitAdTracking) are non-identifying and ship at
+        // (att_status, gaid_limit_ad_tracking) are non-identifying and ship at
         // Anonymous+Full (CanTrack).
         // -----------------------------------------------------------------
 
@@ -1476,7 +1476,7 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.MobileAttributionContextProvider = () =>
                 new Dictionary<string, object>
                 {
-                    ["attStatus"] = "authorized",
+                    ["att_status"] = "authorized",
                     ["idfa"] = "11111111-2222-3333-4444-555555555555",
                 };
             var config = MakeConfig(ConsentLevel.Anonymous);
@@ -1487,8 +1487,8 @@ namespace Immutable.Audience.Tests
             var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
                 .Select(File.ReadAllText)
                 .First(c => c.Contains("\"game_launch\""));
-            StringAssert.Contains("\"attStatus\":\"authorized\"", launchFile,
-                "attStatus must ship at Anonymous: it is non-identifying state");
+            StringAssert.Contains("\"att_status\":\"authorized\"", launchFile,
+                "att_status must ship at Anonymous: it is non-identifying state");
             Assert.IsFalse(launchFile.Contains("\"idfa\""),
                 "idfa must not ship at Anonymous: it is a cross-app device identifier");
         }
@@ -1496,14 +1496,14 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Init_GameLaunch_StripsGaid_WhenConsentAnonymous()
         {
-            // gaid is stripped at Anonymous; gaidLimitAdTracking is non-identifying
+            // gaid is stripped at Anonymous; gaid_limit_ad_tracking is non-identifying
             // state and must still ship so the pipeline can distinguish
             // "fetched, opted out" from "not fetched yet".
             ImmutableAudience.MobileAttributionContextProvider = () =>
                 new Dictionary<string, object>
                 {
                     ["gaid"] = "abcdef01-2345-6789-abcd-ef0123456789",
-                    ["gaidLimitAdTracking"] = false,
+                    ["gaid_limit_ad_tracking"] = false,
                 };
             var config = MakeConfig(ConsentLevel.Anonymous);
             config.EnableMobileAttribution = true;
@@ -1513,8 +1513,8 @@ namespace Immutable.Audience.Tests
             var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
                 .Select(File.ReadAllText)
                 .First(c => c.Contains("\"game_launch\""));
-            StringAssert.Contains("\"gaidLimitAdTracking\":false", launchFile,
-                "gaidLimitAdTracking must ship at Anonymous: it is non-identifying state");
+            StringAssert.Contains("\"gaid_limit_ad_tracking\":false", launchFile,
+                "gaid_limit_ad_tracking must ship at Anonymous: it is non-identifying state");
             Assert.IsFalse(launchFile.Contains("\"gaid\""),
                 "gaid must not ship at Anonymous: it is a cross-app device identifier");
         }
@@ -1542,14 +1542,14 @@ namespace Immutable.Audience.Tests
                 .Select(File.ReadAllText).ToList();
             Assert.IsTrue(blobs.Any(c =>
                 c.Contains("\"install_referrer_received\"") &&
-                c.Contains("\"installReferrer\":\"utm_source=google-play&utm_medium=organic\"")),
-                "install_referrer_received must ship with the installReferrer property");
+                c.Contains("\"install_referrer\":\"utm_source=google-play&utm_medium=organic\"")),
+                "install_referrer_received must ship with the install_referrer property");
         }
 
         [Test]
         public void Init_GameLaunch_NeverIncludesInstallReferrer()
         {
-            // installReferrer is exclusively on the dedicated event; ensure
+            // install_referrer is exclusively on the dedicated event; ensure
             // we don't regress and start leaking it onto game_launch.
             ImmutableAudience.MobileInstallReferrerProvider = () => "utm_source=test";
             var config = MakeConfig(ConsentLevel.Full);
@@ -1560,8 +1560,8 @@ namespace Immutable.Audience.Tests
             var launchFile = Directory.GetFiles(AudiencePaths.QueueDir(_testDir), "*.json")
                 .Select(File.ReadAllText)
                 .First(c => c.Contains("\"game_launch\""));
-            Assert.IsFalse(launchFile.Contains("installReferrer"),
-                "game_launch must never carry installReferrer; it ships on its own event");
+            Assert.IsFalse(launchFile.Contains("install_referrer"),
+                "game_launch must never carry install_referrer; it ships on its own event");
         }
 
         [Test]
@@ -1681,7 +1681,7 @@ namespace Immutable.Audience.Tests
                 .Select(File.ReadAllText).ToList();
             Assert.IsTrue(secondBlobs.Any(c =>
                 c.Contains("\"install_referrer_received\"") &&
-                c.Contains("\"installReferrer\":\"utm_source=second_launch\"")),
+                c.Contains("\"install_referrer\":\"utm_source=second_launch\"")),
                 "second Init must ship install_referrer_received when the cache landed late");
         }
 
@@ -1706,7 +1706,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Init_DoesNotFireInstallReferrerReceived_WhenConsentAnonymous()
         {
-            // installReferrer encodes campaign attribution source; Full-only.
+            // install_referrer encodes campaign attribution source; Full-only.
             // The sent marker must NOT be written so a later upgrade to Full
             // can fire the event.
             ImmutableAudience.MobileInstallReferrerProvider = () => "utm_source=google-play";
@@ -1755,7 +1755,7 @@ namespace Immutable.Audience.Tests
                 .Select(File.ReadAllText).ToList();
             Assert.IsTrue(secondBlobs.Any(c =>
                 c.Contains("\"install_referrer_received\"") &&
-                c.Contains("\"installReferrer\":\"utm_source=upgrade_test\"")),
+                c.Contains("\"install_referrer\":\"utm_source=upgrade_test\"")),
                 "event must fire on the first Full-consent launch after an Anonymous launch");
         }
 
@@ -2083,8 +2083,8 @@ namespace Immutable.Audience.Tests
                 .Select(File.ReadAllText).ToList();
             Assert.IsTrue(blobs.Any(b =>
                 b.Contains("\"tracking_authorization_changed\"") &&
-                b.Contains("\"previousStatus\":\"denied\"") &&
-                b.Contains("\"newStatus\":\"authorized\"") &&
+                b.Contains("\"previous_status\":\"denied\"") &&
+                b.Contains("\"new_status\":\"authorized\"") &&
                 b.Contains("\"idfa\":\"11111111-2222-3333-4444-555555555555\"")),
                 "Init must fire tracking_authorization_changed when ATT status transitions");
         }
@@ -2145,8 +2145,8 @@ namespace Immutable.Audience.Tests
                 .Select(File.ReadAllText).ToList();
             Assert.IsTrue(blobs.Any(b =>
                 b.Contains("\"tracking_authorization_changed\"") &&
-                b.Contains("\"previousStatus\":\"notDetermined\"") &&
-                b.Contains("\"newStatus\":\"authorized\"") &&
+                b.Contains("\"previous_status\":\"notDetermined\"") &&
+                b.Contains("\"new_status\":\"authorized\"") &&
                 b.Contains("\"idfa\":\"11111111-2222-3333-4444-555555555555\"")),
                 "RequestTrackingAuthorizationAsync must fire tracking_authorization_changed when status transitions");
         }

--- a/src/Packages/Audience/Tests/Runtime/Unity/ATTBridgeTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Unity/ATTBridgeTests.cs
@@ -92,7 +92,7 @@ namespace Immutable.Audience.Tests
 
             var ctx = AttributionContext.Capture();
 
-            Assert.AreEqual("authorized", ctx["attStatus"]);
+            Assert.AreEqual("authorized", ctx["att_status"]);
             Assert.AreEqual("11111111-2222-3333-4444-555555555555", ctx["idfa"]);
         }
 
@@ -107,7 +107,7 @@ namespace Immutable.Audience.Tests
 
             var ctx = AttributionContext.Capture();
 
-            Assert.AreEqual("denied", ctx["attStatus"]);
+            Assert.AreEqual("denied", ctx["att_status"]);
             Assert.IsFalse(ctx.ContainsKey("idfa"),
                 "idfa must be omitted when ATT is not authorized");
         }
@@ -121,7 +121,7 @@ namespace Immutable.Audience.Tests
 
             var ctx = AttributionContext.Capture();
 
-            Assert.AreEqual("notDetermined", ctx["attStatus"]);
+            Assert.AreEqual("notDetermined", ctx["att_status"]);
             Assert.IsFalse(ctx.ContainsKey("idfa"));
         }
 
@@ -134,7 +134,7 @@ namespace Immutable.Audience.Tests
 
             var ctx = AttributionContext.Capture();
 
-            Assert.AreEqual("restricted", ctx["attStatus"]);
+            Assert.AreEqual("restricted", ctx["att_status"]);
             Assert.IsFalse(ctx.ContainsKey("idfa"));
         }
 
@@ -148,7 +148,7 @@ namespace Immutable.Audience.Tests
 
             var ctx = AttributionContext.Capture();
 
-            Assert.AreEqual("authorized", ctx["attStatus"]);
+            Assert.AreEqual("authorized", ctx["att_status"]);
             Assert.IsFalse(ctx.ContainsKey("idfa"));
         }
 
@@ -176,7 +176,7 @@ namespace Immutable.Audience.Tests
 
             Assert.IsFalse(props.ContainsKey("gaid"),
                 "must never ship the raw GAID when the user has opted out via isLimitAdTrackingEnabled");
-            Assert.AreEqual(true, props["gaidLimitAdTracking"]);
+            Assert.AreEqual(true, props["gaid_limit_ad_tracking"]);
         }
 
         [Test]
@@ -186,7 +186,7 @@ namespace Immutable.Audience.Tests
             AttributionContext.EmitGaidProps(new GAIDInfo("aaaa-bbbb", limitAdTracking: false), props);
 
             Assert.AreEqual("aaaa-bbbb", props["gaid"]);
-            Assert.AreEqual(false, props["gaidLimitAdTracking"]);
+            Assert.AreEqual(false, props["gaid_limit_ad_tracking"]);
         }
 
         [Test]
@@ -196,7 +196,7 @@ namespace Immutable.Audience.Tests
             AttributionContext.EmitGaidProps(new GAIDInfo(string.Empty, limitAdTracking: false), props);
 
             Assert.IsFalse(props.ContainsKey("gaid"));
-            Assert.AreEqual(false, props["gaidLimitAdTracking"]);
+            Assert.AreEqual(false, props["gaid_limit_ad_tracking"]);
         }
     }
 }

--- a/src/Packages/Audience/Tests/Runtime/Unity/DeviceCollectorTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Unity/DeviceCollectorTests.cs
@@ -52,9 +52,9 @@ namespace Immutable.Audience.Tests
         {
             var props = DeviceCollector.CollectGameLaunchProperties();
             foreach (var key in new[] {
-                "platform", "isEditor", "version", "buildGuid", "unityVersion",
-                "osFamily", "deviceModel", "gpu", "gpuVendor",
-                "cpu", "cpuCores", "ramMb" })
+                "platform", "is_editor", "version", "build_guid", "unity_version",
+                "os_family", "device_model", "gpu", "gpu_vendor",
+                "cpu", "cpu_cores", "ram_mb" })
             {
                 Assert.IsTrue(props.ContainsKey(key), $"expected key '{key}' to be present");
             }
@@ -65,8 +65,8 @@ namespace Immutable.Audience.Tests
         {
             var props = DeviceCollector.CollectGameLaunchProperties();
             foreach (var key in new[] {
-                "platform", "version", "buildGuid", "unityVersion",
-                "osFamily", "deviceModel", "gpu", "gpuVendor", "cpu" })
+                "platform", "version", "build_guid", "unity_version",
+                "os_family", "device_model", "gpu", "gpu_vendor", "cpu" })
             {
                 if (!props.TryGetValue(key, out var val)) continue;
                 if (val is not string s) continue;
@@ -80,8 +80,8 @@ namespace Immutable.Audience.Tests
             // Regression guard: androidId must only appear on Android. Running
             // tests on Editor/Standalone should never populate this field.
             var props = DeviceCollector.CollectGameLaunchProperties();
-            Assert.IsFalse(props.ContainsKey("androidId"),
-                "androidId must not be present on non-Android platforms");
+            Assert.IsFalse(props.ContainsKey("android_id"),
+                "android_id must not be present on non-Android platforms");
         }
 
         [Test]
@@ -90,8 +90,8 @@ namespace Immutable.Audience.Tests
             // Screen.dpi returns 0 on some Linux WMs; the implementation
             // must omit the key rather than forwarding a zero value.
             var props = DeviceCollector.CollectGameLaunchProperties();
-            if (props.TryGetValue("screenDpi", out var dpi))
-                Assert.Greater((int)dpi, 0, "screenDpi must not be 0 when present");
+            if (props.TryGetValue("screen_dpi", out var dpi))
+                Assert.Greater((int)dpi, 0, "screen_dpi must not be 0 when present");
         }
 
         // -----------------------------------------------------------------
@@ -178,7 +178,7 @@ namespace Immutable.Audience.Tests
         {
             var props = DeviceCollector.CollectGameLaunchProperties(
                 isEditorOverride: isEditor);
-            Assert.AreEqual(isEditor, props["isEditor"]);
+            Assert.AreEqual(isEditor, props["is_editor"]);
         }
     }
 }


### PR DESCRIPTION
Renames all multi-word Audience event property string keys from camelCase to snake_case to align with industry standard (Segment, GA4). Event names were already snake_case; this makes properties consistent.

Only string key literals in Dictionary entries are changed. C# class property names are unchanged.

Fixes SDK-413.