### PR TITLE
feat(audience): auto-collect platform ID on consent upgrade to Full

### DIFF
--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -665,6 +665,11 @@ namespace Immutable.Audience
 
             newSession?.Start();
 
+            if (level == ConsentLevel.Full && previous != ConsentLevel.Full)
+            {
+                TryIdentifySteamUser();
+                TryIdentifyEpicUser();
+            }
 
             SyncConsentToBackend(config, level, anonymousIdForPut);
         }


### PR DESCRIPTION
## Summary

Previously Steam and Epic identity collection only ran at `Init`. Games that start with `Anonymous` consent and upgrade to `Full` via `SetConsent` never had the platform ID collected, leaving a gap in identity data for the common consent-prompt flow.

The fix adds `TryIdentifySteamUser` and `TryIdentifyEpicUser` to `SetConsent`, gated on a genuine upgrade to `Full` (`level == Full && previous != Full`). The same two methods already run at `Init`, so behaviour is consistent across both entry points.

Closes SDK-539 / part of SDK-534.

## Use case gotchas

If a game calls `Identify` with its own backend user ID and then cycles consent (Full → Anonymous → Full), auto-collection fires again on the upgrade and sets the platform ID as the active user ID. The dev needs to call `Identify` again with their game user ID after the upgrade — this is expected behaviour since the downgrade already cleared identity state.

If the platform session is not active at the moment consent reaches `Full` (Steam not running, EOS not yet logged in), collection is silently skipped. Devs who need identity reliably in that scenario should call `Identify` manually once the platform session is ready.

## Test plan

- [x] Consent starts `Anonymous`, upgraded to `Full` via `SetConsent` — `identify` event with `identity_type='steam'` fires
- [x] Consent starts `Anonymous`, upgraded to `Full` via `SetConsent` — `identify` event with `identity_type='epic'` fires
- [x] Redundant `SetConsent(Full)` when already `Full` — auto-collection does not fire again
- [x] No errors when neither Steam nor EOS plugin is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)