### PR TITLE
fix(audience): backdate session_end timestamp to when the session actually ended

### DIFF
--- a/src/Packages/Audience/Runtime/Core/Session.cs
+++ b/src/Packages/Audience/Runtime/Core/Session.cs
@@ -9,7 +9,8 @@ namespace Immutable.Audience
     // Fires a session event (session_start / session_heartbeat / session_end)
     // through ImmutableAudience.TrackFromSession. Declared as a named delegate so
     // Session can be driven by tests with a mock without touching the static SDK surface.
-    internal delegate void TrackDelegate(string eventName, Dictionary<string, object> properties, string sessionId);
+    // timestampOverride backdates the wire eventTimestamp; null means "now".
+    internal delegate void TrackDelegate(string eventName, Dictionary<string, object> properties, string sessionId, DateTime? timestampOverride = null);
 
     // Unity session lifecycle. Emits session_start / session_heartbeat / session_end.
     // duration is engagement time (excludes pause). The heartbeat runs on a
@@ -123,11 +124,13 @@ namespace Immutable.Audience
         internal void Resume()
         {
             bool extended;
+            DateTime pausedAt;
             lock (_lock)
             {
                 if (_disposed || _sessionId == null || _pausedAt == null) return;
 
-                var pauseDuration = _getUtcNow() - _pausedAt.Value;
+                pausedAt = _pausedAt.Value;
+                var pauseDuration = _getUtcNow() - pausedAt;
                 _pausedAt = null;
 
                 // Clamp: wall-clock rewind (NTP) would otherwise over-credit engagement.
@@ -144,14 +147,21 @@ namespace Immutable.Audience
             {
                 // Extended pause: roll the session. End/Start fire _track outside _lock.
                 // Between End and Start other public methods early-return on _sessionId=null.
-                End();
+                // pausedAt: Resume can run long after backgrounding actually began.
+                // This corrects the pause that triggers rollover; it does not
+                // adjust for earlier short (<=30s) pauses this session, so
+                // duration_sec remains the only field with zero pause skew.
+                End(pausedAt);
                 Start();
             }
         }
 
         // Ends the session. Drains heartbeat before emitting session_end so wire
         // order holds (drain timeout is best-effort; logs a warning on timeout).
-        internal void End()
+        // endedAt backdates the event timestamp; pass null to fall back to
+        // _pausedAt (if the session is currently paused, e.g. Dispose while
+        // backgrounded) or current time.
+        internal void End(DateTime? endedAt = null)
         {
             // Phase 1: drain outside _lock (OnHeartbeat re-enters _lock).
             DrainHeartbeatTimer();
@@ -159,6 +169,7 @@ namespace Immutable.Audience
             // Phase 2: capture fields and reset so subsequent Start/Dispose sees clean state.
             string sessionId;
             long duration;
+            DateTime? effectiveEndedAt;
             lock (_lock)
             {
                 if (_sessionId == null) return;
@@ -166,6 +177,8 @@ namespace Immutable.Audience
 
                 // ComputeEngagedSecondsLocked folds in the live pause.
                 duration = ComputeEngagedSecondsLocked();
+                // Read _pausedAt before ResetSessionStateLocked clears it.
+                effectiveEndedAt = endedAt ?? _pausedAt;
                 ResetSessionStateLocked();
             }
 
@@ -175,7 +188,7 @@ namespace Immutable.Audience
             {
                 ["session_id"] = sessionId,
                 ["duration_sec"] = duration
-            }, sessionId);
+            }, sessionId, effectiveEndedAt);
         }
 
         // Emits session_end and seals the session without draining the heartbeat
@@ -188,11 +201,15 @@ namespace Immutable.Audience
         {
             string sessionId;
             long duration;
+            DateTime? endedAt;
             lock (_lock)
             {
                 if (_disposed || _sessionId == null) return;
                 sessionId = _sessionId!;
                 duration = ComputeEngagedSecondsLocked();
+                // Backdate to _pausedAt if Shutdown fires while backgrounded,
+                // same as End()'s extended-pause path.
+                endedAt = _pausedAt;
                 ResetSessionStateLocked();
             }
 
@@ -203,7 +220,7 @@ namespace Immutable.Audience
             {
                 ["session_id"] = sessionId,
                 ["duration_sec"] = duration
-            }, sessionId);
+            }, sessionId, endedAt);
         }
 
         public void Dispose()
@@ -254,11 +271,11 @@ namespace Immutable.Audience
         // Heartbeat runs on a background timer, where an uncaught exception
         // crashes the game on modern .NET. Start / End run on the caller's
         // thread, where it would bubble into Init / Shutdown.
