### PR TITLE
feat(audience): warn and drop Identify()/Alias() calls with a malformed passport id

### DIFF
--- a/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppLiveFireTests.cs
@@ -245,7 +245,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
             // dropdown before Init rather than upgrading mid-test.
             yield return LoadAndInit(initialConsent: SampleAppUi.Consent.Full);
 
-            _root!.Q<TextField>(SampleAppUi.IdentityFields.Id).value = "il2cpp-test-user-" + DateTime.UtcNow.Ticks;
+            _root!.Q<TextField>(SampleAppUi.IdentityFields.Id).value = "email|il2cpp-test-user-" + DateTime.UtcNow.Ticks;
             _root.Q<Button>(SampleAppUi.Buttons.Identify).Click();
             yield return null;
 
@@ -253,12 +253,27 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         }
 
         [UnityTest]
+        public IEnumerator Identify_PassportWithInvalidIdFormat_WarnsAndDropsCall()
+        {
+            // Identity type dropdown defaults to Passport; "12345" isn't Passport-shaped.
+            yield return LoadAndInit(initialConsent: SampleAppUi.Consent.Full);
+
+            _root!.Q<TextField>(SampleAppUi.IdentityFields.Id).value = "12345";
+            _root.Q<Button>(SampleAppUi.Buttons.Identify).Click();
+            yield return SampleAppTestHelpers.WaitForLogEntry(_root, SampleAppUi.LogLabels.Sdk, LogLevels.Warn, 5f);
+
+            Assert.IsNull(ImmutableAudience.UserId,
+                "an invalid Passport ID must be a full no-op, not just logged");
+        }
+
+        [UnityTest]
         public IEnumerator Alias_AndFlush_FlushReportsOk()
         {
             yield return LoadAndInit(initialConsent: SampleAppUi.Consent.Full);
 
-            _root!.Q<TextField>(SampleAppUi.IdentityFields.AliasFromId).value = "anon-" + DateTime.UtcNow.Ticks;
-            _root.Q<TextField>(SampleAppUi.IdentityFields.AliasToId).value = "user-" + DateTime.UtcNow.Ticks;
+            // Identity dropdowns default to Passport for both sides.
+            _root!.Q<TextField>(SampleAppUi.IdentityFields.AliasFromId).value = "email|anon-" + DateTime.UtcNow.Ticks;
+            _root.Q<TextField>(SampleAppUi.IdentityFields.AliasToId).value = "email|user-" + DateTime.UtcNow.Ticks;
             _root.Q<Button>(SampleAppUi.Buttons.Alias).Click();
             yield return null;
 
@@ -292,7 +307,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
 
             yield return SetConsentVia(SampleAppUi.Buttons.ConsentFull);
 
-            _root!.Q<TextField>(SampleAppUi.IdentityFields.Id).value = "consent-test-" + DateTime.UtcNow.Ticks;
+            _root!.Q<TextField>(SampleAppUi.IdentityFields.Id).value = "email|consent-test-" + DateTime.UtcNow.Ticks;
             _root.Q<Button>(SampleAppUi.Buttons.Identify).Click();
             yield return null;
 
@@ -406,7 +421,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
             // appear, which means the strip path is intact under IL2CPP.
             yield return LoadAndInit(initialConsent: SampleAppUi.Consent.Full);
 
-            _root!.Q<TextField>(SampleAppUi.IdentityFields.Id).value = "downgrade-user-" + DateTime.UtcNow.Ticks;
+            _root!.Q<TextField>(SampleAppUi.IdentityFields.Id).value = "email|downgrade-user-" + DateTime.UtcNow.Ticks;
             _root.Q<Button>(SampleAppUi.Buttons.Identify).Click();
             yield return SampleAppTestHelpers.WaitForLogEntry(_root, SampleAppUi.LogLabels.Identify, LogLevels.Ok, 5f);
 
@@ -426,7 +441,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
             // a different reflection/serialiser path than Identify(id) alone.
             yield return LoadAndInit(initialConsent: SampleAppUi.Consent.Full);
 
-            _root!.Q<TextField>(SampleAppUi.IdentityFields.Id).value = "traits-user-" + DateTime.UtcNow.Ticks;
+            _root!.Q<TextField>(SampleAppUi.IdentityFields.Id).value = "email|traits-user-" + DateTime.UtcNow.Ticks;
             _root.Q<Button>(SampleAppUi.Buttons.Identify).Click();
             yield return SampleAppTestHelpers.WaitForLogEntry(_root, SampleAppUi.LogLabels.Identify, LogLevels.Ok, 5f);
 
@@ -735,7 +750,7 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
         {
             yield return LoadAndInit(initialConsent: SampleAppUi.Consent.Full);
 
-            var userId = "panel-user-" + DateTime.UtcNow.Ticks;
+            var userId = "email|panel-user-" + DateTime.UtcNow.Ticks;
             _root!.Q<TextField>(SampleAppUi.IdentityFields.Id).value = userId;
             _root.Q<Button>(SampleAppUi.Buttons.Identify).Click();
             yield return SampleAppTestHelpers.WaitForLogEntry(_root, SampleAppUi.LogLabels.Identify, LogLevels.Ok, 5f);

--- a/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppUi.cs
+++ b/examples/audience/Assets/SampleApp/Tests/Runtime/SampleAppUi.cs
@@ -154,6 +154,9 @@ namespace Immutable.Audience.Samples.SampleApp.Tests
             internal const string Identify = "identify()";
             internal const string IdentifyTraits = "identify(traits)";
             internal const string Alias = "alias()";
+
+            // Label AudienceSample.cs.RouteSdkLogToPane gives every mirrored SDK log line.
+            internal const string Sdk = "sdk";
         }
 
         // ---- Consent dropdown / status values ----

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -39,6 +40,15 @@ namespace Immutable.Audience
 
         // Gate against overlapping timer ticks (Timer callbacks run on independent ThreadPool threads).
         private static int _sendInFlight;
+
+        // Passport IDs are "<connection>|<id>" (e.g. "email|abc123", "google-oauth2|123")
+        // or, for some accounts, a bare UUID with no connection prefix.
+        // Not RegexOptions.Compiled: that needs Reflection.Emit, unavailable under IL2CPP/AOT.
+        private static readonly Regex PassportIdPattern = new(@"^[^|]+\|[^|]+$");
+
+        private static readonly Regex PassportUuidPattern = new(
+            @"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            RegexOptions.IgnoreCase);
 
         // volatile: assigned on the Unity main thread at SubsystemRegistration,
         // read from the drain thread in Track / Identify paths.
@@ -411,7 +421,10 @@ namespace Immutable.Audience
         // -----------------------------------------------------------------
 
         /// <summary>
-        /// Attaches a known user ID to subsequent events.
+        /// Attaches a known user ID to subsequent events. When <paramref name="identityType"/> is
+        /// <see cref="IdentityType.Passport"/>, <paramref name="userId"/> must look like a real
+        /// Passport ID (<c>connection|id</c> or a UUID) — otherwise the call is dropped and a
+        /// warning is logged.
         /// </summary>
         /// <param name="userId">The player's identifier within the chosen provider.</param>
         /// <param name="identityType">The identity provider that issued <paramref name="userId"/>.</param>
@@ -424,6 +437,15 @@ namespace Immutable.Audience
             if (string.IsNullOrEmpty(userId))
             {
                 Log.Warn(AudienceLogs.IdentifyEmptyUserId);
+                return;
+            }
+
+            // Trim once: the validated id and the stored/sent id must match.
+            userId = userId.Trim();
+
+            if (identityType == IdentityType.Passport && !IsValidPassportId(userId))
+            {
+                Log.Warn(AudienceLogs.IdentifyPassportIdInvalidFormat(userId));
                 return;
             }
 
@@ -453,8 +475,17 @@ namespace Immutable.Audience
             EnqueueIdentity(msg);
         }
 
+        private static bool IsValidPassportId(string id)
+        {
+            var trimmed = id.Trim();
+            return PassportIdPattern.IsMatch(trimmed) || PassportUuidPattern.IsMatch(trimmed);
+        }
+
         /// <summary>
-        /// Links two user IDs for the same player.
+        /// Links two user IDs for the same player. When either side's identity
+        /// type is <see cref="IdentityType.Passport"/>, that side's id must look
+        /// like a real Passport ID (<c>connection|id</c> or a UUID) — otherwise
+        /// the call is dropped and a warning is logged.
         /// </summary>
         /// <param name="fromId">The previously-known identifier.</param>
         /// <param name="fromType">Identity provider for <paramref name="fromId"/>.</param>
@@ -469,6 +500,22 @@ namespace Immutable.Audience
                 Log.Warn(AudienceLogs.AliasEmptyIds);
                 return;
             }
