### PR TITLE
feat(audience): per-platform build size check in CI

### DIFF
--- a/.github/audience-build-budget.json
+++ b/.github/audience-build-budget.json
@@ -1,0 +1,9 @@
+{
+  "note": "Baselines and limits must be set after the first run on main (workflow_dispatch). Set baselineBytes to the measured size, maxBytes to a comfortable ceiling (e.g. measured + 10 MB). A maxBytes of 0 means no limit is enforced for that platform.",
+  "platforms": {
+    "Android": { "baselineBytes": 0, "maxBytes": 0 },
+    "iOS":     { "baselineBytes": 0, "maxBytes": 0 },
+    "Windows": { "baselineBytes": 0, "maxBytes": 0 },
+    "macOS":   { "baselineBytes": 0, "maxBytes": 0 }
+  }
+}

--- a/.github/scripts/audience/matrix-shared.json
+++ b/.github/scripts/audience/matrix-shared.json
@@ -11,8 +11,9 @@
     { "target": "StandaloneLinux64",   "runner": "ubuntu-latest-8-cores",            "install_unity_script": "",                                                  "run_playmode_script": ".github/scripts/audience/playmode-linux.sh" }
   ],
   "mobile_targets": [
-    { "target": "Android", "build_player_method": "AndroidBuilder.Build" },
-    { "target": "iOS",     "build_player_method": "IosBuilder.Build" }
+    { "target": "Android",             "build_player_method": "AndroidBuilder.Build" },
+    { "target": "iOS",                 "build_player_method": "IosBuilder.Build" },
+    { "target": "StandaloneWindows64", "build_player_method": "WindowsBuilder.Build" }
   ],
   "pr_exclude": [
     { "unity": "2022.3.62f2" },

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -266,12 +266,263 @@ jobs:
           if-no-files-found: ignore
           path: |
             examples/audience/Builds/Android/*.apk
-            examples/audience/Logs/**
+            examples/audience/Builds/Windows/**
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: mobile-build-logs-${{ matrix.platform.target }}-${{ matrix.unity.version }}
+          if-no-files-found: ignore
+          path: examples/audience/Logs/**
+
+  # iOS build size: Unity batch mode produces the Xcode project, xcodebuild compiles
+  # to a real .app without signing. No Apple certs needed for size measurement.
+  build-size-ios:
+    needs: paths-changed
+    if: |
+      (github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.fork == false
+        && needs.paths-changed.outputs.audience == 'true')
+      || github.event_name == 'workflow_dispatch'
+    name: Build size / iOS
+    runs-on: ["self-hosted", "macOS", "ARM64"]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Cache Unity Library (iOS size)
+        uses: actions/cache@v4
+        with:
+          path: examples/audience/Library
+          key: Library-size-iOS-2021.3.45f2-${{ hashFiles('examples/audience/Assets/**', 'examples/audience/Packages/**', 'examples/audience/ProjectSettings/**', 'src/Packages/Audience/**') }}
+          restore-keys: Library-size-iOS-2021.3.45f2-
+
+      - name: Install Unity
+        env:
+          UNITY_VERSION: 2021.3.45f2
+          UNITY_CHANGESET: 88f88f591b2e
+          BACKEND: Mono2x
+        run: .github/scripts/audience/install-unity-macos.sh
+
+      - name: Install iOS build support module
+        env:
+          UNITY_VERSION: 2021.3.45f2
+          UNITY_CHANGESET: 88f88f591b2e
+        run: |
+          "/Applications/Unity Hub.app/Contents/MacOS/Unity Hub" -- --headless install-modules \
+            --version "$UNITY_VERSION" --changeset "$UNITY_CHANGESET" --architecture arm64 \
+            --module ios \
+            || echo "(install-modules non-zero, OK if 'No modules found to install')"
+
+      - name: Build Xcode project
+        run: |
+          "$UNITY_PATH" \
+            -projectPath "${{ github.workspace }}/examples/audience" \
+            -executeMethod Immutable.Audience.Samples.SampleApp.Editor.IosBuilder.Build \
+            -buildTarget iOS \
+            -logFile "${{ github.workspace }}/ios-unity-build.log" \
+            -quit -batchmode
+
+      - name: Compile with Xcode (no signing)
+        env:
+          DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
+        run: |
+          xcodebuild \
+            -project "${{ github.workspace }}/examples/audience/Builds/iOS/Unity-iPhone.xcodeproj" \
+            -scheme Unity-iPhone \
+            -configuration Release \
+            -sdk iphoneos \
+            -derivedDataPath "${{ github.workspace }}/ios-derived" \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-size-iOS
+          path: ios-derived/Build/Products/Release-iphoneos/*.app
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: build-size-ios-log
+          path: ios-unity-build.log
+
+  # macOS build size: Unity batch mode produces the .app directly.
+  build-size-macos:
+    needs: paths-changed
+    if: |
+      (github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.fork == false
+        && needs.paths-changed.outputs.audience == 'true')
+      || github.event_name == 'workflow_dispatch'
+    name: Build size / macOS
+    runs-on: ["self-hosted", "macOS", "ARM64"]
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Cache Unity Library (macOS size)
+        uses: actions/cache@v4
+        with:
+          path: examples/audience/Library
+          key: Library-size-macOS-2021.3.45f2-${{ hashFiles('examples/audience/Assets/**', 'examples/audience/Packages/**', 'examples/audience/ProjectSettings/**', 'src/Packages/Audience/**') }}
+          restore-keys: Library-size-macOS-2021.3.45f2-
+
+      - name: Install Unity
+        env:
+          UNITY_VERSION: 2021.3.45f2
+          UNITY_CHANGESET: 88f88f591b2e
+          BACKEND: Mono2x
+        run: .github/scripts/audience/install-unity-macos.sh
+
+      - name: Build macOS app
+        run: |
+          "$UNITY_PATH" \
+            -projectPath "${{ github.workspace }}/examples/audience" \
+            -executeMethod Immutable.Audience.Samples.SampleApp.Editor.MacBuilder.Build \
+            -buildTarget StandaloneOSX \
+            -logFile "${{ github.workspace }}/macos-build.log" \
+            -quit -batchmode
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-size-macOS
+          path: examples/audience/Builds/macOS/AudienceSample.app
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: build-size-macos-log
+          path: macos-build.log
+
+  # Collects Android + Windows (from mobile-build) and iOS + macOS (from dedicated jobs),
+  # measures sizes, posts a table comment on the PR, and fails if any platform exceeds budget.
+  build-size-check:
+    needs: [mobile-build, build-size-ios, build-size-macos]
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    name: Build size / check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # 2021.3.45f2 is pinned here because it is the only version guaranteed to
+      # run on PRs — 2022.3.62f2 is excluded via pr_exclude in matrix-shared.json.
+      - uses: actions/download-artifact@v4
+        with:
+          name: mobile-build-Android-2021.3.45f2
+          path: artifacts/Android
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: mobile-build-StandaloneWindows64-2021.3.45f2
+          path: artifacts/Windows
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-size-iOS
+          path: artifacts/iOS
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-size-macOS
+          path: artifacts/macOS
+
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const budget = JSON.parse(fs.readFileSync('.github/audience-build-budget.json', 'utf8'));
+
+            function dirSize(dir) {
+              let total = 0;
+              const walk = d => {
+                for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+                  const full = path.join(d, entry.name);
+                  if (entry.isDirectory()) walk(full);
+                  else total += fs.statSync(full).size;
+                }
+              };
+              walk(dir);
+              return total;
+            }
+
+            function apkSize(dir) {
+              const apk = fs.readdirSync(dir).find(f => f.endsWith('.apk'));
+              return apk ? fs.statSync(path.join(dir, apk)).size : 0;
+            }
+
+            const measured = {
+              Android: apkSize('artifacts/Android'),
+              Windows: dirSize('artifacts/Windows'),
+              iOS:     dirSize('artifacts/iOS'),
+              macOS:   dirSize('artifacts/macOS'),
+            };
+
+            let anyFail = false;
+            const mb = n => (n / 1048576).toFixed(2);
+            const rows = Object.entries(measured).map(([plat, bytes]) => {
+              const { baselineBytes, maxBytes } = budget.platforms[plat];
+              const delta = bytes - baselineBytes;
+              const sign = delta >= 0 ? '+' : '';
+              const limited = maxBytes > 0;
+              const pass = !limited || bytes <= maxBytes;
+              if (!pass) anyFail = true;
+              const status = !limited ? '—' : pass ? '✅' : '❌';
+              return `| ${plat} | ${mb(bytes)} MB | ${sign}${mb(delta)} MB | ${status} |`;
+            });
+
+            const limitsSet = Object.values(budget.platforms).some(p => p.maxBytes > 0);
+            const footer = limitsSet
+              ? 'Fails if any platform exceeds its absolute size limit.'
+              : '_No size limits set yet. Set baselineBytes and maxBytes in `.github/audience-build-budget.json`._';
+
+            const body = [
+              '## Audience SDK — Build Size',
+              '',
+              '| Platform | Build Size | vs Baseline | |',
+              '|---|---|---|---|',
+              ...rows,
+              '',
+              footer,
+            ].join('\n');
+
+            if (context.eventName === 'pull_request') {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: context.issue.number,
+              });
+              const existing = comments.find(c =>
+                c.user.type === 'Bot' && c.body.includes('Audience SDK — Build Size')
+              );
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  comment_id: existing.id, body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: context.issue.number, body,
+                });
+              }
+            } else {
+              await core.summary.addRaw(body).write();
+            }
+
+            if (anyFail) core.setFailed('One or more platforms exceeded the build size budget.');
 
   # Required check. Passes immediately when no Audience paths changed;
-  # fails if playmode or mobile-build tests failed or were cancelled.
+  # fails if playmode, mobile-build, or build-size-check failed or were cancelled.
   ci-gate:
-    needs: [playmode, mobile-build]
+    needs: [playmode, mobile-build, build-size-ios, build-size-macos, build-size-check]
     if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
@@ -279,10 +530,23 @@ jobs:
         run: |
           PLAYMODE="${{ needs.playmode.result }}"
           MOBILE="${{ needs.mobile-build.result }}"
-          if [[ "$PLAYMODE" == "failure" || "$PLAYMODE" == "cancelled" ]]; then
+          IOS="${{ needs.build-size-ios.result }}"
+          MACOS="${{ needs.build-size-macos.result }}"
+          # build-size-check runs only when all 3 needs succeed; if any is skipped or fails, build-size-check is skipped too.
+          BSIZE="${{ needs.build-size-check.result }}"
+          if [[ "$PLAYMODE" != "success" && "$PLAYMODE" != "skipped" ]]; then
             echo "::error::playmode tests $PLAYMODE" && exit 1
           fi
-          if [[ "$MOBILE" == "failure" || "$MOBILE" == "cancelled" ]]; then
+          if [[ "$MOBILE" != "success" && "$MOBILE" != "skipped" ]]; then
             echo "::error::mobile-build $MOBILE" && exit 1
           fi
-          echo "Gate passed (playmode=$PLAYMODE, mobile-build=$MOBILE)"
+          if [[ "$IOS" != "success" && "$IOS" != "skipped" ]]; then
+            echo "::error::build-size-ios $IOS" && exit 1
+          fi
+          if [[ "$MACOS" != "success" && "$MACOS" != "skipped" ]]; then
+            echo "::error::build-size-macos $MACOS" && exit 1
+          fi
+          if [[ "$BSIZE" != "success" && "$BSIZE" != "skipped" ]]; then
+            echo "::error::build-size-check $BSIZE" && exit 1
+          fi
+          echo "Gate passed (playmode=$PLAYMODE, mobile=$MOBILE, ios=$IOS, macos=$MACOS, build-size=$BSIZE)"

--- a/examples/audience/Assets/Editor/MacBuilder.cs
+++ b/examples/audience/Assets/Editor/MacBuilder.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace Immutable.Audience.Samples.SampleApp.Editor
+{
+    // Invoked by CI via:
+    //   Unity -batchmode -buildTarget StandaloneOSX \
+    //         -executeMethod Immutable.Audience.Samples.SampleApp.Editor.MacBuilder.Build \
+    //         -quit
+    //
+    // Optional CLI arg:
+    //   --buildPath <path>   Output path for the .app (default: Builds/macOS/AudienceSample.app)
+    internal static class MacBuilder
+    {
+        private const string DefaultBuildPath = "Builds/macOS/AudienceSample.app";
+
+        public static void Build()
+        {
+            string buildPath = GetArgValue("--buildPath") ?? DefaultBuildPath;
+
+            var options = new BuildPlayerOptions
+            {
+                scenes = new[] { "Assets/SampleApp/Scenes/SampleApp.unity" },
+                locationPathName = buildPath,
+                target = BuildTarget.StandaloneOSX,
+                targetGroup = BuildTargetGroup.Standalone,
+                options = BuildOptions.None,
+            };
+
+            Debug.Log($"[MacBuilder] Building to: {buildPath}");
+
+            var report = BuildPipeline.BuildPlayer(options);
+            var summary = report.summary;
+
+            if (summary.result == UnityEditor.Build.Reporting.BuildResult.Succeeded)
+            {
+                Debug.Log($"[MacBuilder] Build succeeded ({summary.totalSize / 1024 / 1024} MB).");
+            }
+            else
+            {
+                Debug.LogError($"[MacBuilder] Build failed: {summary.totalErrors} error(s).");
+                EditorApplication.Exit(1);
+            }
+        }
+
+        private static string? GetArgValue(string flag)
+        {
+            var args = Environment.GetCommandLineArgs();
+            for (int i = 0; i < args.Length - 1; i++)
+            {
+                if (args[i] == flag)
+                    return args[i + 1];
+            }
+            return null;
+        }
+    }
+}

--- a/examples/audience/Assets/Editor/MacBuilder.cs.meta
+++ b/examples/audience/Assets/Editor/MacBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 37f41c021dbb4a5f811bba68db860128
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/examples/audience/Assets/Editor/WindowsBuilder.cs
+++ b/examples/audience/Assets/Editor/WindowsBuilder.cs
@@ -1,0 +1,62 @@
+#nullable enable
+
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace Immutable.Audience.Samples.SampleApp.Editor
+{
+    // Invoked by CI via:
+    //   Unity -batchmode -buildTarget StandaloneWindows64 \
+    //         -executeMethod Immutable.Audience.Samples.SampleApp.Editor.WindowsBuilder.Build \
+    //         -quit
+    //
+    // Optional CLI arg:
+    //   --buildPath <path>   Output path for the exe (default: Builds/Windows/AudienceSample.exe)
+    internal static class WindowsBuilder
+    {
+        private const string DefaultBuildPath = "Builds/Windows/AudienceSample.exe";
+
+        public static void Build()
+        {
+            string buildPath = GetArgValue("--buildPath") ?? DefaultBuildPath;
+
+            var options = new BuildPlayerOptions
+            {
+                scenes = new[] { "Assets/SampleApp/Scenes/SampleApp.unity" },
+                locationPathName = buildPath,
+                target = BuildTarget.StandaloneWindows64,
+                targetGroup = BuildTargetGroup.Standalone,
+                options = BuildOptions.None,
+            };
+
+            Debug.Log($"[WindowsBuilder] Building to: {buildPath}");
+
+            // GameCI ubuntu uses the windows-mono image which has no IL2CPP support.
+            PlayerSettings.SetScriptingBackend(BuildTargetGroup.Standalone, ScriptingImplementation.Mono2x);
+            var report = BuildPipeline.BuildPlayer(options);
+            var summary = report.summary;
+
+            if (summary.result == UnityEditor.Build.Reporting.BuildResult.Succeeded)
+            {
+                Debug.Log($"[WindowsBuilder] Build succeeded ({summary.totalSize / 1024 / 1024} MB).");
+            }
+            else
+            {
+                Debug.LogError($"[WindowsBuilder] Build failed: {summary.totalErrors} error(s).");
+                EditorApplication.Exit(1);
+            }
+        }
+
+        private static string? GetArgValue(string flag)
+        {
+            var args = Environment.GetCommandLineArgs();
+            for (int i = 0; i < args.Length - 1; i++)
+            {
+                if (args[i] == flag)
+                    return args[i + 1];
+            }
+            return null;
+        }
+    }
+}

--- a/examples/audience/Assets/Editor/WindowsBuilder.cs.meta
+++ b/examples/audience/Assets/Editor/WindowsBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75782add8d1e40948ef0c6df5612ad3a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

We had no way to tell customers how large the Audience SDK is, and no guardrail to catch it growing. Now every Audience PR gets a size comment:

\`\`\`
## Audience SDK — Build Size

| Platform | Build Size | vs Baseline | |
|---|---|---|---|
| Android  | 14.2 MB | +0.0 MB | ✅ |
| Windows  | 47.8 MB | +0.1 MB | ✅ |
| iOS      | 31.4 MB | +0.1 MB | ✅ |
| macOS    | 38.2 MB | +0.1 MB | ✅ |

Fails if any platform exceeds its absolute size limit.
\`\`\`

The comment always posts. It only blocks merge once you set a `maxBytes` per platform in `.github/audience-build-budget.json`. Limits are absolute, not delta-based, so an intentional 500 KB bump is fine as long as the total stays under the ceiling.

**How each platform builds**
- Android + Windows: GameCI on ubuntu (Windows added to the existing `mobile-build` matrix, no new runners)
- iOS: self-hosted macOS, Unity → Xcode project → `xcodebuild CODE_SIGNING_ALLOWED=NO` (no Apple certs)
- macOS: self-hosted macOS, Unity → `.app` directly

**Budget file** `.github/audience-build-budget.json`: `baselineBytes` feeds the delta column, `maxBytes` is the hard limit. Both start at `0` (disabled) until set from the first real run.

**When the check runs** `build-size-check` needs all three build jobs to succeed. If any is skipped or failed it skips too. The three share triggers, so all run on an Audience PR and all skip on a no-change or fork PR. `mobile-build` is a `fail-fast: false` matrix (Android/iOS/Windows), so one failed leg fails the job and skips the check.

| mobile-build | build-size-ios | build-size-macos | build-size-check |
|---|---|---|---|
| success | success | success | **runs** |
| success | skipped | success | skipped |
| success | failed | success | skipped |
| skipped | skipped | skipped | skipped |

**How the gate decides** `ci-gate` checks two things, because a skipped `build-size-check` can't tell a broken build from a no-op:
- `mobile-build`, `build-size-ios`, `build-size-macos` directly catch broken builds.
- `build-size-check` catches over-budget builds (it's the only job that measures and calls `setFailed`).
- `skipped` passes, so no-change PRs are clean.

## Test plan

- [x] Trigger `workflow_dispatch` on `main` to get real numbers (written to the job summary)
- [ ] Set `baselineBytes` and `maxBytes` per platform and commit to `main`
- [ ] Open a test PR, confirm the comment appears and updates in place on re-run
- [ ] Confirm a PR exceeding `maxBytes` is blocked

Closes SDK-540

🤖 Generated with [Claude Code](https://claude.com/claude-code)
