### PR TITLE
SDK-981: Guarantee anonymousId is always sent on Unity SDK audience events

### DIFF
--- a/src/Packages/Audience/Runtime/Core/Identity.cs
+++ b/src/Packages/Audience/Runtime/Core/Identity.cs
@@ -8,6 +8,8 @@ namespace Immutable.Audience
     // Manages the anonymous ID and device ID for this device.
     // Both are UUIDs persisted to {"anonymousId":"<uuid>","deviceId":"<uuid>"}.
     // deviceId survives RotateAnonymousId (logout); both are wiped by Reset (opt-out).
+    // If disk read/write fails, both fall back to in-memory-only ids for the rest
+    // of this session rather than leaving anonymousId unset (see LoadOrGenerate).
     //
     // Static caches persist across play sessions in the Unity Editor with domain reload
     // disabled. ImmutableAudience.Init() calls ClearCache() via ResetState() to handle that.
@@ -146,13 +148,12 @@ namespace Immutable.Audience
         // Slow path: read from disk or generate fresh IDs. Must be called under _sync.
         private static void LoadOrGenerate(string persistentDataPath)
         {
+            var filePath = AudiencePaths.IdentityFile(persistentDataPath);
+            string anonId;
+            string deviceId;
+
             try
             {
-                var dir = AudiencePaths.AudienceDir(persistentDataPath);
-                Directory.CreateDirectory(dir);
-
-                var filePath = AudiencePaths.IdentityFile(persistentDataPath);
-
                 if (File.Exists(filePath))
                 {
                     var content = File.ReadAllText(filePath).Trim();
@@ -166,21 +167,35 @@ namespace Immutable.Audience
                     }
 
                     // Partial or old plain-string format: keep anon_id, generate device_id, migrate file.
-                    var anonId = string.IsNullOrEmpty(existingAnonId) ? Guid.NewGuid().ToString() : existingAnonId;
-                    var deviceId = Guid.NewGuid().ToString();
-                    WriteFile(filePath, anonId, deviceId);
-                    _cachedAnonId = anonId;
-                    _cachedDeviceId = deviceId;
-                    return;
+                    anonId = string.IsNullOrEmpty(existingAnonId) ? Guid.NewGuid().ToString() : existingAnonId;
+                    deviceId = Guid.NewGuid().ToString();
                 }
-
+                else
                 {
-                    var anonId = Guid.NewGuid().ToString();
-                    var deviceId = Guid.NewGuid().ToString();
-                    WriteFile(filePath, anonId, deviceId);
-                    _cachedAnonId = anonId;
-                    _cachedDeviceId = deviceId;
+                    anonId = Guid.NewGuid().ToString();
+                    deviceId = Guid.NewGuid().ToString();
                 }
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                // Reading failed, so there's nothing pre-existing to reuse.
+                Log.Warn(AudienceLogs.IdentityLoadOrGenerateFailed(ex));
+                _cachedAnonId ??= Guid.NewGuid().ToString();
+                _cachedDeviceId ??= Guid.NewGuid().ToString();
+                return;
+            }
+
+            // Cache in memory before attempting to persist: a write failure below must
+            // not lose an anonId that was already legitimately read from disk (e.g. a
+            // legacy-format file being migrated), and must still guarantee some id for
+            // the rest of this session even when nothing existed to begin with.
+            _cachedAnonId = anonId;
+            _cachedDeviceId = deviceId;
+
+            try
+            {
+                Directory.CreateDirectory(AudiencePaths.AudienceDir(persistentDataPath));
+                WriteFile(filePath, anonId, deviceId);
             }
             catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
             {

--- a/src/Packages/Audience/Runtime/Events/MessageBuilder.cs
+++ b/src/Packages/Audience/Runtime/Events/MessageBuilder.cs
@@ -88,6 +88,7 @@ namespace Immutable.Audience
             string fromType,
             string toId,
             string toType,
+            string? anonymousId,
             string? deviceId,
             string packageVersion,
             string consentLevel,
@@ -99,6 +100,9 @@ namespace Immutable.Audience
             msg["fromType"] = Truncate(fromType, Constants.MaxFieldLength);
             msg["toId"] = Truncate(toId, Constants.MaxFieldLength);
             msg["toType"] = Truncate(toType, Constants.MaxFieldLength);
+
+            if (!string.IsNullOrEmpty(anonymousId))
+                msg["anonymousId"] = Truncate(anonymousId, Constants.MaxFieldLength);
 
             if (!string.IsNullOrEmpty(deviceId))
                 msg[MessageFields.DeviceId] = Truncate(deviceId, Constants.MaxFieldLength);

--- a/src/Packages/Audience/Runtime/ImmutableAudience.cs
+++ b/src/Packages/Audience/Runtime/ImmutableAudience.cs
@@ -547,9 +547,10 @@ namespace Immutable.Audience
             var config = _config;
             if (config == null) return;
 
+            var anonymousId = Identity.GetOrCreate(config.PersistentDataPath!, state.Level);
             var deviceId = Identity.GetOrCreateDeviceId(config.PersistentDataPath!, state.Level);
             var msg = MessageBuilder.Alias(fromId, fromType.ToLowercaseString(), toId, toType.ToLowercaseString(),
-                deviceId, Constants.LibraryVersion, state.Level.ToLowercaseString(), _session?.SessionId, config.TestMode);
+                anonymousId, deviceId, Constants.LibraryVersion, state.Level.ToLowercaseString(), _session?.SessionId, config.TestMode);
             EnqueueIdentity(msg);
         }
 

