### PR TITLE
docs(audience): clarify Windows and Linux are 64-bit only

### DIFF
--- a/src/Packages/Audience/README.md
+++ b/src/Packages/Audience/README.md
@@ -14,7 +14,7 @@ https://github.com/immutable/unity-immutable-sdk.git?path=src/Packages/Audience#
 
 For reproducible builds, replace `#main` with a release tag or a specific commit SHA.
 
-Requires Unity 2021.3 or later. Works under Mono and IL2CPP.
+Requires Unity 2021.3 or later. Works under Mono and IL2CPP. Supported platforms: Android, iOS, Windows 10+ (64-bit), macOS, Linux (64-bit).
 
 ## First event
 


### PR DESCRIPTION
Audience SDK asmdef restricts to `WindowsStandalone64` and `LinuxStandalone64` — 32-bit builds silently fail with CS0246. Adds supported platform list to the README install section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)