### PR TITLE
fix(audience): fix iOS App Store rejection due to incomplete privacy manifest and ATT copy

### DIFF
--- a/src/Packages/Audience/Editor/AudienceMobileBuildSettings.cs
+++ b/src/Packages/Audience/Editor/AudienceMobileBuildSettings.cs
@@ -18,17 +18,23 @@ namespace Immutable.Audience.Editor
     /// </remarks>
     public sealed class AudienceMobileBuildSettings : ScriptableObject
     {
-        // Fallback so a build never ships with the key missing (which would
-        // block App Store submission). Studios should override on the asset
-        // with copy describing what is collected and why.
+        // Fallback used when no asset exists or the field is left blank.
+        // Apple reviewers reject generic strings — studios MUST replace this
+        // with copy that names their app and explains the specific use case
+        // (e.g. "Game Name uses your advertising identifier to attribute app
+        // installs and measure ad campaign performance."). Submitting this
+        // default will likely result in an App Store rejection.
         internal const string DefaultTrackingUsageDescription =
-            "Your data may be used to deliver personalised ads to you. " +
-            "You can change this preference at any time in Settings.";
+            "This app uses your device's advertising identifier to attribute " +
+            "app installs and measure ad campaign performance. You can change " +
+            "this preference at any time in Settings > Privacy & Security > Tracking.";
 
         [SerializeField]
-        [Tooltip("Copy shown in the iOS App Tracking Transparency prompt. " +
-                 "Apple rejects empty or generic strings. Describe what is " +
-                 "collected and why.")]
+        [Tooltip("REQUIRED: Customise this before submitting to the App Store. " +
+                 "Apple rejects generic strings — describe what YOUR app collects " +
+                 "and why (e.g. 'Game Name uses your advertising identifier to " +
+                 "attribute installs and measure ad performance.'). " +
+                 "Left blank, the SDK default is used but will likely be rejected.")]
         private string trackingUsageDescription = DefaultTrackingUsageDescription;
 
         [SerializeField]

--- a/src/Packages/Audience/Editor/iOSPrivacyManifestPostProcessor.cs
+++ b/src/Packages/Audience/Editor/iOSPrivacyManifestPostProcessor.cs
@@ -69,6 +69,26 @@ namespace Immutable.Audience.Editor
             // IDFA collection constitutes tracking under Apple's definition.
             root.SetBoolean("NSPrivacyTracking", true);
 
+            // Apple requires every domain contacted for tracking to be listed.
+            const string trackingDomain = "api.immutable.com";
+            PlistElementArray trackingDomains;
+            if (root.values.TryGetValue("NSPrivacyTrackingDomains", out var existingDomains) &&
+                existingDomains is PlistElementArray existingDomainsArray)
+            {
+                trackingDomains = existingDomainsArray;
+            }
+            else
+            {
+                trackingDomains = root.CreateArray("NSPrivacyTrackingDomains");
+            }
+
+            var hasDomain = false;
+            foreach (var item in trackingDomains.values)
+            {
+                if (item is PlistElementString ds && ds.value == trackingDomain) { hasDomain = true; break; }
+            }
+            if (!hasDomain) trackingDomains.AddString(trackingDomain);
+
             PlistElementArray dataTypes;
             if (root.values.TryGetValue("NSPrivacyCollectedDataTypes", out var existing) &&
                 existing is PlistElementArray existingArray)

--- a/src/Packages/Audience/Runtime/Plugins/iOS/PrivacyInfo.attribution.xcprivacy
+++ b/src/Packages/Audience/Runtime/Plugins/iOS/PrivacyInfo.attribution.xcprivacy
@@ -5,7 +5,9 @@
 	<key>NSPrivacyTracking</key>
 	<true/>
 	<key>NSPrivacyTrackingDomains</key>
-	<array/>
+	<array>
+		<string>api.immutable.com</string>
+	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Why

Two gaps in the SDK's iOS privacy config caused an App Store rejection:

1. **`NSPrivacyTrackingDomains` was empty** — Apple requires every tracking domain listed when `NSPrivacyTracking = true`. The SDK calls `api.immutable.com` but it was missing from both the static manifest and the build-time post-processor.
2. **Generic ATT prompt** — Apple flags `NSUserTrackingUsageDescription` strings that don't describe a specific use case. The default was vague enough to get most apps rejected.

## Changes

- `PrivacyInfo.attribution.xcprivacy` — add `api.immutable.com` to `NSPrivacyTrackingDomains`
- `iOSPrivacyManifestPostProcessor` — inject the tracking domain at build time (idempotent)
- `AudienceMobileBuildSettings` — improve default ATT copy; strengthen tooltip to make clear it must be customised per-app before submission

Closes SDK-483, part of SDK-450.

## Test plan

- [ ] Build with `AUDIENCE_MOBILE_ATTRIBUTION` enabled; confirm `api.immutable.com` appears in `UnityFramework/PrivacyInfo.xcprivacy`
- [ ] Re-run post-processor; confirm domain is not duplicated
- [ ] Check `AudienceMobileBuildSettings` inspector shows updated tooltip and default string

🤖 Generated with [Claude Code](https://claude.com/claude-code)