### PR TITLE
feat(audience): stamp consentLevel on Unity SDK messages

### DIFF
--- a/src/Packages/Audience/Runtime/Core/Constants.cs
+++ b/src/Packages/Audience/Runtime/Core/Constants.cs
@@ -53,6 +53,7 @@ namespace Immutable.Audience
         internal const string Type = "type";
         internal const string UserId = "userId";
         internal const string DeviceId = "deviceId";
+        internal const string ConsentLevel = "consentLevel";
     }
 
     /// <summary>

--- a/src/Packages/Audience/Runtime/Events/MessageBuilder.cs
+++ b/src/Packages/Audience/Runtime/Events/MessageBuilder.cs
@@ -13,10 +13,11 @@ namespace Immutable.Audience
             string? userId,
             string? deviceId,
             string packageVersion,
+            string consentLevel,
             Dictionary<string, object>? properties = null,
             bool testMode = false)
         {
-            var msg = BuildBase(MessageTypes.Track, packageVersion, testMode);
+            var msg = BuildBase(MessageTypes.Track, packageVersion, consentLevel, testMode);
             msg["eventName"] = Truncate(eventName, Constants.MaxFieldLength);
 
             if (!string.IsNullOrEmpty(anonymousId))
@@ -43,10 +44,11 @@ namespace Immutable.Audience
             string? deviceId,
             string identityType,
             string packageVersion,
+            string consentLevel,
             Dictionary<string, object>? traits = null,
             bool testMode = false)
         {
-            var msg = BuildBase(MessageTypes.Identify, packageVersion, testMode);
+            var msg = BuildBase(MessageTypes.Identify, packageVersion, consentLevel, testMode);
 
             if (!string.IsNullOrEmpty(anonymousId))
                 msg["anonymousId"] = Truncate(anonymousId, Constants.MaxFieldLength);
@@ -75,9 +77,10 @@ namespace Immutable.Audience
             string toType,
             string? deviceId,
             string packageVersion,
+            string consentLevel,
             bool testMode = false)
         {
-            var msg = BuildBase(MessageTypes.Alias, packageVersion, testMode);
+            var msg = BuildBase(MessageTypes.Alias, packageVersion, consentLevel, testMode);
             msg["fromId"] = Truncate(fromId, Constants.MaxFieldLength);
             msg["fromType"] = Truncate(fromType, Constants.MaxFieldLength);
             msg["toId"] = Truncate(toId, Constants.MaxFieldLength);
@@ -89,7 +92,8 @@ namespace Immutable.Audience
             return msg;
         }
 
-        private static Dictionary<string, object> BuildBase(string type, string packageVersion, bool testMode)
+        private static Dictionary<string, object> BuildBase(
+            string type, string packageVersion, string consentLevel, bool testMode)
         {
             var msg = new Dictionary<string, object>
             {
@@ -101,7 +105,14 @@ namespace Immutable.Audience
                     ["library"] = Constants.LibraryName,
                     ["libraryVersion"] = Truncate(packageVersion, Constants.MaxFieldLength)
                 },
-                ["surface"] = Constants.Surface
+                ["surface"] = Constants.Surface,
+                // Consent level under which this event was collected. Stamped so
+                // the backend records the explicit level rather than inferring it
+                // from userId presence (which can't tell full-but-unidentified
+                // traffic from anonymous). Callers only build messages under a
+                // decided level (anonymous/full); none-consent events are never
+                // emitted.
+                [MessageFields.ConsentLevel] = consentLevel
             };
             if (testMode)
                 msg["test"] = true;

--- a/src/Packages/Audience/Runtime/Events/MessageBuilder.cs
+++ b/src/Packages/Audience/Runtime/Events/MessageBuilder.cs
@@ -106,12 +106,6 @@ namespace Immutable.Audience
                     ["libraryVersion"] = Truncate(packageVersion, Constants.MaxFieldLength)
                 },
                 ["surface"] = Constants.Surface,
