### PR TITLE
fix(release): show fixes before features in audience release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,12 +55,12 @@ jobs:
               "pr_template": "- #{{TITLE}} (##{{NUMBER}})",
               "categories": [
                 {
-                    "title": "## Features",
-                    "labels": ["audience-feature"]
-                },
-                {
                     "title": "## Fixes",
                     "labels": ["audience-fix"]
+                },
+                {
+                    "title": "## Features",
+                    "labels": ["audience-feature"]
                 },
                 {
                     "title": "## Performance",


### PR DESCRIPTION
## Summary
- Reorders the audience changelog categories so Fixes appears before Features in release notes.

## Test plan
- [ ] Merge and trigger an audience release — verify Fixes section appears above Features in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)