+
+            // Trim once: the validated ids and the sent ids must match.
+            fromId = fromId.Trim();
+            toId = toId.Trim();
+
+            if (fromType == IdentityType.Passport && !IsValidPassportId(fromId))
+            {
+                Log.Warn(AudienceLogs.AliasPassportIdInvalidFormat("from", fromId));
+                return;
+            }
+            if (toType == IdentityType.Passport && !IsValidPassportId(toId))
+            {
+                Log.Warn(AudienceLogs.AliasPassportIdInvalidFormat("to", toId));
+                return;
+            }
+
             var state = _state;
             if (!state.Level.CanIdentify())
             {

--- a/src/Packages/Audience/Runtime/Utility/Log.cs
+++ b/src/Packages/Audience/Runtime/Utility/Log.cs
@@ -76,8 +76,18 @@ namespace Immutable.Audience
         internal static string IdentifyDiscarded(ConsentLevel current) =>
             $"Identify discarded. Requires Full consent, current is {current}.";
 
+        internal static string IdentifyPassportIdInvalidFormat(string userId) =>
+            $"Identify called with identityType Passport but userId \"{userId}\" doesn't look like a " +
+            "Passport ID (expected a format like \"email|123\" or a UUID). Check you're passing the " +
+            "Passport user ID, not your own internal user ID. Call ignored.";
+
         internal static string AliasDiscarded(ConsentLevel current) =>
             $"Alias discarded. Requires Full consent, current is {current}.";
+
+        internal static string AliasPassportIdInvalidFormat(string side, string id) =>
+            $"Alias called with {side}Type Passport but {side}Id \"{id}\" doesn't look like a " +
+            "Passport ID (expected a format like \"email|123\" or a UUID). Check you're passing the " +
+            "Passport user ID, not your own internal user ID. Call ignored.";
 
         // ---- Consent / Shutdown ----
 

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -738,11 +738,138 @@ namespace Immutable.Audience.Tests
         }
 
         [Test]