-                // Consent level under which this event was collected. Stamped so
-                // the backend records the explicit level rather than inferring it
-                // from userId presence (which can't tell full-but-unidentified
-                // traffic from anonymous). Callers only build messages under a
-                // decided level (anonymous/full); none-consent events are never
-                // emitted.
                 [MessageFields.ConsentLevel] = consentLevel
             };
             if (testMode)

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -1019,9 +1019,6 @@ namespace Immutable.Audience
             {
                 var state = _state;
                 if (!state.Level.CanTrack()) return null;
-                // Re-stamp under the drain lock so consentLevel reflects the level
-                // at enqueue time, not the (possibly higher) level when the message
-                // was built — the userId strip below relies on the same check.
                 m[MessageFields.ConsentLevel] = state.Level.ToLowercaseString();
                 if (state.Level != ConsentLevel.Full)
                     m.Remove(MessageFields.UserId);

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -354,7 +354,8 @@ namespace Immutable.Audience
             var deviceId = Identity.GetOrCreateDeviceId(config.PersistentDataPath!, state.Level);
             // ToProperties returns a fresh dict per call, so no snapshot needed.
             var userId = state.Level == ConsentLevel.Full ? state.UserId : null;
-            var msg = MessageBuilder.Track(eventName, anonymousId, userId, deviceId, Constants.LibraryVersion, properties, config.TestMode);
+            var msg = MessageBuilder.Track(eventName, anonymousId, userId, deviceId, Constants.LibraryVersion,
+                state.Level.ToLowercaseString(), properties, config.TestMode);
             EnqueueTrack(msg);
         }
 
@@ -382,7 +383,7 @@ namespace Immutable.Audience
             var deviceId = Identity.GetOrCreateDeviceId(config.PersistentDataPath!, state.Level);
             var userId = state.Level == ConsentLevel.Full ? state.UserId : null;
             var msg = MessageBuilder.Track(eventName, anonymousId, userId, deviceId, Constants.LibraryVersion,
-                SnapshotCallerDict(properties), config.TestMode);
+                state.Level.ToLowercaseString(), SnapshotCallerDict(properties), config.TestMode);
             EnqueueTrack(msg);
         }
 
@@ -429,7 +430,7 @@ namespace Immutable.Audience
             var anonymousId = Identity.GetOrCreate(config.PersistentDataPath!, level);
             var deviceId = Identity.GetOrCreateDeviceId(config.PersistentDataPath!, level);
             var msg = MessageBuilder.Identify(anonymousId, userId, deviceId, identityType.ToLowercaseString(),
-                Constants.LibraryVersion, SnapshotCallerDict(traits), config.TestMode);
+                Constants.LibraryVersion, level.ToLowercaseString(), SnapshotCallerDict(traits), config.TestMode);
             EnqueueIdentity(msg);
         }
 
@@ -461,7 +462,7 @@ namespace Immutable.Audience
 
             var deviceId = Identity.GetOrCreateDeviceId(config.PersistentDataPath!, state.Level);
             var msg = MessageBuilder.Alias(fromId, fromType.ToLowercaseString(), toId, toType.ToLowercaseString(),
-                deviceId, Constants.LibraryVersion, config.TestMode);
+                deviceId, Constants.LibraryVersion, state.Level.ToLowercaseString(), config.TestMode);
             EnqueueIdentity(msg);
         }
 
@@ -1018,6 +1019,10 @@ namespace Immutable.Audience
             {
                 var state = _state;
                 if (!state.Level.CanTrack()) return null;
+                // Re-stamp under the drain lock so consentLevel reflects the level
+                // at enqueue time, not the (possibly higher) level when the message
+                // was built — the userId strip below relies on the same check.
+                m[MessageFields.ConsentLevel] = state.Level.ToLowercaseString();
                 if (state.Level != ConsentLevel.Full)
                     m.Remove(MessageFields.UserId);
                 return m;

--- a/src/Packages/Audience/Runtime/Transport/DiskStore.cs
+++ b/src/Packages/Audience/Runtime/Transport/DiskStore.cs
@@ -147,7 +147,7 @@ namespace Immutable.Audience
                 return;
             }
 
-            if (type == MessageTypes.Track && TrackNeedsDowngrade(msg))
+            if (type == MessageTypes.Track && TrackNeedsDowngradeToAnonymous(msg))
                 RewriteTrackForAnonymous(path, msg);
         }
 
@@ -155,7 +155,7 @@ namespace Immutable.Audience
         // still carries a userId or a consentLevel other than "anonymous". The
         // check keeps already-anonymous messages untouched so a fail-closed
         // rewrite error can only ever discard events that actually had to change.