--- a/src/Packages/Audience/Runtime/Utility/Log.cs
+++ b/src/Packages/Audience/Runtime/Utility/Log.cs
@@ -206,7 +206,7 @@ namespace Immutable.Audience
 
         internal static string IdentityLoadOrGenerateFailed(Exception ex) =>
             $"Identity file read/write failed. {ex.GetType().Name}: {ex.Message}. " +
-            "Events will ship without identity fields this session.";
+            "Continuing with in-memory ids for this session; any values generated just now will not persist across restarts.";
 
         // ---- Install-time device/context collection ----
 

--- a/src/Packages/Audience/Tests/Runtime/Core/IdentityTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Core/IdentityTests.cs
@@ -80,6 +80,29 @@ namespace Immutable.Audience.Tests
         }
 
         [Test]
+        public void ExistingFile_LegacyPlainString_MigrationWriteFails_PreservesReadAnonId()
+        {
+            // The anon_id here was already legitimately persisted and successfully
+            // read; only the migration write (adding device_id) fails. That must not
+            // discard the real anon_id for a fresh random one.
+            var legacyAnonId = "already-persisted-legacy-id";
+            var dir = AudiencePaths.AudienceDir(_testDir);
+            Directory.CreateDirectory(dir);
+            var identityFile = AudiencePaths.IdentityFile(_testDir);
+            File.WriteAllText(identityFile, legacyAnonId);
+
+            // Force WriteFile's tmp-then-replace to fail by blocking its .tmp path
+            // with a directory: File.WriteAllText(tmpPath, ...) throws
+            // UnauthorizedAccessException when tmpPath is an existing directory.
+            Directory.CreateDirectory(identityFile + ".tmp");
+
+            var result = Identity.GetOrCreate(_testDir, ConsentLevel.Anonymous);
+
+            Assert.AreEqual(legacyAnonId, result,
+                "a failed migration write must not discard an anon_id that was already legitimately persisted");
+        }
+
+        [Test]
         public void SecondCall_ReturnsSameAnonId()
         {
             var id1 = Identity.GetOrCreate(_testDir, ConsentLevel.Anonymous);
@@ -97,6 +120,50 @@ namespace Immutable.Audience.Tests
 
             var filePath = AudiencePaths.IdentityFile(_testDir);
             Assert.IsFalse(File.Exists(filePath), "identity file must not be written when consent is None");
+        }
+
+        [Test]
+        public void PersistenceFails_FallsBackToInMemoryId()
+        {
+            // Force Directory.CreateDirectory(AudienceDir) to throw IOException by
+            // pre-creating a *file* at the exact path the identity directory needs.
+            File.WriteAllText(AudiencePaths.AudienceDir(_testDir), "blocking file");
+
+            var id = Identity.GetOrCreate(_testDir, ConsentLevel.Anonymous);
+
+            Assert.IsNotNull(id, "anonymousId must still be populated even when persistence fails");
+            Assert.IsNotEmpty(id);
+        }
+
+        [Test]
+        public void PersistenceFails_InMemoryIdStableForRestOfSession()
+        {
+            File.WriteAllText(AudiencePaths.AudienceDir(_testDir), "blocking file");
+
+            var id1 = Identity.GetOrCreate(_testDir, ConsentLevel.Anonymous);
+            var id2 = Identity.GetOrCreate(_testDir, ConsentLevel.Anonymous);
+
+            Assert.AreEqual(id1, id2, "the in-memory fallback id must not change between calls in the same session");
+        }
+
+        [Test]
+        public void ReadFails_FallsBackToInMemoryIds()
+        {
+            // Distinct from the persistence-failure tests above: here the *read*
+            // itself throws (exercising LoadOrGenerate's first catch block), not
+            // just the later write, so there's nothing pre-existing to reuse at all.
+            var identityFile = AudiencePaths.IdentityFile(_testDir);
+            Directory.CreateDirectory(AudiencePaths.AudienceDir(_testDir));
+            File.WriteAllText(identityFile, "{\"anonymousId\":\"existing-anon\",\"deviceId\":\"existing-device\"}");
+            using var exclusiveLock = new FileStream(identityFile, FileMode.Open, FileAccess.Read, FileShare.None);
+
+            var anonId = Identity.GetOrCreate(_testDir, ConsentLevel.Anonymous);
+            var deviceId = Identity.GetOrCreateDeviceId(_testDir, ConsentLevel.Anonymous);
+
+            Assert.IsNotNull(anonId, "anonymousId must still be populated even when the read itself fails");
+            Assert.IsNotEmpty(anonId);
+            Assert.IsNotNull(deviceId);
+            Assert.IsNotEmpty(deviceId);
         }
 
         // -----------------------------------------------------------------