+        public void Identify_PassportWithInvalidIdFormat_WarnsAndDropsCall()
+        {
+            var lines = new List<string>();
+            Log.Writer = lines.Add;
+            try
+            {
+                ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
+
+                ImmutableAudience.Identify("12345", IdentityType.Passport);
+                ImmutableAudience.Shutdown();
+
+                Assert.That(lines, Has.Some.Contains("doesn't look like a"),
+                    "a malformed passport id should surface a warning so a developer notices the mismatch");
+                Assert.IsNull(ImmutableAudience.UserId,
+                    "the call must be a full no-op so later Track/Page calls don't inherit the bad id");
+
+                var queueDir = AudiencePaths.QueueDir(_testDir);
+                var contents = Directory.GetFiles(queueDir, "*.json")
+                    .Select(File.ReadAllText).ToList();
+                Assert.IsFalse(contents.Any(c => c.Contains("\"identify\"")),
+                    "the event should be dropped, not just flagged; a warning alone isn't enough to " +
+                    "stop the bad id from reaching downstream analytics");
+            }
+            finally
+            {
+                Log.Writer = null;
+            }
+        }
+
+        [TestCase("email|abc123")]
+        [TestCase("google-oauth2|11261203362550278288455")]
+        [TestCase("550e8400-e29b-41d4-a716-446655440000")]
+        [TestCase(" 550e8400-e29b-41d4-a716-446655440000\n")]
+        public void Identify_PassportWithValidIdFormat_DoesNotWarn(string userId)
+        {
+            var lines = new List<string>();
+            Log.Writer = lines.Add;
+            try
+            {
+                ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
+
+                ImmutableAudience.Identify(userId, IdentityType.Passport);
+
+                Assert.IsEmpty(lines);
+            }
+            finally
+            {
+                Log.Writer = null;
+            }
+        }
+
+        [Test]
+        public void Identify_PassportWithWhitespaceOnlyPadding_StillWarns()
+        {
+            var lines = new List<string>();
+            Log.Writer = lines.Add;
+            try
+            {
+                ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
+
+                ImmutableAudience.Identify("  12345  ", IdentityType.Passport);
+
+                Assert.That(lines, Has.Some.Contains("doesn't look like a"),
+                    "surrounding whitespace alone must not turn an invalid id into a valid one");
+            }
+            finally
+            {
+                Log.Writer = null;
+            }
+        }
+
+        [Test]
+        public void Identify_PassportWithPaddedValidId_StoresAndSendsTrimmedId()
+        {
+            ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
+
+            ImmutableAudience.Identify(" email|abc123\n", IdentityType.Passport);
+
+            Assert.AreEqual("email|abc123", ImmutableAudience.UserId,
+                "the id validated and the id stored must be the same trimmed value");
+
+            ImmutableAudience.Shutdown();
+
+            var queueDir = AudiencePaths.QueueDir(_testDir);
+            var contents = Directory.GetFiles(queueDir, "*.json").Select(File.ReadAllText).ToList();
+            Assert.IsTrue(contents.Any(c => c.Contains("\"email|abc123\"")),
+                "the enqueued event must carry the trimmed id, not the padded one");
+            Assert.IsFalse(contents.Any(c => c.Contains("email|abc123\\n")),
+                "the enqueued event must not carry the untrimmed padding");
+        }
+
+        [Test]
+        public void Alias_PassportWithPaddedValidId_SendsTrimmedId()
+        {
+            ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
+
+            ImmutableAudience.Alias("steam123", IdentityType.Steam, " email|user_456\n", IdentityType.Passport);
+            ImmutableAudience.Shutdown();
+
+            var queueDir = AudiencePaths.QueueDir(_testDir);
+            var contents = Directory.GetFiles(queueDir, "*.json").Select(File.ReadAllText).ToList();
+            Assert.IsTrue(contents.Any(c => c.Contains("\"email|user_456\"")),
+                "the enqueued event must carry the trimmed id, not the padded one");
+            Assert.IsFalse(contents.Any(c => c.Contains("email|user_456\\n")),
+                "the enqueued event must not carry the untrimmed padding");
+        }
+
+        [Test]
+        public void Identify_NonPassportWithNumericId_DoesNotWarn()
+        {
+            var lines = new List<string>();
+            Log.Writer = lines.Add;
+            try
+            {
+                ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
+
+                ImmutableAudience.Identify("12345", IdentityType.Steam);
+
+                Assert.IsEmpty(lines);
+            }
+            finally
+            {
+                Log.Writer = null;
+            }
+        }
+
+        [Test]
         public void Alias_FullConsent_WritesAliasEvent()
         {
             ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
 
-            ImmutableAudience.Alias("steam123", IdentityType.Steam, "user_456", IdentityType.Passport);
+            ImmutableAudience.Alias("steam123", IdentityType.Steam, "email|user_456", IdentityType.Passport);
             ImmutableAudience.Shutdown();
 
             var queueDir = AudiencePaths.QueueDir(_testDir);
@@ -750,6 +877,79 @@ namespace Immutable.Audience.Tests
                 .Select(File.ReadAllText).ToList();
             Assert.IsTrue(contents.Any(c =>
                 c.Contains("\"alias\"") && c.Contains("\"steam123\"")));
+        }
+
+        [Test]
+        public void Alias_PassportToWithInvalidIdFormat_WarnsAndDropsCall()
+        {
+            var lines = new List<string>();
+            Log.Writer = lines.Add;
+            try
+            {
+                ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
+
+                ImmutableAudience.Alias("steam123", IdentityType.Steam, "12345", IdentityType.Passport);
+                ImmutableAudience.Shutdown();
+
+                Assert.That(lines, Has.Some.Contains("doesn't look like a"),
+                    "a malformed passport id on the to side should surface a warning");
+
+                var queueDir = AudiencePaths.QueueDir(_testDir);
+                var contents = Directory.GetFiles(queueDir, "*.json")
+                    .Select(File.ReadAllText).ToList();
+                Assert.IsFalse(contents.Any(c => c.Contains("\"alias\"")),
+                    "the event should be dropped, not just flagged");
+            }
+            finally
+            {
+                Log.Writer = null;
+            }
+        }
+
+        [Test]
+        public void Alias_PassportFromWithInvalidIdFormat_WarnsAndDropsCall()
+        {
+            var lines = new List<string>();
+            Log.Writer = lines.Add;
+            try
+            {
+                ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
+
+                ImmutableAudience.Alias("12345", IdentityType.Passport, "steam123", IdentityType.Steam);
+                ImmutableAudience.Shutdown();
+
+                Assert.That(lines, Has.Some.Contains("doesn't look like a"),
+                    "a malformed passport id on the from side should surface a warning");
+
+                var queueDir = AudiencePaths.QueueDir(_testDir);
+                var contents = Directory.GetFiles(queueDir, "*.json")
+                    .Select(File.ReadAllText).ToList();
+                Assert.IsFalse(contents.Any(c => c.Contains("\"alias\"")),
+                    "the event should be dropped, not just flagged");
+            }
+            finally
+            {
+                Log.Writer = null;
+            }
+        }
+
+        [Test]
+        public void Alias_NonPassportIdentityTypes_DoesNotWarn()
+        {
+            var lines = new List<string>();
+            Log.Writer = lines.Add;
+            try
+            {
+                ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
+
+                ImmutableAudience.Alias("12345", IdentityType.Steam, "67890", IdentityType.Epic);
+
+                Assert.IsEmpty(lines);
+            }
+            finally
+            {
+                Log.Writer = null;
+            }
         }
 
         // -----------------------------------------------------------------
