### PR TITLE
fix(audience): lock context.libraryVersion to the SDK version

### DIFF
--- a/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
+++ b/examples/audience/Assets/SampleApp/Scripts/AudienceSample.cs
@@ -368,7 +368,6 @@ namespace Immutable.Audience.Samples.SampleApp
                 ["enableMobileAttribution"]  = config.EnableMobileAttribution,
                 ["flushIntervalSeconds"]     = config.FlushIntervalSeconds,
                 ["flushSize"]                = config.FlushSize,
-                ["packageVersion"]           = config.PackageVersion,
                 ["shutdownFlushTimeoutMs"]   = config.ShutdownFlushTimeoutMs,
             };
             if (!string.IsNullOrEmpty(config.PublishableKey))

--- a/src/Packages/Audience/Runtime/AudienceConfig.cs
+++ b/src/Packages/Audience/Runtime/AudienceConfig.cs
@@ -117,11 +117,6 @@ namespace Immutable.Audience
         public string? PersistentDataPath { get; set; }
 
         /// <summary>
-        /// Library version sent on every message.
-        /// </summary>
-        public string PackageVersion { get; set; } = Constants.LibraryVersion;
-
-        /// <summary>
         /// Maximum time <see cref="ImmutableAudience.Shutdown"/> waits for
         /// the final flush, in milliseconds.
         /// </summary>

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -330,7 +330,7 @@ namespace Immutable.Audience
             var anonymousId = Identity.GetOrCreate(config.PersistentDataPath!, state.Level);
             // ToProperties returns a fresh dict per call, so no snapshot needed.
             var userId = state.Level == ConsentLevel.Full ? state.UserId : null;
-            var msg = MessageBuilder.Track(eventName, anonymousId, userId, config.PackageVersion, properties, config.TestMode);
+            var msg = MessageBuilder.Track(eventName, anonymousId, userId, Constants.LibraryVersion, properties, config.TestMode);
             EnqueueTrack(msg);
         }
 
@@ -356,7 +356,7 @@ namespace Immutable.Audience
 
             var anonymousId = Identity.GetOrCreate(config.PersistentDataPath!, state.Level);
             var userId = state.Level == ConsentLevel.Full ? state.UserId : null;
-            var msg = MessageBuilder.Track(eventName, anonymousId, userId, config.PackageVersion,
+            var msg = MessageBuilder.Track(eventName, anonymousId, userId, Constants.LibraryVersion,
                 SnapshotCallerDict(properties), config.TestMode);
             EnqueueTrack(msg);
         }
@@ -403,7 +403,7 @@ namespace Immutable.Audience
 
             var anonymousId = Identity.GetOrCreate(config.PersistentDataPath!, level);
             var msg = MessageBuilder.Identify(anonymousId, userId, identityType.ToLowercaseString(),
-                config.PackageVersion, SnapshotCallerDict(traits), config.TestMode);
+                Constants.LibraryVersion, SnapshotCallerDict(traits), config.TestMode);
             EnqueueIdentity(msg);
         }
 
@@ -434,7 +434,7 @@ namespace Immutable.Audience
             if (config == null) return;
 
             var msg = MessageBuilder.Alias(fromId, fromType.ToLowercaseString(), toId, toType.ToLowercaseString(),
-                config.PackageVersion, config.TestMode);
+                Constants.LibraryVersion, config.TestMode);
             EnqueueIdentity(msg);
         }
 


### PR DESCRIPTION
Fixes SDK-489.

`context.libraryVersion` identifies the tracking library itself, and we rely on it to segment audience telemetry by SDK version (it is how the recent IL2CPP stripping regression was diagnosed). Game developers could override it through the public `AudienceConfig.PackageVersion` property, which let arbitrary values land in that field and undermine the signal. This pins `libraryVersion` to the SDK's own version and removes the override.

The version still comes from `Constants.LibraryVersion`, which `ConstantsTests.LibraryVersion_MatchesPackageJson` already keeps in sync with `package.json`, so there is no risk of it drifting.

**Breaking change:** removes the public `AudienceConfig.PackageVersion` property (minor bump on the 0.x line). It was unused internally. If developers need to report their own game/app version later, that should be a dedicated field rather than reusing `libraryVersion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)