### PR TITLE
fix(audience): prevent IL2CPP stripping of Unity hooks assembly

### DIFF
--- a/src/Packages/Audience/Runtime/Unity/AudienceUnityHooks.cs
+++ b/src/Packages/Audience/Runtime/Unity/AudienceUnityHooks.cs
@@ -4,9 +4,13 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Immutable.Audience.Unity.Mobile;
 using UnityEngine;
+using UnityEngine.Scripting;
+
+[assembly: AlwaysLinkAssembly]
 
 namespace Immutable.Audience.Unity
 {
+    [Preserve]
     internal static class AudienceUnityHooks
     {
         // Captured at SubsystemRegistration so the Install Referrer provider


### PR DESCRIPTION
Fixes SDK-480.

## Problem

Games built with IL2CPP + High stripping silently lose all Unity context fields (`userAgent`, `locale`, `screen`, `timezone`) from every event. The linker strips the entire `Immutable.Audience.Unity` assembly when it finds no call sites into it — so the `[RuntimeInitializeOnLoadMethod]` hook never fires and `ContextProvider` is never registered. Only `library` and `libraryVersion` survive because they come from `Immutable.Audience.Runtime`, which has direct references keeping it alive.

The SDK ships a `link.xml` to guard against this, but Unity's linker skips it for packages loaded via a `file:` path outside the project tree. Studios without a project-level `link.xml` fallback hit this silently.

Confirmed in production on project 18282: ~97% of 0.3.0 events are missing `userAgent`. All 0.2.2 events from the same project had it — the regression correlates with them switching to an IL2CPP + High stripping build around the 0.3.0 upgrade.

## Fix

Two lines in `AudienceUnityHooks.cs`:

- `[assembly: AlwaysLinkAssembly]` — forces the linker to process the assembly regardless of call sites
- `[Preserve]` on the class — keeps `Install()` alive once the assembly is included

`[Preserve]` alone is not enough: if the linker skips the assembly entirely, it never evaluates the attribute.

## Test plan

- [x] Build example app with IL2CPP + High stripping and no audience lines in `link.xml`
- [x] Confirm events include full context (`userAgent`, `locale`, `screen`, `timezone`)
- [x] Confirm no `PersistentDataPath is required` crash on init