-        private void SafeTrack(string eventName, Dictionary<string, object> properties, string sessionId)
+        private void SafeTrack(string eventName, Dictionary<string, object> properties, string sessionId, DateTime? timestampOverride = null)
         {
             try
             {
-                _track(eventName, properties, sessionId);
+                _track(eventName, properties, sessionId, timestampOverride);
             }
             catch (Exception ex)
             {

--- a/src/Packages/Audience/Runtime/Events/MessageBuilder.cs
+++ b/src/Packages/Audience/Runtime/Events/MessageBuilder.cs
@@ -16,9 +16,10 @@ namespace Immutable.Audience
             string consentLevel,
             Dictionary<string, object>? properties = null,
             string? sessionId = null,
-            bool testMode = false)
+            bool testMode = false,
+            DateTime? eventTimestamp = null)
         {
-            var msg = BuildBase(MessageTypes.Track, packageVersion, consentLevel, testMode);
+            var msg = BuildBase(MessageTypes.Track, packageVersion, consentLevel, testMode, eventTimestamp);
             msg["eventName"] = Truncate(eventName, Constants.MaxFieldLength);
 
             if (!string.IsNullOrEmpty(anonymousId))
@@ -105,13 +106,15 @@ namespace Immutable.Audience
         }
 
         private static Dictionary<string, object> BuildBase(
-            string type, string packageVersion, string consentLevel, bool testMode)
+            string type, string packageVersion, string consentLevel, bool testMode, DateTime? eventTimestamp = null)
         {
             var msg = new Dictionary<string, object>
             {
                 [MessageFields.Type] = type,
                 ["messageId"] = Guid.NewGuid().ToString(),
-                ["eventTimestamp"] = DateTime.UtcNow.ToString("o"),
+                // ToUniversalTime guards against a caller passing Local/Unspecified;
+                // "o" only round-trips as UTC when Kind is actually Utc.
+                ["eventTimestamp"] = (eventTimestamp ?? DateTime.UtcNow).ToUniversalTime().ToString("o"),
                 ["context"] = new Dictionary<string, object>
                 {
                     ["library"] = Constants.LibraryName,

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -383,26 +383,27 @@ namespace Immutable.Audience
             Dictionary<string, object>? properties,
             string? sessionId,
             ConsentState state,
-            AudienceConfig config)
+            AudienceConfig config,
+            DateTime? timestampOverride = null)
         {
             var anonymousId = Identity.GetOrCreate(config.PersistentDataPath!, state.Level);
             var deviceId = Identity.GetOrCreateDeviceId(config.PersistentDataPath!, state.Level);
             var userId = state.Level == ConsentLevel.Full ? state.UserId : null;
             var msg = MessageBuilder.Track(eventName, anonymousId, userId, deviceId, Constants.LibraryVersion,
-                state.Level.ToLowercaseString(), properties, sessionId, config.TestMode);
+                state.Level.ToLowercaseString(), properties, sessionId, config.TestMode, timestampOverride);
             EnqueueTrack(msg);
         }
 
         // Bound to Session's TrackDelegate. sessionId is the value Session already
         // captured locally before any state reset, not read live from _session
         // (End() nulls the live session id before this fires for session_end).
-        private static void TrackFromSession(string eventName, Dictionary<string, object> properties, string sessionId)
+        private static void TrackFromSession(string eventName, Dictionary<string, object> properties, string sessionId, DateTime? timestampOverride = null)
         {
             var state = _state;
             if (!_initialized || !state.Level.CanTrack()) return;
             var config = _config;
             if (config == null) return;
-            EnqueueTrackedEvent(eventName, properties, sessionId, state, config);
+            EnqueueTrackedEvent(eventName, properties, sessionId, state, config, timestampOverride);
         }
 
         // -----------------------------------------------------------------

--- a/src/Packages/Audience/Tests/Runtime/Core/SessionTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Core/SessionTests.cs
@@ -10,17 +10,17 @@ namespace Immutable.Audience.Tests
     [TestFixture]
     internal class SessionTests
     {
-        private List<(string name, Dictionary<string, object> props)> _events;
+        private List<(string name, Dictionary<string, object> props, DateTime? timestampOverride)> _events;
 
         [SetUp]
         public void SetUp()
         {
-            _events = new List<(string, Dictionary<string, object>)>();
+            _events = new List<(string, Dictionary<string, object>, DateTime?)>();
         }
 
-        private void MockTrack(string name, Dictionary<string, object> props, string sessionId)
+        private void MockTrack(string name, Dictionary<string, object> props, string sessionId, DateTime? timestampOverride = null)
         {
-            _events.Add((name, props));
+            _events.Add((name, props, timestampOverride));
         }
 
         // -----------------------------------------------------------------
@@ -80,6 +80,30 @@ namespace Immutable.Audience.Tests
         }
 
         [Test]