-        private static bool TrackNeedsDowngrade(Dictionary<string, object> msg)
+        private static bool TrackNeedsDowngradeToAnonymous(Dictionary<string, object> msg)
         {
             if (msg.ContainsKey(MessageFields.UserId)) return true;
             return !(msg.TryGetValue(MessageFields.ConsentLevel, out var cl)
@@ -183,9 +183,6 @@ namespace Immutable.Audience
         private void RewriteTrackForAnonymous(string path, Dictionary<string, object> msg)
         {
             msg.Remove(MessageFields.UserId);
-            // Normalise the stamped consent so a downgraded event never still
-            // reports "full"; also covers events persisted before consentLevel
-            // existed (they gain "anonymous" rather than staying unset).
             msg[MessageFields.ConsentLevel] = ConsentLevel.Anonymous.ToLowercaseString();
 
             try

--- a/src/Packages/Audience/Runtime/Transport/DiskStore.cs
+++ b/src/Packages/Audience/Runtime/Transport/DiskStore.cs
@@ -147,8 +147,20 @@ namespace Immutable.Audience
                 return;
             }
 
-            if (type == MessageTypes.Track && msg.ContainsKey(MessageFields.UserId))
-                RewriteTrackWithoutUserId(path, msg);
+            if (type == MessageTypes.Track && TrackNeedsDowngrade(msg))
+                RewriteTrackForAnonymous(path, msg);
+        }
+
+        // A queued track needs rewriting on a Full -> Anonymous downgrade if it
+        // still carries a userId or a consentLevel other than "anonymous". The
+        // check keeps already-anonymous messages untouched so a fail-closed
+        // rewrite error can only ever discard events that actually had to change.
+        private static bool TrackNeedsDowngrade(Dictionary<string, object> msg)
+        {
+            if (msg.ContainsKey(MessageFields.UserId)) return true;
+            return !(msg.TryGetValue(MessageFields.ConsentLevel, out var cl)
+                     && cl is string s
+                     && s == ConsentLevel.Anonymous.ToLowercaseString());
         }
 
         private static bool IsIdentityMessage(string type) =>
@@ -168,9 +180,13 @@ namespace Immutable.Audience
             return true;
         }
 