@@ -820,7 +1020,7 @@ namespace Immutable.Audience.Tests
             var sessionId = ImmutableAudience.SessionId;
             Assert.IsFalse(string.IsNullOrEmpty(sessionId), "sanity: a session should be active after Init");
 
-            ImmutableAudience.Alias("steam123", IdentityType.Steam, "user_456", IdentityType.Passport);
+            ImmutableAudience.Alias("steam123", IdentityType.Steam, "email|user_456", IdentityType.Passport);
             ImmutableAudience.FlushQueueToDiskForTesting();
 
             var queueDir = AudiencePaths.QueueDir(_testDir);
@@ -2065,7 +2265,7 @@ namespace Immutable.Audience.Tests
             ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
 
             ImmutableAudience.Identify("player_steam", IdentityType.Steam);
-            ImmutableAudience.Alias("player_steam", IdentityType.Steam, "player_passport", IdentityType.Passport);
+            ImmutableAudience.Alias("player_steam", IdentityType.Steam, "email|player_passport", IdentityType.Passport);
             ImmutableAudience.Track("tracked_before_downgrade");
 
             ImmutableAudience.FlushQueueToDiskForTesting();


### PR DESCRIPTION
## Summary
Studios sometimes call `Identify()` or `Alias()` with `IdentityType.Passport` but pass their own internal user id instead of a real Passport id, and today nothing catches it, so bad data silently flows into the audience pipeline. This rejects the call (no event sent, `UserId` untouched) and logs a warning when the id doesn't match the shape Passport actually issues (`connection|id` or a bare UUID), so studios see the mistake immediately during local testing instead of finding it in the data warehouse later.

## Test plan
- [x] Unit tests covering: malformed passport id warns and drops the call (no event enqueued, `UserId` stays null) for both `Identify()` and `Alias()` (either side); valid pipe-form/UUID/whitespace-padded ids and non-passport identity types never warn or drop
- [x] Unit tests confirming a whitespace-padded valid passport id is stored and sent trimmed, not with the padding intact (the id that's validated and the id that's stored/sent must match)
- [x] Sample-app PlayMode test exercising the `Identify()` rejection through the UI, and fixed existing sample-app tests (`Identify` and `Alias`) that used non-Passport-shaped ids under the default Passport identity type
- [x] `dotnet build src/Audience.Build/Audience.Tests/Audience.Tests.csproj` succeeds with no new warnings
- [x] `dotnet test src/Audience.Build/Audience.Tests/Audience.Tests.csproj` passes (375 tests, 0 failed)