### PR TITLE
Set Audience SDK build size baselines and limits

### DIFF
--- a/.github/audience-build-budget.json
+++ b/.github/audience-build-budget.json
@@ -1,9 +1,8 @@
 {
-  "note": "Baselines and limits must be set after the first run on main (workflow_dispatch). Set baselineBytes to the measured size, maxBytes to a comfortable ceiling (e.g. measured + 10 MB). A maxBytes of 0 means no limit is enforced for that platform.",
   "platforms": {
-    "Android": { "baselineBytes": 0, "maxBytes": 0 },
-    "iOS":     { "baselineBytes": 0, "maxBytes": 0 },
-    "Windows": { "baselineBytes": 0, "maxBytes": 0 },
-    "macOS":   { "baselineBytes": 0, "maxBytes": 0 }
+    "Android": { "emptyAppBytes": 22283581, "baselineBytes": 22662981, "maxBytes": 43255101 },
+    "iOS":     { "emptyAppBytes": 40651984, "baselineBytes": 49583841, "maxBytes": 61623504 },
+    "Windows": { "emptyAppBytes": 53708485, "baselineBytes": 53877292, "maxBytes": 74680005 },
+    "macOS":   { "emptyAppBytes": 95371892, "baselineBytes": 96318267, "maxBytes": 116343412 }
   }
 }

--- a/.github/workflows/test-audience-sample-app.yml
+++ b/.github/workflows/test-audience-sample-app.yml
@@ -464,30 +464,30 @@ jobs:
 
             let anyFail = false;
             const mb = n => (n / 1048576).toFixed(2);
+            const sign = n => { const r = parseFloat(mb(n)); return (r < 0 ? '-' : '+') + mb(Math.abs(n)) + ' MB'; };
             const rows = Object.entries(measured).map(([plat, bytes]) => {
-              const { baselineBytes, maxBytes } = budget.platforms[plat];
-              const delta = bytes - baselineBytes;
-              const sign = delta >= 0 ? '+' : '';
+              const { baselineBytes, maxBytes, emptyAppBytes } = budget.platforms[plat];
+              const sdkBytes = emptyAppBytes > 0 ? bytes - emptyAppBytes : null;
+              const change = bytes - baselineBytes;
               const limited = maxBytes > 0;
               const pass = !limited || bytes <= maxBytes;
               if (!pass) anyFail = true;
               const status = !limited ? '—' : pass ? '✅' : '❌';
-              return `| ${plat} | ${mb(bytes)} MB | ${sign}${mb(delta)} MB | ${status} |`;
+              const maxSdkBytes = limited && emptyAppBytes > 0 ? maxBytes - emptyAppBytes : null;
+              const sdkCol = sdkBytes !== null
+                ? (maxSdkBytes !== null ? `${mb(sdkBytes)} / ${mb(maxSdkBytes)} MB` : `${mb(sdkBytes)} MB`)
+                : '—';
+              return `| ${plat} | ${sdkCol} | ${sign(change)} | ${status} |`;
             });
-
-            const limitsSet = Object.values(budget.platforms).some(p => p.maxBytes > 0);
-            const footer = limitsSet
-              ? 'Fails if any platform exceeds its absolute size limit.'
-              : '_No size limits set yet. Set baselineBytes and maxBytes in `.github/audience-build-budget.json`._';
 
             const body = [
               '## Audience SDK — Build Size',
               '',
-              '| Platform | Build Size | vs Baseline | |',
+              '| Platform | SDK Size | Change | |',
               '|---|---|---|---|',
               ...rows,
               '',
-              footer,
+              'SDK Size = build minus empty app. Change = vs baseline. Fails if any platform exceeds its absolute size limit.',
             ].join('\n');
 
             if (context.eventName === 'pull_request') {


### PR DESCRIPTION
Sets build size baselines and limits in `.github/audience-build-budget.json` and restructures the PR size comment to focus on SDK footprint rather than total app size.

The comment now shows SDK Size (build minus empty app) and Change (delta vs baseline), so reviewers see exactly what the SDK itself weighs and whether a PR grew or shrunk it.