+        public void Dispose_WhilePaused_BackdatesTimestampToPauseStart()
+        {
+            // Symmetry with the extended-pause rollover: quitting while
+            // backgrounded should timestamp session_end to when backgrounding
+            // began, not shutdown time.
+            var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
+            DateTime Clock() => now;
+
+            var session = new Session(MockTrack, getUtcNow: Clock);
+            session.Start();
+
+            now = now.AddSeconds(10);
+            session.Pause();
+            var pausedAt = now;
+
+            now = now.AddSeconds(5); // quit mid-background, well under 30s
+            session.Dispose();
+
+            var sessionEnd = _events.First(e => e.name == "session_end");
+            Assert.AreEqual(pausedAt, sessionEnd.timestampOverride,
+                "Dispose while paused should backdate session_end to when backgrounding began");
+        }
+
+        [Test]
         public void Dispose_CalledTwice_DoesNotFireTwice()
         {
             var session = new Session(MockTrack);
@@ -98,7 +122,7 @@ namespace Immutable.Audience.Tests
         public void Start_PassesSessionIdToTrackDelegate()
         {
             string capturedSessionId = null;
-            void Track(string name, Dictionary<string, object> props, string sessionId)
+            void Track(string name, Dictionary<string, object> props, string sessionId, DateTime? timestampOverride = null)
             {
                 if (name == "session_start") capturedSessionId = sessionId;
             }
@@ -118,7 +142,7 @@ namespace Immutable.Audience.Tests
             // ending session's id: it comes from the local variable captured
             // before the reset, not a live re-read of (by-then-null) SessionId.
             string capturedSessionId = null;
-            void Track(string name, Dictionary<string, object> props, string sessionId)
+            void Track(string name, Dictionary<string, object> props, string sessionId, DateTime? timestampOverride = null)
             {
                 if (name == "session_end") capturedSessionId = sessionId;
             }
@@ -140,7 +164,7 @@ namespace Immutable.Audience.Tests
             // Same race as End(): EmitEndAndSeal also resets state before
             // firing session_end.
             string capturedSessionId = null;
-            void Track(string name, Dictionary<string, object> props, string sessionId)
+            void Track(string name, Dictionary<string, object> props, string sessionId, DateTime? timestampOverride = null)
             {
                 if (name == "session_end") capturedSessionId = sessionId;
             }
@@ -154,6 +178,42 @@ namespace Immutable.Audience.Tests
             Assert.IsNotNull(capturedSessionId,
                 "EmitEndAndSeal must pass the ending session's id through the delegate, not null");
             Assert.AreEqual(endingId, capturedSessionId);
+        }
+
+        [Test]
+        public void EmitEndAndSeal_WhilePaused_BackdatesTimestampToPauseStart()
+        {
+            // Shutdown() calls EmitEndAndSeal, not End/Dispose. Same fix:
+            // quitting while backgrounded should timestamp session_end to
+            // when backgrounding began, not shutdown time.
+            var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
+            DateTime Clock() => now;
+
+            using var session = new Session(MockTrack, getUtcNow: Clock);
+            session.Start();
+
+            now = now.AddSeconds(10);
+            session.Pause();
+            var pausedAt = now;
+
+            now = now.AddSeconds(5);
+            session.EmitEndAndSeal();
+
+            var sessionEnd = _events.First(e => e.name == "session_end");
+            Assert.AreEqual(pausedAt, sessionEnd.timestampOverride,
+                "EmitEndAndSeal while paused should backdate session_end to when backgrounding began");
+        }
+
+        [Test]
+        public void EmitEndAndSeal_WithoutPause_DoesNotBackdateTimestamp()
+        {
+            using var session = new Session(MockTrack);
+            session.Start();
+            session.EmitEndAndSeal();
+
+            var sessionEnd = _events.First(e => e.name == "session_end");
+            Assert.IsNull(sessionEnd.timestampOverride,
+                "EmitEndAndSeal without a pause should not backdate the event timestamp");
         }
 
         // -----------------------------------------------------------------
@@ -171,7 +231,7 @@ namespace Immutable.Audience.Tests
             var events = new List<(string name, Dictionary<string, object> props)>();
             var gate = new object();
 
-            void Track(string name, Dictionary<string, object> props, string sessionId)
+            void Track(string name, Dictionary<string, object> props, string sessionId, DateTime? timestampOverride = null)
             {
                 lock (gate) events.Add((name, props));
                 if (name == "session_heartbeat") heartbeatFired.Set();
@@ -453,6 +513,87 @@ namespace Immutable.Audience.Tests
         }
 
         [Test]
+        public void End_AfterExtendedPauseRollover_BackdatesTimestampToPauseStart()
+        {
+            // session_end can only be detected on Resume, which may run long
+            // after the session actually stopped being active (e.g. an
+            // hour-long background). The event's wire timestamp should
+            // reflect when backgrounding began (_pausedAt), not wake-up time,
+            // so warehouse queries don't need duration_sec to reconstruct
+            // when the session really ended.
+            var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
+            DateTime Clock() => now;
+
+            using var session = new Session(MockTrack, getUtcNow: Clock);
+            session.Start();
+
+            now = now.AddSeconds(10);
+            session.Pause();
+            var pausedAt = now;
+
+            now = now.AddSeconds(40); // extended pause: rolls the session on Resume
+            session.Resume();
+
+            var sessionEnd = _events.First(e => e.name == "session_end");
+            Assert.AreEqual(pausedAt, sessionEnd.timestampOverride,
+                "session_end from an extended-pause rollover should backdate to when backgrounding began");
+        }
+
+        [Test]
+        public void End_AfterExtendedPauseRollover_WithEarlierShortPause_TimestampStillIncludesShortPauseGap()
+        {
+            // Backdating corrects for the pause that triggers rollover, but the
+            // wire timestamp is a single real instant (pausedAt) — it is not
+            // adjusted for any short (<=30s) pause earlier in the same session.
+            // session_end.timestamp - session_start.timestamp therefore still
+            // includes those earlier short gaps; duration_sec (which folds in
+            // every pause, short and long) remains the only field with zero
+            // pause skew. Analysts should use duration_sec for engaged time,
+            // not naive timestamp subtraction.
+            var now = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc);
+            DateTime Clock() => now;
+
+            using var session = new Session(MockTrack, getUtcNow: Clock);
+            session.Start();
+            var sessionStart = now;
+
+            now = now.AddSeconds(5);
+            session.Pause(); // short pause: 3s, well under the 30s threshold
+            now = now.AddSeconds(3);
+            session.Resume();
+
+            now = now.AddSeconds(10); // 10s more engaged
+            session.Pause();
+            var pausedAt = now;
+
+            now = now.AddSeconds(40); // extended pause: rolls the session
+            session.Resume();
+
+            var sessionEnd = _events.First(e => e.name == "session_end");
+            var duration = (long)sessionEnd.props["duration_sec"];
+            var timestampDeltaSec = (sessionEnd.timestampOverride!.Value - sessionStart).TotalSeconds;
+
+            Assert.AreEqual(15L, duration, "duration_sec excludes both the short and the extended pause");
+            Assert.AreEqual(18d, timestampDeltaSec,
+                "timestamp delta still includes the earlier 3s short pause (5 + 3 + 10 = 18), unlike duration_sec");
+        }
+
+        [Test]
+        public void End_WithoutPause_DoesNotBackdateTimestamp()
+        {
+            // A normal End (Shutdown/Dispose, no pause involved) has no
+            // backgrounding gap to correct for, so it should use current
+            // time rather than a backdated value.
+            using var session = new Session(MockTrack);
+            session.Start();
+            session.End();
+
+            var sessionEnd = _events.First(e => e.name == "session_end");
+            Assert.IsNull(sessionEnd.timestampOverride,
+                "a normal End should not backdate the event timestamp");
+        }
+
+        [Test]
         public void Heartbeat_AfterShortPause_ReportsPauseAdjustedDuration()
         {
             // Engaged 6s, paused 2s, resumed, then heartbeat → 6 s engaged.
@@ -545,7 +686,7 @@ namespace Immutable.Audience.Tests
             using var releaseBeat = new ManualResetEvent(false);
             try
             {
-                void Track(string name, Dictionary<string, object> props, string sessionId)
+                void Track(string name, Dictionary<string, object> props, string sessionId, DateTime? timestampOverride = null)
                 {
                     if (name == "session_heartbeat")
                     {
@@ -613,7 +754,7 @@ namespace Immutable.Audience.Tests
             Log.Writer = line => { lock (warnings) warnings.Add(line); };
             try
             {
-                void ThrowingTrack(string name, Dictionary<string, object> props, string sessionId)
+                void ThrowingTrack(string name, Dictionary<string, object> props, string sessionId, DateTime? timestampOverride = null)
                 {
                     if (name == "session_heartbeat")
                         throw new InvalidOperationException("track explode");
@@ -648,7 +789,7 @@ namespace Immutable.Audience.Tests
             Log.Writer = line => { lock (warnings) warnings.Add(line); };
             try
             {
-                void ThrowingTrack(string name, Dictionary<string, object> props, string sessionId)
+                void ThrowingTrack(string name, Dictionary<string, object> props, string sessionId, DateTime? timestampOverride = null)
                 {
                     if (name == "session_start")
                         throw new InvalidOperationException("track explode");
@@ -683,7 +824,7 @@ namespace Immutable.Audience.Tests
             Log.Writer = line => { lock (warnings) warnings.Add(line); };
             try
             {
-                void ThrowingTrack(string name, Dictionary<string, object> props, string sessionId)
+                void ThrowingTrack(string name, Dictionary<string, object> props, string sessionId, DateTime? timestampOverride = null)
                 {
                     if (name == "session_end")
                         throw new InvalidOperationException("track explode");
@@ -719,7 +860,7 @@ namespace Immutable.Audience.Tests
             Log.Writer = _ => throw new InvalidOperationException("log explode");
             try
             {
-                void ThrowingTrack(string name, Dictionary<string, object> props, string sessionId)
+                void ThrowingTrack(string name, Dictionary<string, object> props, string sessionId, DateTime? timestampOverride = null)
                 {
                     if (name == "session_heartbeat")
                         throw new InvalidOperationException("track explode");

--- a/src/Packages/Audience/Tests/Runtime/Events/MessageBuilderTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Events/MessageBuilderTests.cs
@@ -208,6 +208,32 @@ namespace Immutable.Audience.Tests
         }
 
         [Test]
+        public void Track_EventTimestampOverride_UsedInsteadOfNow()
+        {
+            var backdated = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            var result = MessageBuilder.Track("session_end", AnonId, null, null, PackageVersion, Consent,
+                eventTimestamp: backdated);
+
+            Assert.AreEqual(backdated.ToString("o"), result["eventTimestamp"]);
+        }
+
+        [Test]
+        public void Track_EventTimestampOverride_NonUtcKind_NormalizedToUtc()
+        {
+            // All current callers pass a UTC value, but the override is a public
+            // seam: a future caller passing Local/Unspecified must not silently
+            // ship a non-UTC "o" string past the backend's schema check.
+            var unspecified = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
+
+            var result = MessageBuilder.Track("session_end", AnonId, null, null, PackageVersion, Consent,
+                eventTimestamp: unspecified);
+
+            var ts = (string)result["eventTimestamp"];
+            Assert.IsTrue(ts.EndsWith("Z"), $"eventTimestamp must normalize to UTC ('Z' suffix); got: '{ts}'");
+        }
+
+        [Test]
         public void AllMessages_Context_LibraryAndLibraryVersionAreNonEmptyStrings()
         {
             foreach (var msg in EveryMessageType())


### PR DESCRIPTION
Fixes [SDK-645](https://linear.app/imtbl/issue/SDK-645/unity-audience-session-end-timestamp-reflects-wake-up-time-not-actual).

## What

`session_end` now backdates its wire `eventTimestamp` to the moment the app actually stopped being active, instead of the moment the SDK happened to notice.

## Why

`session_end` can only be detected once something else happens (the app wakes up, or gets shut down) — never at the actual moment the session stopped. Previously the event was always timestamped at that detection moment, so a session that ended by backgrounding could show a `session_end` timestamped minutes or hours later than reality.

### Scenarios this fixes

| Scenario | Before | After |
|---|---|---|
| App backgrounded >30s, then reopened | `session_end` timestamped at reopen (e.g. 1hr later) | Backdated to when backgrounding began |
| App force-quit while backgrounded | `session_end` timestamped at quit | Backdated to when backgrounding began |
| Normal quit while active (not backgrounded) | `session_end` timestamped at quit | Unchanged — quit time *is* when it ended |

**Caveat:** `duration_sec` on the same event remains the only field with zero pause skew — it excludes every pause in a session, short and long. The backdated timestamp only corrects for the *final* pause before the session ends, so a session with an earlier short (<=30s) alt-tab will still show a small residual gap (bounded by that pause's length) between `session_end.timestamp - session_start.timestamp` and `duration_sec`. For exact engaged-time math, use `duration_sec`.

## Test plan

- [x] `dotnet test` on `Audience.Tests.csproj` — full suite green
- [x] Unit tests cover all three scenarios above, plus: a normal (unpaused) end is not backdated, `MessageBuilder.Track` honors an explicit timestamp override and normalizes non-UTC input, and a characterization test locking in the short-pause caveat
