### PR TITLE
Isolate Install() collector failures in Audience SDK

### DIFF
--- a/src/Packages/Audience/Runtime/Unity/AudienceUnityHooks.cs
+++ b/src/Packages/Audience/Runtime/Unity/AudienceUnityHooks.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Immutable.Audience.Unity.Mobile;
@@ -31,12 +32,33 @@ namespace Immutable.Audience.Unity
             _persistentDataPath = Application.persistentDataPath;
             ImmutableAudience.DefaultPersistentDataPathProvider = () => Application.persistentDataPath;
 
+            // Set before the collectors below run so a collector failure logs via Debug.Log, not Console.WriteLine.
+            if (Log.Writer == null) Log.Writer = Debug.Log;
+
             // Captured once on main thread; ReadOnlyDictionary blocks downstream mutation.
-            IReadOnlyDictionary<string, object> launchProps =
-                new ReadOnlyDictionary<string, object>(DeviceCollector.CollectGameLaunchProperties());
-            IReadOnlyDictionary<string, object> contextProps =
-                new ReadOnlyDictionary<string, object>(DeviceCollector.CollectContext());
+            // Each collector is isolated so one throwing can't block the other's provider or abort Install().
+            IReadOnlyDictionary<string, object> launchProps;
+            try
+            {
+                launchProps = new ReadOnlyDictionary<string, object>(DeviceCollector.CollectGameLaunchProperties());
+            }
+            catch (Exception ex)
+            {
+                Log.Warn(AudienceLogs.LaunchPropertiesCollectionFailed(ex));
+                launchProps = new ReadOnlyDictionary<string, object>(new Dictionary<string, object>());
+            }
             ImmutableAudience.LaunchContextProvider = () => launchProps;
+
+            IReadOnlyDictionary<string, object> contextProps;
+            try
+            {
+                contextProps = new ReadOnlyDictionary<string, object>(DeviceCollector.CollectContext());
+            }
+            catch (Exception ex)
+            {
+                Log.Warn(AudienceLogs.ContextCollectionFailed(ex));
+                contextProps = new ReadOnlyDictionary<string, object>(new Dictionary<string, object>());
+            }
             ImmutableAudience.ContextProvider = () => contextProps;
 
 #if UNITY_IOS && !UNITY_EDITOR && AUDIENCE_MOBILE_ATTRIBUTION
@@ -58,8 +80,6 @@ namespace Immutable.Audience.Unity
 #endif
 
             UnityLifecycleBridge.EnsureExists();
-
-            if (Log.Writer == null) Log.Writer = Debug.Log;
         }
 
         // Warms the install referrer cache for the next launch and returns

--- a/src/Packages/Audience/Runtime/Unity/DeviceCollector.cs
+++ b/src/Packages/Audience/Runtime/Unity/DeviceCollector.cs
@@ -32,18 +32,28 @@ namespace Immutable.Audience.Unity
 
         private static string? TryResolveScreenString()
         {
-            var resolution = Screen.currentResolution;
-            int width = resolution.width;
-            int height = resolution.height;
-
-            if (width <= 0 || height <= 0)
+            // Can throw before a window/graphics device exists this early in boot;
+            // isolated so a failure here doesn't cost CollectContext()'s other fields.
+            try
             {
-                width = Screen.width;
-                height = Screen.height;
-            }
+                var resolution = Screen.currentResolution;
+                int width = resolution.width;
+                int height = resolution.height;
 
-            if (width <= 0 || height <= 0) return null;
-            return $"{width}x{height}";
+                if (width <= 0 || height <= 0)
+                {
+                    width = Screen.width;
+                    height = Screen.height;
+                }
+
+                if (width <= 0 || height <= 0) return null;
+                return $"{width}x{height}";
+            }
+            catch (Exception ex)
+            {
+                Log.Warn(AudienceLogs.ScreenResolutionReadFailed(ex));
+                return null;
+            }
         }
 
         internal static Dictionary<string, object> CollectGameLaunchProperties(

--- a/src/Packages/Audience/Runtime/Utility/Log.cs
+++ b/src/Packages/Audience/Runtime/Utility/Log.cs
@@ -168,6 +168,20 @@ namespace Immutable.Audience
             $"Identity file read/write failed. {ex.GetType().Name}: {ex.Message}. " +
             "Events will ship without identity fields this session.";
 
+        // ---- Install-time device/context collection ----
+
+        internal static string LaunchPropertiesCollectionFailed(Exception ex) =>
+            $"CollectGameLaunchProperties threw {ex.GetType().Name}: {ex.Message} during Install(). " +
+            "game_launch will ship without auto-detected Unity context this session.";
+
+        internal static string ContextCollectionFailed(Exception ex) =>
+            $"CollectContext threw {ex.GetType().Name}: {ex.Message} during Install(). " +
+            "All events will ship without locale/screen/timezone/userAgent this session.";
+
+        internal static string ScreenResolutionReadFailed(Exception ex) =>
+            $"Screen resolution read threw {ex.GetType().Name}: {ex.Message}. " +
+            "Continuing without a screen field.";
+
         // ---- Steam auto-detection ----
 
         internal static string SteamPlatformDetectionFailed(Exception ex) =>


### PR DESCRIPTION
## What
`CollectGameLaunchProperties()` and `CollectContext()` ran back to back with no error handling in `AudienceUnityHooks.Install()`. An exception in either (most likely a `Screen.currentResolution` read too early in boot) aborted `Install()` before the other collector's provider was assigned, silently disabling it too. Each collector now runs in its own try/catch, with the failure logged via `Log.Warn` and its provider still assigned using whatever partial data survives.

## Why
Field data showed real integrators hitting exactly this: one early-boot exception silently stripped context (locale/screen/timezone/userAgent) and `game_launch` device fields from every event for practically the whole session, with no crash or visible error to flag it.

## Test plan
- [x] Reproduced the original bug in the Unity Editor: forced `CollectContext()` to throw, confirmed the uncaught exception silently blanked context and `game_launch` properties for the rest of the session (verified via raw event payloads)
- [x] Applied the fix and re-tested with only the screen read forced to throw: confirmed a logged warning instead of an uncaught exception, and that `locale`/`timezone`/`userAgent` still came through with only `screen` missing
- [x] Confirmed `game_launch`'s own properties (`version`, `cpu`, `gpu`, `unity_version`, etc.) were unaffected by the context-collector failure, verifying the two collectors are isolated from each other
- [ ] Run the existing Audience unit test suite (blocked locally by a pre-existing, unrelated missing-assembly issue in the generated csproj outside Unity; needs Unity Editor Test Runner or CI)