--- a/src/Packages/Audience/Tests/Runtime/Events/MessageBuilderTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/Events/MessageBuilderTests.cs
@@ -110,7 +110,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Alias_AllFourFieldsPresent()
         {
-            var result = MessageBuilder.Alias("from-id", "email", "to-id", "steam", null, PackageVersion, "full");
+            var result = MessageBuilder.Alias("from-id", "email", "to-id", "steam", null, null, PackageVersion, "full");
 
             Assert.AreEqual("alias", result["type"]);
             Assert.AreEqual("from-id", result["fromId"]);
@@ -122,10 +122,39 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Alias_DeviceId_PresentWhenProvided()
         {
-            var result = MessageBuilder.Alias("from-id", "email", "to-id", "steam", DeviceId, PackageVersion, "full");
+            var result = MessageBuilder.Alias("from-id", "email", "to-id", "steam", null, DeviceId, PackageVersion, "full");
 
             Assert.IsTrue(result.ContainsKey("deviceId"));
             Assert.AreEqual(DeviceId, result["deviceId"]);
+        }
+
+        [Test]
+        public void Alias_AnonymousId_PresentWhenProvided()
+        {
+            // anonymousId isn't used for the merge (fromId/toId are), but is still
+            // required so alias messages have the same shape as every other event.
+            var result = MessageBuilder.Alias("from-id", "email", "to-id", "steam", AnonId, null, PackageVersion, "full");
+
+            Assert.IsTrue(result.ContainsKey("anonymousId"));
+            Assert.AreEqual(AnonId, result["anonymousId"]);
+        }
+
+        [Test]
+        public void Alias_AnonymousId_AbsentWhenNull()
+        {
+            var result = MessageBuilder.Alias("from-id", "email", "to-id", "steam", null, null, PackageVersion, "full");
+
+            Assert.IsFalse(result.ContainsKey("anonymousId"));
+        }
+
+        [Test]
+        public void Alias_AnonymousIdLongerThan256Chars_TruncatedTo256()
+        {
+            var longAnonId = new string('a', 300);
+
+            var result = MessageBuilder.Alias("from-id", "email", "to-id", "steam", longAnonId, null, PackageVersion, "full");
+
+            Assert.AreEqual(256, ((string)result["anonymousId"]).Length);
         }
 
         [Test]
@@ -133,7 +162,7 @@ namespace Immutable.Audience.Tests
         {
             var track = MessageBuilder.Track("evt", null, null, null, null, PackageVersion, Consent);
             var identify = MessageBuilder.Identify(null, "u1", null, "steam", PackageVersion, "full");
-            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", null, PackageVersion, "full");
+            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", null, null, PackageVersion, "full");
 
             foreach (var msg in new[] { track, identify, alias })
             {
@@ -148,7 +177,7 @@ namespace Immutable.Audience.Tests
         {
             var track = MessageBuilder.Track("evt", null, null, null, null, PackageVersion, Consent);
             var identify = MessageBuilder.Identify(null, "u1", null, "steam", PackageVersion, "full");
-            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", null, PackageVersion, "full");
+            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", null, null, PackageVersion, "full");
 
             Assert.AreEqual("unity", track["surface"]);
             Assert.AreEqual("unity", identify["surface"]);
@@ -162,7 +191,7 @@ namespace Immutable.Audience.Tests
             // backend records the explicit level instead of inferring it.
             var track = MessageBuilder.Track("evt", null, null, null, null, PackageVersion, "anonymous");
             var identify = MessageBuilder.Identify(null, "u1", null, "steam", PackageVersion, "full");
-            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", null, PackageVersion, "full");
+            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", null, null, PackageVersion, "full");
 
             Assert.AreEqual("anonymous", track["consentLevel"]);
             Assert.AreEqual("full", identify["consentLevel"]);
@@ -283,7 +312,7 @@ namespace Immutable.Audience.Tests
         {
             var track = MessageBuilder.Track("evt", null, null, null, null, PackageVersion, Consent, testMode: true);
             var identify = MessageBuilder.Identify(null, "u1", null, "steam", PackageVersion, "full", testMode: true);
-            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", null, PackageVersion, "full", testMode: true);
+            var alias = MessageBuilder.Alias("f", "t1", "t", "t2", null, null, PackageVersion, "full", testMode: true);
 
             foreach (var msg in new[] { track, identify, alias })
             {
@@ -296,7 +325,7 @@ namespace Immutable.Audience.Tests
         {
             yield return MessageBuilder.Track("evt", null, null, null, null, PackageVersion, Consent);
             yield return MessageBuilder.Identify(null, "u1", null, "steam", PackageVersion, "full");
-            yield return MessageBuilder.Alias("f", "t1", "t", "t2", null, PackageVersion, "full");
+            yield return MessageBuilder.Alias("f", "t1", "t", "t2", null, null, PackageVersion, "full");
         }
 
         // -----------------------------------------------------------------
@@ -342,7 +371,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Alias_SessionIdProvided_PresentInDict()
         {
-            var result = MessageBuilder.Alias("from-id", "email", "to-id", "steam", null, PackageVersion, "full",
+            var result = MessageBuilder.Alias("from-id", "email", "to-id", "steam", null, null, PackageVersion, "full",
                 sessionId: "session-1");
 
             Assert.IsTrue(result.ContainsKey("sessionId"));
@@ -352,7 +381,7 @@ namespace Immutable.Audience.Tests
         [Test]
         public void Alias_SessionIdNull_AbsentFromDict()
         {
-            var result = MessageBuilder.Alias("from-id", "email", "to-id", "steam", null, PackageVersion, "full");
+            var result = MessageBuilder.Alias("from-id", "email", "to-id", "steam", null, null, PackageVersion, "full");
 
             Assert.IsFalse(result.ContainsKey("sessionId"));
         }

--- a/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
+++ b/src/Packages/Audience/Tests/Runtime/ImmutableAudienceTests.cs
@@ -958,6 +958,55 @@ namespace Immutable.Audience.Tests
         }
 
         [Test]
+        public void Alias_FullConsent_IncludesAnonymousId()
+        {
+            // anonymousId isn't used for the merge (fromId/toId are), but every
+            // message type, alias included, must still carry it.
+            ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));
+            var expectedAnonId = Identity.GetOrCreate(_testDir, ConsentLevel.Full);
+
+            ImmutableAudience.Alias("steam123", IdentityType.Steam, "email|user_456", IdentityType.Passport);
+            ImmutableAudience.Shutdown();
+
+            var queueDir = AudiencePaths.QueueDir(_testDir);
+            var contents = Directory.GetFiles(queueDir, "*.json")
+                .Select(File.ReadAllText).ToList();
+            Assert.IsTrue(
+                contents.Any(c => c.Contains("\"alias\"") && c.Contains($"\"anonymousId\":\"{expectedAnonId}\"")),
+                "an Alias() envelope must carry the session's actual anonymousId, not just any anonymousId key");
+        }
+
+        [Test]
+        public void Track_IdentityPersistenceFails_QueuedEventStillIncludesAnonymousId()
+        {
+            // End-to-end regression test for the actual bug: block only the identity
+            // file specifically (not the whole AudienceDir, which the queue also
+            // lives under and must keep working) by pre-creating a directory at the
+            // exact path the identity file needs, then verify a real Track() call
+            // still enqueues an envelope carrying anonymousId.
+            var identityFile = AudiencePaths.IdentityFile(_testDir);
+            Directory.CreateDirectory(identityFile);
+
+            try
+            {
+                ImmutableAudience.Init(MakeConfig(ConsentLevel.Anonymous));
+                ImmutableAudience.Track("test_event");
+                ImmutableAudience.Shutdown();
+
+                var queueDir = AudiencePaths.QueueDir(_testDir);
+                var contents = Directory.GetFiles(queueDir, "*.json").Select(File.ReadAllText).ToList();
+                Assert.IsTrue(contents.Any(c => c.Contains("\"test_event\"") && c.Contains("\"anonymousId\"")),
+                    "a track event must still carry anonymousId even when identity persistence fails");
+            }
+            finally
+            {
+                // TearDown calls Identity.Reset, which File.Deletes this path; it must
+                // be a plain file (or absent) again, not the blocking directory.
+                Directory.Delete(identityFile, recursive: true);
+            }
+        }
+
+        [Test]
         public void Alias_PassportToWithInvalidIdFormat_Throws()
         {
             ImmutableAudience.Init(MakeConfig(ConsentLevel.Full));


### PR DESCRIPTION
## Summary

| File | Change |
|---|---|
| `Identity.cs` | `LoadOrGenerate` now falls back to an in-memory-only id when disk read/write fails, instead of leaving the cached anonymousId/deviceId null |
| `MessageBuilder.cs` | `Alias` gains an `anonymousId` parameter (previously had none at all) |
| `ImmutableAudience.cs` | `Alias()` now resolves and passes `anonymousId` alongside `deviceId` |
| `Log.cs` | Warning message updated to reflect the new fallback behavior instead of claiming events ship without identity fields |

Brings the Unity SDK's guarantee in line with ts-immutable-sdk, which already guarantees anonymousId on every event via its shared `baseMessage()`/`BaseMessage` type. Also documented on the REST API side (SDK-982): anonymousId doesn't drive the alias merge (`fromId`/`toId` do), but is required so every message type has the same shape.

## Test plan

- [x] `dotnet test` in `src/Audience.Build/Audience.Tests`: 399 passed, 1 skipped, 0 failed
- [x] New tests: `Identity.PersistenceFails_FallsBackToInMemoryId`, `Identity.PersistenceFails_InMemoryIdStableForRestOfSession`, `MessageBuilder.Alias_AnonymousId_PresentWhenProvided`/`_AbsentWhenNull`, `ImmutableAudience.Alias_FullConsent_IncludesAnonymousId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)