-        private void RewriteTrackWithoutUserId(string path, Dictionary<string, object> msg)
+        private void RewriteTrackForAnonymous(string path, Dictionary<string, object> msg)
         {
             msg.Remove(MessageFields.UserId);
+            // Normalise the stamped consent so a downgraded event never still
+            // reports "full"; also covers events persisted before consentLevel
+            // existed (they gain "anonymous" rather than staying unset).
+            msg[MessageFields.ConsentLevel] = ConsentLevel.Anonymous.ToLowercaseString();
 
             try
             {

--- a/src/Packages/Audience/Tests/Runtime/Events/MessageBuilderTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Events/MessageBuilderTests.cs
@@ -11,11 +11,12 @@ namespace Immutable.Audience.Tests
         private const string PackageVersion = "1.2.3";
         private const string AnonId = "anon-1";
         private const string DeviceId = "device-1";
+        private const string Consent = "anonymous";
 
         [Test]
         public void Track_RequiredFieldsPresent()
         {
-            var result = MessageBuilder.Track("level_complete", AnonId, null, null, PackageVersion);
+            var result = MessageBuilder.Track("level_complete", AnonId, null, null, PackageVersion, Consent);
 
             Assert.AreEqual("track", result["type"]);
             Assert.IsTrue(result.ContainsKey("messageId"));
@@ -30,7 +31,7 @@ namespace Immutable.Audience.Tests
         {
             var longName = new string('x', 300);
 
-            var result = MessageBuilder.Track(longName, null, null, null, PackageVersion);
+            var result = MessageBuilder.Track(longName, null, null, null, PackageVersion, Consent);
 
             Assert.AreEqual(256, ((string)result["eventName"]).Length);
         }
@@ -38,7 +39,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Track_NullUserId_NotPresentInDict()
         {
-            var result = MessageBuilder.Track("evt", AnonId, null, null, PackageVersion);
+            var result = MessageBuilder.Track("evt", AnonId, null, null, PackageVersion, Consent);
 
             Assert.IsFalse(result.ContainsKey("userId"));
         }
@@ -46,7 +47,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Track_NonNullUserId_PresentInDict()
         {
-            var result = MessageBuilder.Track("evt", AnonId, "user-99", null, PackageVersion);
+            var result = MessageBuilder.Track("evt", AnonId, "user-99", null, PackageVersion, Consent);
 
             Assert.IsTrue(result.ContainsKey("userId"));
             Assert.AreEqual("user-99", result["userId"]);
@@ -55,7 +56,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Track_DeviceId_PresentWhenProvided()
         {
-            var result = MessageBuilder.Track("evt", AnonId, null, DeviceId, PackageVersion);
+            var result = MessageBuilder.Track("evt", AnonId, null, DeviceId, PackageVersion, Consent);
 
             Assert.IsTrue(result.ContainsKey("deviceId"));
             Assert.AreEqual(DeviceId, result["deviceId"]);
@@ -64,7 +65,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Track_DeviceId_AbsentWhenNull()
         {
-            var result = MessageBuilder.Track("evt", AnonId, null, null, PackageVersion);
+            var result = MessageBuilder.Track("evt", AnonId, null, null, PackageVersion, Consent);
 
             Assert.IsFalse(result.ContainsKey("deviceId"));
         }
@@ -72,7 +73,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Identify_TypeAndIdentityFieldsPresent()
         {
-            var result = MessageBuilder.Identify("anon-42", "user-42", null, "steam", PackageVersion);
+            var result = MessageBuilder.Identify("anon-42", "user-42", null, "steam", PackageVersion, "full");
 
             Assert.AreEqual("identify", result["type"]);
             Assert.AreEqual("anon-42", result["anonymousId"]);
@@ -83,7 +84,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Identify_DeviceId_PresentWhenProvided()
         {
-            var result = MessageBuilder.Identify("anon-42", "user-42", DeviceId, "steam", PackageVersion);
+            var result = MessageBuilder.Identify("anon-42", "user-42", DeviceId, "steam", PackageVersion, "full");
 
             Assert.IsTrue(result.ContainsKey("deviceId"));
             Assert.AreEqual(DeviceId, result["deviceId"]);
@@ -92,7 +93,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Alias_AllFourFieldsPresent()
         {
-            var result = MessageBuilder.Alias("from-id", "email", "to-id", "steam", null, PackageVersion);
+            var result = MessageBuilder.Alias("from-id", "email", "to-id", "steam", null, PackageVersion, "full");
 
             Assert.AreEqual("alias", result["type"]);
             Assert.AreEqual("from-id", result["fromId"]);
@@ -104,7 +105,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Alias_DeviceId_PresentWhenProvided()
         {
-            var result = MessageBuilder.Alias("from-id", "email", "to-id", "steam", DeviceId, PackageVersion);
+            var result = MessageBuilder.Alias("from-id", "email", "to-id", "steam", DeviceId, PackageVersion, "full");
 
             Assert.IsTrue(result.ContainsKey("deviceId"));
             Assert.AreEqual(DeviceId, result["deviceId"]);
@@ -113,9 +114,9 @@ namespace Immutable.Audience.Tests
         [Test]
         public void AllMessages_ContextContainsLibraryAndLibraryVersion()
         {
-            var track = MessageBuilder.Track("evt", null, null, null, PackageVersion);
-            var identify = MessageBuilder.Identify(null, "u1", null, "steam", PackageVersion);
-            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", null, PackageVersion);
+            var track = MessageBuilder.Track("evt", null, null, null, PackageVersion, Consent);
+            var identify = MessageBuilder.Identify(null, "u1", null, "steam", PackageVersion, "full");
+            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", null, PackageVersion, "full");
 
             foreach (var msg in new[] { track, identify, alias })
             {
@@ -128,13 +129,39 @@ namespace Immutable.Audience.Tests
         [Test]
         public void AllMessages_SurfaceIsUnity()
         {
-            var track = MessageBuilder.Track("evt", null, null, null, PackageVersion);
-            var identify = MessageBuilder.Identify(null, "u1", null, "steam", PackageVersion);
-            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", null, PackageVersion);
+            var track = MessageBuilder.Track("evt", null, null, null, PackageVersion, Consent);
+            var identify = MessageBuilder.Identify(null, "u1", null, "steam", PackageVersion, "full");
+            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", null, PackageVersion, "full");
 
             Assert.AreEqual("unity", track["surface"]);
             Assert.AreEqual("unity", identify["surface"]);
             Assert.AreEqual("unity", alias["surface"]);
+        }
+
+        [Test]
+        public void AllMessages_ConsentLevelStamped()
+        {
+            // Every message carries the consent level it was built under, so the
+            // backend records the explicit level instead of inferring it.
+            var track = MessageBuilder.Track("evt", null, null, null, PackageVersion, "anonymous");
+            var identify = MessageBuilder.Identify(null, "u1", null, "steam", PackageVersion, "full");
+            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", null, PackageVersion, "full");
+
+            Assert.AreEqual("anonymous", track["consentLevel"]);
+            Assert.AreEqual("full", identify["consentLevel"]);
+            Assert.AreEqual("full", alias["consentLevel"]);
+        }
+
+        [Test]
+        public void Track_ConsentLevelFull_NoUserId_IsFullButUnidentified()
+        {
+            // Full consent does not require a userId (e.g. before Identify()); the
+            // explicit consentLevel is exactly what distinguishes this from
+            // anonymous traffic.
+            var result = MessageBuilder.Track("evt", AnonId, null, null, PackageVersion, "full");
+
+            Assert.AreEqual("full", result["consentLevel"]);
+            Assert.IsFalse(result.ContainsKey("userId"));
         }
 
         [Test]
@@ -154,7 +181,7 @@ namespace Immutable.Audience.Tests
             // Backend deduplicates on messageId; collisions silently drop events.
             var ids = new HashSet<string>();
             for (var i = 0; i < 1000; i++)
-                ids.Add((string)MessageBuilder.Track("evt", null, null, null, PackageVersion)["messageId"]);
+                ids.Add((string)MessageBuilder.Track("evt", null, null, null, PackageVersion, Consent)["messageId"]);
             Assert.AreEqual(1000, ids.Count);
         }
 
@@ -196,7 +223,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Track_TestModeTrue_IncludesTestFlag()
         {
-            var result = MessageBuilder.Track("evt", null, null, null, PackageVersion, testMode: true);
+            var result = MessageBuilder.Track("evt", null, null, null, PackageVersion, Consent, testMode: true);
             Assert.IsTrue(result.ContainsKey("test"), "test field must be present when testMode is true");
             Assert.AreEqual(true, result["test"]);
         }
@@ -204,16 +231,16 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Track_TestModeFalse_ExcludesTestFlag()
         {
-            var result = MessageBuilder.Track("evt", null, null, null, PackageVersion, testMode: false);
+            var result = MessageBuilder.Track("evt", null, null, null, PackageVersion, Consent, testMode: false);
             Assert.IsFalse(result.ContainsKey("test"), "test field must not be present when testMode is false");
         }
 
         [Test]
         public void AllMessages_TestModeTrue_AllIncludeTestFlag()
         {
-            var track = MessageBuilder.Track("evt", null, null, null, PackageVersion, testMode: true);
-            var identify = MessageBuilder.Identify(null, "u1", null, "steam", PackageVersion, testMode: true);
-            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", null, PackageVersion, testMode: true);
+            var track = MessageBuilder.Track("evt", null, null, null, PackageVersion, Consent, testMode: true);
+            var identify = MessageBuilder.Identify(null, "u1", null, "steam", PackageVersion, "full", testMode: true);
+            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", null, PackageVersion, "full", testMode: true);
 
             foreach (var msg in new[] { track, identify, alias })
             {
@@ -224,9 +251,9 @@ namespace Immutable.Audience.Tests
 
         private static IEnumerable<Dictionary<string, object>> EveryMessageType()
         {
-            yield return MessageBuilder.Track("evt", null, null, null, PackageVersion);
-            yield return MessageBuilder.Identify(null, "u1", null, "steam", PackageVersion);
-            yield return MessageBuilder.Alias("f", "t1", "t", "t2", null, PackageVersion);
+            yield return MessageBuilder.Track("evt", null, null, null, PackageVersion, Consent);
+            yield return MessageBuilder.Identify(null, "u1", null, "steam", PackageVersion, "full");
+            yield return MessageBuilder.Alias("f", "t1", "t", "t2", null, PackageVersion, "full");
         }
     }
 }

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -1976,7 +1976,11 @@ namespace Immutable.Audience.Tests
                 Assert.AreNotEqual("identify", type, "identify must be purged on Full -> Anonymous");
                 Assert.AreNotEqual("alias", type, "alias must be purged on Full -> Anonymous");
                 if (type == "track")
+                {
                     Assert.IsFalse(msg.ContainsKey("userId"), "userId must be stripped from queued track on Full -> Anonymous");
+                    Assert.AreEqual("anonymous", msg["consentLevel"],
+                        "consentLevel must be downgraded to anonymous on queued track");
+                }
             }
         }
 
@@ -2001,6 +2005,26 @@ namespace Immutable.Audience.Tests
             Assert.AreEqual(1, trackFiles.Count);
             Assert.IsFalse(trackFiles[0].ContainsKey("userId"),
                 "Track under Anonymous consent must not carry userId");
+            Assert.AreEqual("anonymous", trackFiles[0]["consentLevel"],
+                "Track under Anonymous consent must stamp consentLevel anonymous");
+        }
+
+        [Test]
+        public void FullConsent_TrackStampsConsentLevelFull()
+        {
+            ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
+            ImmutableAudience.Track("tracked_under_full");
+            ImmutableAudience.FlushQueueToDiskForTesting();
+
+            var queueDir = AudiencePaths.QueueDir(_testDir);
+            var track = Directory.GetFiles(queueDir, "*.json")
+                .Select(f => JsonReader.DeserializeObject(File.ReadAllText(f)))
+                .First(m => (string)m["type"] == "track"
+                            && m.ContainsKey("eventName")
+                            && (string)m["eventName"] == "tracked_under_full");
+
+            Assert.AreEqual("full", track["consentLevel"],
+                "Track under Full consent must stamp consentLevel full");
         }
 
         // -----------------------------------------------------------------

--- a/src/Packages/Audience/Tests/Runtime/Transport/DiskStoreTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Transport/DiskStoreTests.cs
@@ -166,8 +166,8 @@ namespace Immutable.Audience.Tests
         {
             _store.Write("{\"type\":\"identify\",\"anonymousId\":\"a\",\"userId\":\"u\"}");
             _store.Write("{\"type\":\"alias\",\"fromId\":\"a\",\"toId\":\"u\"}");
-            _store.Write("{\"type\":\"track\",\"eventName\":\"x\",\"anonymousId\":\"a\",\"userId\":\"u\"}");
-            _store.Write("{\"type\":\"track\",\"eventName\":\"y\",\"anonymousId\":\"a\"}");
+            _store.Write("{\"type\":\"track\",\"eventName\":\"x\",\"anonymousId\":\"a\",\"userId\":\"u\",\"consentLevel\":\"full\"}");
+            _store.Write("{\"type\":\"track\",\"eventName\":\"y\",\"anonymousId\":\"a\",\"consentLevel\":\"full\"}");
 
             _store.ApplyAnonymousDowngrade();
 
@@ -180,7 +180,26 @@ namespace Immutable.Audience.Tests
                 var msg = JsonReader.DeserializeObject(json);
                 Assert.AreEqual("track", msg["type"]);
                 Assert.IsFalse(msg.ContainsKey("userId"), "userId must be stripped from queued track messages");
+                // consentLevel must be normalised to anonymous, even for the track
+                // that never carried a userId (full-but-unidentified).
+                Assert.AreEqual("anonymous", msg["consentLevel"],
+                    "consentLevel must be downgraded to anonymous on queued track messages");
             }
+        }
+
+        [Test]
+        public void ApplyAnonymousDowngrade_TrackWithoutConsentLevel_GainsAnonymous()
+        {
+            // A track persisted by a pre-consentLevel build (no consentLevel field)
+            // is normalised to anonymous on downgrade rather than left unset.
+            _store.Write("{\"type\":\"track\",\"eventName\":\"legacy\",\"anonymousId\":\"a\"}");
+
+            _store.ApplyAnonymousDowngrade();
+
+            var remaining = _store.ReadBatch(10);
+            Assert.AreEqual(1, remaining.Count);
+            var msg = JsonReader.DeserializeObject(File.ReadAllText(remaining[0]));
+            Assert.AreEqual("anonymous", msg["consentLevel"]);
         }
 
         [Test]


### PR DESCRIPTION
## What

- Stamps the current consent level onto every Unity SDK message in `MessageBuilder.BuildBase()` (threaded through `Track`/`Identify`/`Alias`), serialized as `consentLevel` (`none`/`anonymous`/`full`) to match the API.
- On a `Full → Anonymous` downgrade, queued track messages now have `consentLevel` rewritten to `anonymous` alongside the existing `userId` strip — in both the in-memory `EnqueueChecked` transform and the on-disk `DiskStore` rewrite. The disk rewrite also normalises events persisted before `consentLevel` existed.

## Why

Consent level is being plumbed end-to-end through the pipeline (SDK → audience ingest → attribution → postbacks) as part of SDK-449. Attribution currently *infers* consent from the presence of a `userId`, which cannot distinguish full-but-unidentified traffic from genuinely anonymous traffic. Sending the decided level explicitly lets the backend record provenance rather than guess.

This is the Unity half of SDK-565, mirroring the web/pixel SDK change (ts-immutable-sdk) and the audience-service ingest/derivation side (SDK-554, already landed and accepting the field as optional). Non-breaking, forward-compatible.

Notes:
- Every build/enqueue path is consent-guarded (`CanTrack`/`CanIdentify`), so the stamped level is always a decided, sendable value (`anonymous`/`full`) — never `none`. Unity's `ConsentLevel` enum has no `not_set` (which the API rejects), so it can never be emitted.
- The `EnqueueChecked` transform re-stamps under the drain lock so `consentLevel` reflects consent at enqueue time, closing the build→enqueue race the same way the existing `userId` strip does.

## End-to-end validation (dev)

Ran the **audience sample app** against the dev environment and drove the consent flow (init full, identify, downgrade to anonymous). Confirmed in BigQuery (`dev-im-cdp.cdp_raw.events`) that every event emitted by this SDK carries `consent_level`, and can be identified as Unity traffic via `surface = 'unity'` (`context.library = com.immutable.audience`):

```
▶ bq query --project_id=dev-im-cdp --use_legacy_sql=false '
SELECT
  publish_time,
  JSON_VALUE(data, "$.type")                   AS type,
  JSON_VALUE(data, "$.eventName")              AS event_name,
  JSON_VALUE(data, "$.surface")                AS surface,
  JSON_VALUE(data, "$.context.library")        AS library,
  JSON_VALUE(data, "$.context.libraryVersion") AS library_version,
  JSON_VALUE(data, "$.anonymous_id")           AS anonymous_id,
  JSON_VALUE(data, "$.user_id")                AS user_id,
  JSON_VALUE(data, "$.consent_level")          AS consent_level,
  JSON_VALUE(data, "$.test")                   AS test
FROM `dev-im-cdp.cdp_raw.events`
WHERE JSON_VALUE(data, "$.anonymous_id") = "b2dca53a-9608-4e05-84b4-d35c13d8e76d"
ORDER BY publish_time DESC
LIMIT 100;'
Waiting on bqjob_r34ba1b3e1dd9c92_0000019f209c0245_1 ... (0s) Current status: DONE   
+---------------------+----------+------------+---------+------------------------+-----------------+--------------------------------------+---------+---------------+------+
|    publish_time     |   type   | event_name | surface |        library         | library_version |             anonymous_id             | user_id | consent_level | test |
+---------------------+----------+------------+---------+------------------------+-----------------+--------------------------------------+---------+---------------+------+
| 2026-07-02 02:13:44 | track    | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | NULL    | anonymous     | true |
| 2026-07-02 02:13:44 | track    | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | NULL    | anonymous     | true |
| 2026-07-02 02:13:43 | track    | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | NULL    | anonymous     | true |
| 2026-07-02 02:13:43 | track    | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | NULL    | anonymous     | true |
| 2026-07-02 02:13:08 | track    | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | john    | full          | true |
| 2026-07-02 02:13:08 | track    | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | john    | full          | true |
| 2026-07-02 02:12:08 | track    | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | john    | full          | true |
| 2026-07-02 02:12:07 | track    | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | john    | full          | true |
| 2026-07-02 02:12:07 | track    | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | john    | full          | true |
| 2026-07-02 02:12:07 | track    | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | john    | full          | true |
| 2026-07-02 02:12:07 | track    | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | john    | full          | true |
| 2026-07-02 02:11:52 | identify | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | john    | full          | true |
| 2026-07-02 02:11:27 | track    | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | NULL    | full          | true |
| 2026-07-02 02:11:27 | track    | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | NULL    | full          | true |
| 2026-07-02 02:11:27 | track    | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | NULL    | full          | true |
| 2026-07-02 02:11:17 | track    | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | NULL    | full          | true |
| 2026-07-02 02:11:12 | track    | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | NULL    | full          | true |
| 2026-07-02 02:11:12 | track    | NULL       | unity   | com.immutable.audience | 0.5.0           | b2dca53a-9608-4e05-84b4-d35c13d8e76d | NULL    | full          | true |
+---------------------+----------+------------+---------+------------------------+-----------------+--------------------------------------+---------+---------------+------+
```